### PR TITLE
Potential fix for code scanning alert no. 27: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/winsdk/security/code-scanning/27](https://github.com/microsoft/winsdk/security/code-scanning/27)

To fix this problem, you should add a `permissions` block to your workflow (either at the root level, or inside the specific job(s)). Based on the workflow steps shown, the only required permission is `contents: read`, since the job checks out code and uploads build/test artifacts, but does not push any commits or create releases/issues. Insert a `permissions` block specifying `contents: read`, either at the root of the workflow file (after `name:` and before `on:`), or at the job level for `build-and-package:`. The single best way for a single-job workflow is to add it at the root level. Place the following YAML between `name: Build` and `on:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
