### PR TITLE
Increased the MinVersion attribute in `appxmanifest.hostedapp.xml` to 10.0.19041.0

### DIFF
--- a/src/winsdk-CLI/Winsdk.Cli/Templates/appxmanifest.hostedapp.xml
+++ b/src/winsdk-CLI/Winsdk.Cli/Templates/appxmanifest.hostedapp.xml
@@ -23,7 +23,7 @@
   </Properties>
 
   <Dependencies>
-    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.18362.0" MaxVersionTested="10.0.26100.0" />
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.19041.0" MaxVersionTested="10.0.26100.0" />
     <uap10:HostRuntimeDependency Name="{HostRuntimeDependencyPackageName}" Publisher="CN={HostRuntimeDependencyPublisherName}" MinVersion="{HostRuntimeDependencyMinVersion}" />
   </Dependencies>
 


### PR DESCRIPTION
This change ensures compatibility with features and APIs introduced in Windows 10.0.19041.0 (hostedapp manifest validation).