### PR TITLE
Enhanced `ManifestService` to derive `packageName` from `entryPoint` …

### DIFF
--- a/src/winapp-CLI/WinApp.Cli.Tests/EndToEndTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/EndToEndTests.cs
@@ -140,7 +140,7 @@ public class EndToEndTests : BaseCommandTests
         var manifestArgs = new[]
         {
             projectDir.FullName,
-            "--package-name", "CustomPackageName",
+            "--package-name", "net9.0-windows",
             "--publisher-name", "CN=TestPublisher",
             "--version", "2.5.0.0",
             "--description", "Custom test application",
@@ -157,7 +157,7 @@ public class EndToEndTests : BaseCommandTests
         Assert.IsTrue(File.Exists(manifestPath), "Manifest should be created");
         
         var manifestContent = await File.ReadAllTextAsync(manifestPath);
-        Assert.IsTrue(manifestContent.Contains("CustomPackageName", StringComparison.OrdinalIgnoreCase), 
+        Assert.IsTrue(manifestContent.Contains("Id=\"net9.A0Windows\"", StringComparison.OrdinalIgnoreCase), 
             "Manifest should contain custom package name");
         Assert.IsTrue(manifestContent.Contains("CN=TestPublisher", StringComparison.Ordinal), 
             "Manifest should contain custom publisher");

--- a/src/winapp-CLI/WinApp.Cli/Services/ManifestService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/ManifestService.cs
@@ -35,7 +35,14 @@ internal partial class ManifestService(
         }
 
         // Interactive mode if not --yes (get defaults for prompts)
-        packageName ??= SystemDefaultsHelper.GetDefaultPackageName(directory);
+        if (string.IsNullOrEmpty(entryPoint))
+        {
+            packageName ??= SystemDefaultsHelper.GetDefaultPackageName(directory);
+        }
+        else
+        {
+            packageName ??= Path.GetFileNameWithoutExtension(entryPoint);
+        }
         publisherName ??= SystemDefaultsHelper.GetDefaultPublisherCN();
         entryPoint ??= $"{packageName}.exe";
 

--- a/src/winapp-CLI/WinApp.Cli/Templates/appxmanifest.hostedapp.xml
+++ b/src/winapp-CLI/WinApp.Cli/Templates/appxmanifest.hostedapp.xml
@@ -32,7 +32,7 @@
   </Resources>
 
   <Applications>
-    <Application Id="{PackageNameCamelCase}"
+    <Application Id="{ApplicationId}"
       uap10:HostId="{HostId}"
       uap10:Parameters="{HostParameters}">
       <uap:VisualElements

--- a/src/winapp-CLI/WinApp.Cli/Templates/appxmanifest.packaged.xml
+++ b/src/winapp-CLI/WinApp.Cli/Templates/appxmanifest.packaged.xml
@@ -31,7 +31,7 @@
   </Resources>
 
   <Applications>
-    <Application Id="{PackageNameCamelCase}"
+    <Application Id="{ApplicationId}"
       Executable="{Executable}"
       EntryPoint="Windows.FullTrustApplication"
       uap10:TrustLevel="mediumIL" 

--- a/src/winapp-CLI/WinApp.Cli/Templates/appxmanifest.sparse.xml
+++ b/src/winapp-CLI/WinApp.Cli/Templates/appxmanifest.sparse.xml
@@ -33,7 +33,7 @@
   </Resources>
 
   <Applications>
-    <Application Id="{PackageNameCamelCase}"
+    <Application Id="{ApplicationId}"
       Executable="{Executable}"
       uap10:TrustLevel="mediumIL" 
       uap10:RuntimeBehavior="packagedClassicApp">


### PR DESCRIPTION
…when provided, improving flexibility in manifest generation. Improved robustness of manifest generation by handling edge cases for empty or invalid `ApplicationId` inputs.

Improves/Fixes #98 