### PR TITLE
Removed flag to look for installed WIndows SDK when generating headers

### DIFF
--- a/src/winapp-CLI/WinApp.Cli/Services/CppWinrtService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/CppWinrtService.cs
@@ -28,7 +28,6 @@ internal sealed class CppWinrtService(ILogger<CppWinrtService> logger) : ICppWin
         var rspPath = new FileInfo(Path.Combine(outputDir.FullName, ".cppwinrt.rsp"));
 
         var sb = new StringBuilder();
-        sb.AppendLine("-input sdk+");
         foreach (var winmd in winmdInputs)
         {
             sb.AppendLine($"-input \"{winmd}\"");


### PR DESCRIPTION
Fixes #129 

We are already using the nuget version of the sdk, no need to also use an installed version.