### PR TITLE
Use variable pipelines, and download gh.exe directly instead of using winget

### DIFF
--- a/.pipelines/release.yml
+++ b/.pipelines/release.yml
@@ -15,16 +15,9 @@ parameters:
   - name: DoEsrp
     type: boolean
     default: true
-  - name: signingIdentity
-    type: object
-    default:
-      serviceName: $(SigningServiceName)
-      appId: $(SigningAppId)
-      tenantId: $(SigningTenantId)
-      akvName: $(SigningAKVName)
-      authCertName: $(SigningAuthCertName)
-      signCertName: $(SigningSignCertName)
-      signTTSCertName: $(SigningSignTTSCertName)
+
+variables:
+  - group: signingIdentity
 
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
@@ -71,7 +64,6 @@ extends:
             parameters:
               stable: 'true'
               DoEsrp: ${{ parameters.DoEsrp }}
-              signingIdentity: ${{ parameters.signingIdentity }}
           - task: PowerShell@2
             name: SetMeta
             displayName: Export version
@@ -194,14 +186,21 @@ extends:
               artifactName: npm-package
               targetPath: $(Pipeline.Workspace)/npm-package
           steps:
+            - task: PowerShell@2
+              displayName: "Echo debug info"
+              inputs:
+                targetType: 'inline'
+                script: |
+                  Write-Host "SigningServiceName: $(SigningServiceName)"
+
             - task: EsrpRelease@10
               condition: always()
               inputs:
-                ConnectedServiceName: ${{ parameters.signingIdentity.serviceName }}
+                ConnectedServiceName: $(SigningServiceName)
                 usemanagedidentity: true
-                keyvaultname: ${{ parameters.signingIdentity.akvName }}
-                signcertname: ${{ parameters.signingIdentity.signTTSCertName }}
-                clientid: ${{ parameters.signingIdentity.appId }}
+                keyvaultname: $(SigningAKVName)
+                signcertname: $(SigningSignTTSCertName)
+                clientid: $(SigningAppId)
                 intent: 'PackageDistribution'
                 contenttype: 'npm'
                 contentsource: 'Folder'
@@ -211,7 +210,7 @@ extends:
                 approvers: '$(EsrpApproversEmail)'
                 serviceendpointurl: 'https://api.esrp.microsoft.com'
                 mainpublisher: 'ESRPRELPACMAN'
-                domaintenantid: ${{ parameters.signingIdentity.tenantId }}
+                domaintenantid: $(SigningTenantId)
 
     - stage: Release_WinGet
       displayName: Create WinGet Release
@@ -238,6 +237,7 @@ extends:
               GH_TOKEN: $(GITHUB_TOKEN)
             inputs:
               targetType: 'inline'
+              errorActionPreference: 'stop'
               script: |
                 # Download and install C++ Runtime framework package
                 Write-Host "Installing VCLibs dependency..."
@@ -246,12 +246,12 @@ extends:
                 Add-AppxPackage $vcLibsFile
                 
                 # Install gh
+                # TODO: Change this to get the latest version of gh
                 Write-Host "Installing gh..."
-                winget install --id GitHub.cli --source winget --silent --accept-source-agreements
-                if ($LASTEXITCODE -ne 0) {
-                  Write-Host "winget returned exit code: $LASTEXITCODE"
-                  Write-Host "Continuing in case gh is already installed..."
-                }
+                $tempDir = $(Agent.TempDirectory)
+                Write-Host "TempDir: $tempDir"
+                Invoke-WebRequest -Uri "https://github.com/cli/cli/releases/download/v2.83.1/gh_2.83.1_windows_amd64.zip" -OutFile "$tempdir\gh.zip"
+                Expand-Archive "$tempdir\gh.zip" -DestinationPath "$tempDir\gh"
 
                 # Download and install wingetcreate
                 Write-Host "Installing wingetcreate..."
@@ -264,7 +264,7 @@ extends:
                 # We need to keep this fork up-to-date, otherwise the wingetcreate command will fail.
                 # See: https://github.com/microsoft/winget-create/issues/502
                 Write-Host "Syncing winget-pkgs fork..."
-                & "$env:ProgramFiles\GitHub CLI\gh.exe" repo sync $(WingetPkgsFork) -b master
+                & " $tempDir\gh\bin\gh.exe" repo sync $(WingetPkgsFork) -b master
                 if ($LASTEXITCODE -ne 0) {
                   Write-Error "Failed to sync winget-pkgs fork. Exit code: $LASTEXITCODE"
                   exit $LASTEXITCODE

--- a/.pipelines/templates/build.yaml
+++ b/.pipelines/templates/build.yaml
@@ -1,13 +1,6 @@
 parameters:
   stable: 'false'
   DoEsrp: false
-  signingIdentity:
-    serviceName: ''
-    appId: ''
-    tenantId: ''
-    akvName: ''
-    authCertName: ''
-    signCertName: ''
 
 steps:
 - task: PowerShell@2
@@ -20,12 +13,12 @@ steps:
   - task: EsrpCodeSigning@5
     displayName: Code Sign ESRP - CLI
     inputs:
-      ConnectedServiceName: ${{ parameters.signingIdentity.serviceName }}
-      AppRegistrationClientId: ${{ parameters.signingIdentity.appId }}
-      AppRegistrationTenantId: ${{ parameters.signingIdentity.tenantId }}
-      AuthAKVName: ${{ parameters.signingIdentity.akvName }}
-      AuthCertName: ${{ parameters.signingIdentity.authCertName }}
-      AuthSignCertName: ${{ parameters.signingIdentity.signCertName }}
+      ConnectedServiceName: $(SigningServiceName)
+      AppRegistrationClientId: $(SigningAppId)
+      AppRegistrationTenantId: $(SigningTenantId)
+      AuthAKVName: $(SigningAKVName)
+      AuthCertName: $(SigningAuthCertName)
+      AuthSignCertName: $(SigningSignCertName)
       FolderPath: '$(System.DefaultWorkingDirectory)/artifacts/cli/'
       Pattern: |
         win-arm64/winapp.exe
@@ -71,12 +64,12 @@ steps:
   - task: EsrpCodeSigning@5
     displayName: Code Sign ESRP - MSIX Packages
     inputs:
-      ConnectedServiceName: ${{ parameters.signingIdentity.serviceName }}
-      AppRegistrationClientId: ${{ parameters.signingIdentity.appId }}
-      AppRegistrationTenantId: ${{ parameters.signingIdentity.tenantId }}
-      AuthAKVName: ${{ parameters.signingIdentity.akvName }}
-      AuthCertName: ${{ parameters.signingIdentity.authCertName }}
-      AuthSignCertName: ${{ parameters.signingIdentity.signCertName }}
+      ConnectedServiceName: $(SigningServiceName)
+      AppRegistrationClientId: $(SigningAppId)
+      AppRegistrationTenantId: $(SigningTenantId)
+      AuthAKVName: $(SigningAKVName)
+      AuthCertName: $(SigningAuthCertName)
+      AuthSignCertName: $(SigningSignCertName)
       FolderPath: '$(System.DefaultWorkingDirectory)/artifacts/msix-packages/'
       Pattern: '*.msix'
       UseMinimatch: true


### PR DESCRIPTION
In release.yml:
* Use variable pipelines for variables.
* Download gh.exe directly instead of using winget.