### PR TITLE
Set authcertname and not usemanagedidentity

### DIFF
--- a/.pipelines/release.yml
+++ b/.pipelines/release.yml
@@ -210,8 +210,9 @@ extends:
               condition: always()
               inputs:
                 ConnectedServiceName: ${{ parameters.signingIdentity.serviceName }}
-                usemanagedidentity: true
+                usemanagedidentity: false
                 keyvaultname: ${{ parameters.signingIdentity.akvName }}
+                authcertname: ${{ parameters.signingIdentity.authCertName }}
                 signcertname: ${{ parameters.signingIdentity.signTTSCertName }}
                 clientid: ${{ parameters.signingIdentity.appId }}
                 intent: 'PackageDistribution'


### PR DESCRIPTION
In talking with ESRP team, our config is setup not to use managed identity, so setting usemanagedidentity to false and populating authcertname.

Verified this by running the pipeline on a test branch.