### PR TITLE
Use signCertName instead of signTTSCertName for NPM publishing

### DIFF
--- a/.pipelines/release.yml
+++ b/.pipelines/release.yml
@@ -213,7 +213,7 @@ extends:
                 usemanagedidentity: false
                 keyvaultname: ${{ parameters.signingIdentity.akvName }}
                 authcertname: ${{ parameters.signingIdentity.authCertName }}
-                signcertname: ${{ parameters.signingIdentity.signTTSCertName }}
+                signcertname: ${{ parameters.signingIdentity.signCertName }}
                 clientid: ${{ parameters.signingIdentity.appId }}
                 intent: 'PackageDistribution'
                 contenttype: 'npm'


### PR DESCRIPTION
Use signCertName instead of signTTSCertName for NPM publishing