### PR TITLE
Remove explicit disabling of stack trace in Release build

### DIFF
--- a/src/winapp-CLI/WinApp.Cli/WinApp.Cli.csproj
+++ b/src/winapp-CLI/WinApp.Cli/WinApp.Cli.csproj
@@ -38,7 +38,6 @@
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <UseSystemResourceKeys>true</UseSystemResourceKeys>
-    <StackTraceSupport>false</StackTraceSupport>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This increases our size by ~1mb per arch, but we can't get meaningful info on release builds/bug reports traces, which we are printing, without it.