### PR TITLE
Fixed bug where cert was always re-generated on restore and improved logging.

### DIFF
--- a/src/winapp-CLI/WinApp.Cli.Tests/DirectoryPackagesServiceTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/DirectoryPackagesServiceTests.cs
@@ -39,7 +39,7 @@ public class DirectoryPackagesServiceTests : BaseCommandTests
     }
 
     [TestMethod]
-    public void UpdatePackageVersionsNoFileExistsReturnsFalse()
+    public void UpdatePackageVersionsNoFileExistsThrowsFileNotFoundException()
     {
         // Arrange
         var packageVersions = new Dictionary<string, string>
@@ -47,11 +47,9 @@ public class DirectoryPackagesServiceTests : BaseCommandTests
             { "Microsoft.Windows.SDK.BuildTools", "10.0.22621.3233" }
         };
 
-        // Act
-        var result = _directoryPackagesService.UpdatePackageVersions(new DirectoryInfo(_testTempDirectory), packageVersions, TestTaskContext);
-
-        // Assert
-        Assert.IsFalse(result, "Should return false when Directory.Packages.props doesn't exist");
+        // Act & Assert
+        Assert.ThrowsExactly<FileNotFoundException>(() =>
+            _directoryPackagesService.UpdatePackageVersions(new DirectoryInfo(_testTempDirectory), packageVersions, TestTaskContext));
     }
 
     [TestMethod]
@@ -148,7 +146,7 @@ public class DirectoryPackagesServiceTests : BaseCommandTests
     }
 
     [TestMethod]
-    public void UpdatePackageVersionsNoChangesNeededReturnsTrue()
+    public void UpdatePackageVersionsNoChangesNeededReturnsFalse()
     {
         // Arrange
         var propsFilePath = Path.Combine(_testTempDirectory, "Directory.Packages.props");
@@ -168,7 +166,7 @@ public class DirectoryPackagesServiceTests : BaseCommandTests
         var result = _directoryPackagesService.UpdatePackageVersions(new DirectoryInfo(_testTempDirectory), packageVersions, TestTaskContext);
 
         // Assert
-        Assert.IsTrue(result, "Should return true even when no changes are needed");
+        Assert.IsFalse(result, "Should return false when no changes are needed");
         
         var updatedContent = File.ReadAllText(propsFilePath);
         Assert.AreEqual(originalContent, updatedContent, "Content should remain unchanged");
@@ -206,7 +204,7 @@ public class DirectoryPackagesServiceTests : BaseCommandTests
     }
 
     [TestMethod]
-    public void UpdatePackageVersionsEmptyFileReturnsFalse()
+    public void UpdatePackageVersionsEmptyFileThrowsXmlException()
     {
         // Arrange
         var propsFilePath = Path.Combine(_testTempDirectory, "Directory.Packages.props");
@@ -217,15 +215,13 @@ public class DirectoryPackagesServiceTests : BaseCommandTests
             { "Microsoft.Windows.SDK.BuildTools", "10.0.22621.3233" }
         };
 
-        // Act
-        var result = _directoryPackagesService.UpdatePackageVersions(new DirectoryInfo(_testTempDirectory), packageVersions, TestTaskContext);
-
-        // Assert
-        Assert.IsFalse(result, "Should return false for empty/invalid XML file");
+        // Act & Assert
+        Assert.ThrowsExactly<System.Xml.XmlException>(() =>
+            _directoryPackagesService.UpdatePackageVersions(new DirectoryInfo(_testTempDirectory), packageVersions, TestTaskContext));
     }
 
     [TestMethod]
-    public void UpdatePackageVersionsNoPackageVersionElementsReturnsFalse()
+    public void UpdatePackageVersionsNoPackageVersionElementsThrowsInvalidOperationException()
     {
         // Arrange
         var propsFilePath = Path.Combine(_testTempDirectory, "Directory.Packages.props");
@@ -241,11 +237,9 @@ public class DirectoryPackagesServiceTests : BaseCommandTests
             { "Microsoft.Windows.SDK.BuildTools", "10.0.22621.3233" }
         };
 
-        // Act
-        var result = _directoryPackagesService.UpdatePackageVersions(new DirectoryInfo(_testTempDirectory), packageVersions, TestTaskContext);
-
-        // Assert
-        Assert.IsFalse(result, "Should return false when no PackageVersion elements exist");
+        // Act & Assert
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+            _directoryPackagesService.UpdatePackageVersions(new DirectoryInfo(_testTempDirectory), packageVersions, TestTaskContext));
     }
 
     [TestMethod]

--- a/src/winapp-CLI/WinApp.Cli/Services/DirectoryPackagesService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/DirectoryPackagesService.cs
@@ -25,100 +25,86 @@ internal class DirectoryPackagesService : IDirectoryPackagesService
     /// </summary>
     /// <param name="configDir">Directory containing winapp.yaml and potentially Directory.Packages.props</param>
     /// <param name="packageVersions">Dictionary of package names to versions from winapp.yaml</param>
-    /// <returns>True if file was found and updated, false otherwise</returns>
+    /// <returns>True if any package versions were changed, false if no changes were needed</returns>
+    /// <exception cref="FileNotFoundException">Thrown when Directory.Packages.props does not exist</exception>
+    /// <exception cref="InvalidOperationException">Thrown when the file is invalid or has no PackageVersion elements</exception>
     public bool UpdatePackageVersions(DirectoryInfo configDir, Dictionary<string, string> packageVersions, TaskContext taskContext)
     {
         var propsFilePath = Path.Combine(configDir.FullName, DirectoryPackagesFileName);
 
         if (!File.Exists(propsFilePath))
         {
-            taskContext.AddDebugMessage($"{UiSymbols.Note} No {DirectoryPackagesFileName} found in {configDir.FullName}");
-            return false;
+            throw new FileNotFoundException($"No {DirectoryPackagesFileName} found in {configDir.FullName}", propsFilePath);
         }
 
-        try
+        taskContext.AddStatusMessage($"{UiSymbols.Wrench} Updating {DirectoryPackagesFileName} to match winapp.yaml versions...");
+
+        // Load the XML document with whitespace preservation
+        var doc = new XmlDocument();
+        doc.PreserveWhitespace = true;
+        doc.Load(propsFilePath);
+
+        if (doc.DocumentElement == null)
         {
-            taskContext.AddStatusMessage($"{UiSymbols.Wrench} Updating {DirectoryPackagesFileName} to match winapp.yaml versions...");
+            throw new InvalidOperationException($"{DirectoryPackagesFileName} has no root element");
+        }
 
-            // Load the XML document with whitespace preservation
-            var doc = new XmlDocument();
-            doc.PreserveWhitespace = true;
-            doc.Load(propsFilePath);
+        // Find all PackageVersion elements using XPath
+        var packageVersionNodes = doc.SelectNodes("//PackageVersion");
 
-            if (doc.DocumentElement == null)
+        if (packageVersionNodes == null || packageVersionNodes.Count == 0)
+        {
+            throw new InvalidOperationException($"No PackageVersion elements found in {DirectoryPackagesFileName}");
+        }
+
+        var updated = 0;
+
+        foreach (XmlNode packageVersion in packageVersionNodes)
+        {
+            if (packageVersion.Attributes == null)
             {
-                taskContext.AddStatusMessage($"{UiSymbols.Note} {DirectoryPackagesFileName} has no root element");
-                return false;
+                continue;
             }
 
-            // Find all PackageVersion elements using XPath
-            var packageVersionNodes = doc.SelectNodes("//PackageVersion");
+            var includeAttr = packageVersion.Attributes["Include"];
+            var versionAttr = packageVersion.Attributes["Version"];
 
-            if (packageVersionNodes == null || packageVersionNodes.Count == 0)
+            if (includeAttr == null || versionAttr == null)
             {
-                taskContext.AddDebugMessage($"{UiSymbols.Note} No PackageVersion elements found in {DirectoryPackagesFileName}");
-                return false;
+                continue;
             }
 
-            var updated = 0;
+            var packageName = includeAttr.Value;
 
-            foreach (XmlNode packageVersion in packageVersionNodes)
+            // Check if this package is in our winapp.yaml config
+            if (packageVersions.TryGetValue(packageName, out var newVersion))
             {
-                if (packageVersion.Attributes == null)
+                var oldVersion = versionAttr.Value;
+
+                if (oldVersion != newVersion)
                 {
-                    continue;
+                    versionAttr.Value = newVersion;
+                    updated++;
+                    taskContext.AddStatusMessage($"{UiSymbols.Check} Updated {packageName}: {oldVersion} → {newVersion}");
                 }
-
-                var includeAttr = packageVersion.Attributes["Include"];
-                var versionAttr = packageVersion.Attributes["Version"];
-
-                if (includeAttr == null || versionAttr == null)
+                else
                 {
-                    continue;
+                    taskContext.AddDebugMessage($"{UiSymbols.Check} {packageName} already at version {newVersion}");
                 }
-
-                var packageName = includeAttr.Value;
-
-                // Check if this package is in our winapp.yaml config
-                if (packageVersions.TryGetValue(packageName, out var newVersion))
-                {
-                    var oldVersion = versionAttr.Value;
-
-                    if (oldVersion != newVersion)
-                    {
-                        versionAttr.Value = newVersion;
-                        updated++;
-                        taskContext.AddStatusMessage($"{UiSymbols.Check} Updated {packageName}: {oldVersion} → {newVersion}");
-                    }
-                    else
-                    {
-                        taskContext.AddDebugMessage($"{UiSymbols.Check} {packageName} already at version {newVersion}");
-                    }
-                }
-            }
-
-            if (updated > 0)
-            {
-                // Save the document - PreserveWhitespace will maintain original formatting
-                doc.Save(propsFilePath);
-
-                taskContext.AddStatusMessage($"{UiSymbols.Save} Updated {updated} package version(s) in {DirectoryPackagesFileName}");
-                return true;
-            }
-            else
-            {
-                taskContext.AddStatusMessage($"{UiSymbols.Check} No package versions needed updating in {DirectoryPackagesFileName}");
-                return true;
             }
         }
-        catch (Exception ex)
-        {
-            taskContext.AddStatusMessage($"{UiSymbols.Note} Failed to update {DirectoryPackagesFileName}: {ex.Message}");
-            if (ex.StackTrace != null)
-            {
-                taskContext.AddDebugMessage(ex.StackTrace);
-            }
 
+        if (updated > 0)
+        {
+            // Save the document - PreserveWhitespace will maintain original formatting
+            doc.Save(propsFilePath);
+
+            taskContext.AddStatusMessage($"{UiSymbols.Save} Updated {updated} package version(s) in {DirectoryPackagesFileName}");
+            return true;
+        }
+        else
+        {
+            taskContext.AddStatusMessage($"{UiSymbols.Check} No package versions needed updating in {DirectoryPackagesFileName}");
             return false;
         }
     }

--- a/src/winapp-CLI/WinApp.Cli/Services/IDirectoryPackagesService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/IDirectoryPackagesService.cs
@@ -22,6 +22,8 @@ internal interface IDirectoryPackagesService
     /// </summary>
     /// <param name="configDir">Directory containing winapp.yaml and potentially Directory.Packages.props</param>
     /// <param name="packageVersions">Dictionary of package names to versions from winapp.yaml</param>
-    /// <returns>True if file was found and updated, false otherwise</returns>
+    /// <returns>True if any package versions were changed, false if no changes were needed</returns>
+    /// <exception cref="FileNotFoundException">Thrown when Directory.Packages.props does not exist</exception>
+    /// <exception cref="InvalidOperationException">Thrown when the file is invalid or has no PackageVersion elements</exception>
     bool UpdatePackageVersions(DirectoryInfo configDir, Dictionary<string, string> packageVersions, TaskContext taskContext);
 }

--- a/src/winapp-CLI/WinApp.Cli/Services/IWorkspaceSetupService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/IWorkspaceSetupService.cs
@@ -9,5 +9,5 @@ internal interface IWorkspaceSetupService
 {
     public DirectoryInfo? FindWindowsAppSdkMsixDirectory(Dictionary<string, string>? usedVersions = null);
     public Task<int> SetupWorkspaceAsync(WorkspaceSetupOptions options, CancellationToken cancellationToken = default);
-    public Task InstallWindowsAppRuntimeAsync(DirectoryInfo msixDir, TaskContext taskContext, CancellationToken cancellationToken);
+    public Task<(int InstalledCount, int ErrorCount)> InstallWindowsAppRuntimeAsync(DirectoryInfo msixDir, TaskContext taskContext, CancellationToken cancellationToken);
 }


### PR DESCRIPTION
## Description

Improve logs for restore and fixed a bug where cert was always re-generated on restore even if the cert file already existed.

## Related Issue

Fixes #245

## Type of Change

<!-- Mark the appropriate option(s) with an "x" -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration/build change
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🧪 Test update

## Checklist

### Build & Tests

- [X] All CI builds pass (Build and Package workflow)
- [X] All existing tests pass
- [ ] New tests added for new functionality (if applicable)
- [X] Tested locally on Windows

### README & Guides

<!-- Check all that apply to your changes -->

- [ ] Main [README.md](../README.md) updated (if applicable)
- [ ] [docs/usage.md](../docs/usage.md) updated (if CLI commands changed)
- [ ] [Language-specific guides](../docs/guides) updated (if applicable)
- [ ] [Sample projects updated](../samples) to reflect changes (if applicable)
- [X] No documentation updates needed
