### PR TITLE
Fix Regression in RunCommandAsync

### DIFF
--- a/src/winapp-CLI/WinApp.Cli.Tests/PowerShellServiceTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/PowerShellServiceTests.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using WinApp.Cli.Services;
+
+namespace WinApp.Cli.Tests;
+
+[TestClass]
+[DoNotParallelize]
+public class PowerShellServiceTests() : BaseCommandTests(configPaths: false)
+{
+    [TestMethod]
+    public async Task RunCommandAsync_WithRestoreStyleStdOut_ShouldReturnStdOut()
+    {
+        var service = GetRequiredService<IPowerShellService>();
+
+        var (exitCode, output, error) = await service.RunCommandAsync(
+            "Write-Output 'SKIP|Microsoft.WindowsAppRuntime.1.8.msix|Already installed'; Write-Output 'INSTALLING|2 packages will be installed'",
+            TestTaskContext,
+            cancellationToken: TestContext.CancellationToken);
+
+        Assert.AreEqual(0, exitCode);
+        Assert.IsTrue(
+            output.Contains("SKIP|Microsoft.WindowsAppRuntime.1.8.msix|Already installed", StringComparison.Ordinal),
+            $"Expected SKIP marker in output. Captured output:\n{output}");
+        Assert.IsTrue(
+            output.Contains("INSTALLING|2 packages will be installed", StringComparison.Ordinal),
+            $"Expected INSTALLING marker in output. Captured output:\n{output}");
+        Assert.IsTrue(string.IsNullOrWhiteSpace(error));
+    }
+
+    [TestMethod]
+    public async Task RunCommandAsync_WithRestoreStyleStdErr_ShouldReturnStdErr()
+    {
+        var service = GetRequiredService<IPowerShellService>();
+
+        var (exitCode, output, error) = await service.RunCommandAsync(
+            "[Console]::Error.WriteLine('ERROR|Microsoft.WindowsAppRuntime.1.8.msix|Installation failed'); exit 1",
+            TestTaskContext,
+            cancellationToken: TestContext.CancellationToken);
+
+        Assert.AreNotEqual(0, exitCode);
+        Assert.IsTrue(string.IsNullOrWhiteSpace(output));
+        Assert.IsTrue(
+            error.Contains("ERROR|Microsoft.WindowsAppRuntime.1.8.msix|Installation failed", StringComparison.Ordinal),
+            $"Expected ERROR marker in stderr. Captured error:\n{error}");
+    }
+}

--- a/src/winapp-CLI/WinApp.Cli/Services/PowerShellService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/PowerShellService.cs
@@ -100,8 +100,8 @@ internal class PowerShellService : IPowerShellService
             process.StandardInput.Close();
 
             await Task.WhenAll(outTask, errTask);
-            stdOut = NormalizePowerShellStream(outTask.Result);
-            stdErr = NormalizePowerShellStream(errTask.Result);
+            stdOut = outTask.Result.Trim();
+            stdErr = NormalizePowerShellErrorStream(errTask.Result);
         }
 
         await process.WaitForExitAsync(cancellationToken);
@@ -121,7 +121,7 @@ internal class PowerShellService : IPowerShellService
         return (exitCode, stdOut, stdErr);
     }
 
-    private static string NormalizePowerShellStream(string stream)
+    private static string NormalizePowerShellErrorStream(string stream)
     {
         if (string.IsNullOrWhiteSpace(stream))
         {
@@ -129,10 +129,16 @@ internal class PowerShellService : IPowerShellService
         }
 
         var trimmed = stream.Trim();
+
+        if (!trimmed.Contains("<Objs", StringComparison.OrdinalIgnoreCase))
+        {
+            return trimmed;
+        }
+
         var reasonIndex = trimmed.IndexOf("Reason:", StringComparison.OrdinalIgnoreCase);
         if (reasonIndex < 0)
         {
-            return string.Empty;
+            return trimmed;
         }
 
         var reasonStart = reasonIndex + "Reason:".Length;
@@ -153,7 +159,8 @@ internal class PowerShellService : IPowerShellService
             .Select(line => line.Trim())
             .Where(line => !string.IsNullOrWhiteSpace(line));
 
-        return string.Join(" ", lines).Trim();
+        var normalized = string.Join(" ", lines).Trim();
+        return string.IsNullOrWhiteSpace(normalized) ? trimmed : normalized;
     }
 
     private static string StripXmlTags(string value)


### PR DESCRIPTION
## Description

Fix regression in RunCommandAsync. Restore trimmed output for stdout. Restore trimmed errors for non-CLIXML errors. 

## Related Issue

<!-- Link to any related issues: Fixes #123, Closes #456, Related to #789 -->
#308 
## Type of Change

<!-- Keep the applicable line(s), delete the rest -->
- 🐛 Bug fix

## Checklist
<!-- Delete the ones that do not apply to your changes -->

- [x] New tests added for new functionality (if applicable)
- [x] Tested locally on Windows

## Screenshots / Demo
`npx winapp restore --verbose` now prints
```
...
SKIP|Microsoft.WindowsAppRuntime.1.8.msix|Already installed or newer version exists
INSTALL|Microsoft.WindowsAppRuntime.DDLM.1.8.msix|Will install
SKIP|Microsoft.WindowsAppRuntime.Main.1.8.msix|Already installed or newer version exists
SKIP|Microsoft.WindowsAppRuntime.Singleton.1.8.msix|Already installed or newer version exists
INSTALLING|1 packages will be installed
SUCCESS|Microsoft.WindowsAppRuntime.DDLM.1.8.msix|Installation successful
...
```
Output like this was missing before change. 
## Additional Notes

<!-- Any additional information that reviewers should know -->

## AI Description

<!-- ai-description-start -->
This pull request fixes a regression in the `RunCommandAsync` method by restoring the trimmed output for both standard output (stdout) and error output (stderr) streams, improving the command result handling in the CLI. This enhancement ensures that users receive the intended output format when executing restore commands. After this change, the command:
```bash
npx winapp restore --verbose
```
will provide clearer output with appropriate success markers included.
<!-- ai-description-end -->
