### PR TITLE
Fix Signing Success Message

### DIFF
--- a/src/winapp-CLI/WinApp.Cli/Commands/SignCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/SignCommand.cs
@@ -62,7 +62,7 @@ internal class SignCommand : Command, IShortDescription
                 {
                     await certificateService.SignFileAsync(filePath, certPath, taskContext, password, timestamp, cancellationToken);
 
-                    return (0, "Signed file: {filePath}");
+                    return (0, $"Signed file: {filePath}");
                 }
                 catch (InvalidOperationException error)
                 {


### PR DESCRIPTION
## Description

Fix signing success message to include filepath. 
Before: ✅ Signed file: {filePath}
After: ✅ Signed file: .\my-app.msix

## Type of Change

<!-- Keep the applicable line(s), delete the rest -->
- 🐛 Bug fix

## Checklist
<!-- Delete the ones that do not apply to your changes -->

- [x] Tested locally on Windows

## AI Description

<!-- ai-description-start -->
The signing command's success message has been updated to include the actual file path that was signed. The message format now specifies the filepath explicitly, providing clearer feedback to users. For example, the message will now display as: "✅ Signed file: .\my-app.msix".
<!-- ai-description-end -->
