### PR TITLE
Add Warning for pfx in Input Folder

### DIFF
--- a/src/winapp-CLI/WinApp.Cli.Tests/BaseCommandTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/BaseCommandTests.cs
@@ -26,6 +26,7 @@ public abstract class BaseCommandTests(bool configPaths = true, bool verboseLogg
 
     public TestContext TestContext { get; set; } = null!;
     private protected TaskContext TestTaskContext { private set; get; } = null!;
+    private protected GroupableTask TestTask { private set; get; } = null!;
     private protected Lock RenderLock { private set; get; } = null!;
     private protected TestConsole TestAnsiConsole { private set; get; } = null!;
 
@@ -62,10 +63,10 @@ public abstract class BaseCommandTests(bool configPaths = true, bool verboseLogg
 
         _serviceProvider = services.BuildServiceProvider();
 
-        GroupableTask dummyTask = new GroupableTask("Dummy Task", null);
+        TestTask = new GroupableTask("Dummy Task", null);
 
         RenderLock = new Lock();
-        TestTaskContext = new TaskContext(dummyTask, null, TestAnsiConsole, GetRequiredService<ILogger<TaskContext>>(), RenderLock);
+        TestTaskContext = new TaskContext(TestTask, null, TestAnsiConsole, GetRequiredService<ILogger<TaskContext>>(), RenderLock);
 
         // Set up services with test cache directory
         if (configPaths)

--- a/src/winapp-CLI/WinApp.Cli.Tests/PackageCommandTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/PackageCommandTests.cs
@@ -4,6 +4,7 @@
 using System.IO.Compression;
 using System.Security.Cryptography.X509Certificates;
 using System.Text.RegularExpressions;
+using WinApp.Cli.ConsoleTasks;
 using WinApp.Cli.Services;
 
 namespace WinApp.Cli.Tests;
@@ -1115,6 +1116,84 @@ public class PackageCommandTests : BaseCommandTests
 
         Assert.Contains("--executable", ex.Message, "Error message should mention --executable option");
         Assert.Contains("no", ex.Message, "Error message should mention no exe files found");
+    }
+
+    #endregion
+
+    #region PFX Certificate Warning Tests
+
+    [TestMethod]
+    public async Task CreateMsixPackageAsync_PfxFileInInputFolder_EmitsWarning()
+    {
+        // Arrange - Create a valid package structure with a .pfx file inside
+        var packageDir = new DirectoryInfo(Path.Combine(_tempDirectory.FullName, "PackageWithPfx"));
+        CreateTestPackageStructure(packageDir);
+
+        // Place a fake .pfx file in the input folder
+        await File.WriteAllTextAsync(Path.Combine(packageDir.FullName, "dev-cert.pfx"), "fake pfx content", TestContext.CancellationToken);
+
+        // Act
+        var result = await _msixService.CreateMsixPackageAsync(
+            inputFolder: packageDir,
+            outputPath: _tempDirectory,
+            TestTaskContext,
+            packageName: "TestPackage",
+            skipPri: true,
+            autoSign: false,
+            cancellationToken: TestContext.CancellationToken
+        );
+
+        // Assert - Package should still be created (warning, not blocking)
+        Assert.IsTrue(result.MsixPath.Exists, "MSIX package should still be created when .pfx is present");
+
+        // Verify warning was emitted as a status message on the task context
+        var statusMessages = TestTask.SubTasks
+            .OfType<StatusMessageTask>()
+            .Select(t => t.CompletedMessage ?? string.Empty)
+            .ToList();
+        Assert.IsTrue(
+            statusMessages.Any(m => m.Contains("PFX certificate file found", StringComparison.OrdinalIgnoreCase)),
+            $"Status messages should contain PFX warning. Messages:\n{string.Join("\n", statusMessages)}");
+        Assert.IsTrue(
+            statusMessages.Any(m => m.Contains("dev-cert.pfx", StringComparison.OrdinalIgnoreCase)),
+            $"Warning should mention the specific PFX file name. Messages:\n{string.Join("\n", statusMessages)}");
+    }
+
+    [TestMethod]
+    public async Task CreateMsixPackageAsync_PfxFileInSubdirectory_EmitsWarning()
+    {
+        // Arrange - Create a valid package structure with a .pfx file in a subdirectory
+        var packageDir = new DirectoryInfo(Path.Combine(_tempDirectory.FullName, "PackageWithNestedPfx"));
+        CreateTestPackageStructure(packageDir);
+
+        // Place a fake .pfx file in a subdirectory
+        var certsDir = Path.Combine(packageDir.FullName, "certs");
+        Directory.CreateDirectory(certsDir);
+        await File.WriteAllTextAsync(Path.Combine(certsDir, "test.pfx"), "fake pfx content", TestContext.CancellationToken);
+
+        // Act
+        var result = await _msixService.CreateMsixPackageAsync(
+            inputFolder: packageDir,
+            outputPath: _tempDirectory,
+            TestTaskContext,
+            packageName: "TestPackage",
+            skipPri: true,
+            autoSign: false,
+            cancellationToken: TestContext.CancellationToken
+        );
+
+        // Assert - Package should still be created
+        Assert.IsTrue(result.MsixPath.Exists, "MSIX package should still be created when .pfx is in subdirectory");
+
+        // Verify warning includes the relative path
+        var statusMessages = TestTask.SubTasks
+            .OfType<StatusMessageTask>()
+            .Select(t => t.CompletedMessage ?? string.Empty)
+            .ToList();
+        Assert.IsTrue(
+            statusMessages.Any(m => m.Contains("certs\\test.pfx", StringComparison.OrdinalIgnoreCase)
+                                    || m.Contains("certs/test.pfx", StringComparison.OrdinalIgnoreCase)),
+            $"Warning should mention the relative path to the PFX file. Messages:\n{string.Join("\n", statusMessages)}");
     }
 
     #endregion

--- a/src/winapp-CLI/WinApp.Cli/ConsoleTasks/TaskContext.cs
+++ b/src/winapp-CLI/WinApp.Cli/ConsoleTasks/TaskContext.cs
@@ -62,6 +62,10 @@ internal class TaskContext
         {
             message = message.Insert(UiSymbols.Info.Length, " ");
         }
+        if (message.StartsWith(UiSymbols.Warning))
+        {
+            message = message.Insert(UiSymbols.Warning.Length, " ");
+        }
         var subTask = new StatusMessageTask(message, _task, _ansiConsole, _logger, _renderLock);
         lock (_renderLock)
         {

--- a/src/winapp-CLI/WinApp.Cli/Services/MsixService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/MsixService.cs
@@ -887,6 +887,18 @@ internal partial class MsixService(
             throw new DirectoryNotFoundException($"Input folder not found: {inputFolder}");
         }
 
+        // Warn if the input folder contains .pfx certificate files, which are likely
+        // development certificates that should not be included in the package payload.
+        var pfxFiles = inputFolder.EnumerateFiles("*.pfx", SearchOption.AllDirectories).ToList();
+        if (pfxFiles.Count > 0)
+        {
+            foreach (var pfxFile in pfxFiles)
+            {
+                var relativePath = Path.GetRelativePath(inputFolder.FullName, pfxFile.FullName);
+                taskContext.AddStatusMessage($"{UiSymbols.Warning} PFX certificate file found in input folder: {relativePath}. Consider removing it before packaging.");
+            }
+        }
+
         // Determine manifest path based on priority:
         // 1. Use provided manifestPath parameter
         // 2. Check for appxmanifest.xml in input folder


### PR DESCRIPTION
## Description

Print out warning when a .pfx file is found in the input folder during `winapp pack`. Warning does not block operation; msix still generated. 

PR also fixes small bug with warning messages. Warning icon needed extra space in its formatting otherwise warning message doesn't show space between icon and text: 
<img width="1490" height="73" alt="image" src="https://github.com/user-attachments/assets/c12caccc-ec41-4abb-bec4-20dce353a6da" />

## Related Issue

Fixes #191
## Type of Change

- 🐛 Bug fix
- 🧪 Test update

## Checklist
<!-- Delete the ones that do not apply to your changes -->

- [x] New tests added for new functionality (if applicable)
- [x] Tested locally on Windows

## Screenshots / Demo

<!-- If applicable, add screenshots or GIFs demonstrating the changes -->

## Additional Notes

NEW - .pfx in input folder during `winapp pack`:
<img width="1492" height="80" alt="image" src="https://github.com/user-attachments/assets/312c3e0e-47f0-4be8-9d1a-5113f0d4ca69" />

No warning printed if no .pfx files found. 

## AI Description

<!-- ai-description-start -->
_This section is auto-generated by AI when the PR is opened or updated. To opt out, delete this entire section including the marker comments._
<!-- ai-description-end -->
