### PR TITLE
Force utf-8 encoding in generate and validate scripts for docs

### DIFF
--- a/scripts/generate-llm-docs.ps1
+++ b/scripts/generate-llm-docs.ps1
@@ -57,9 +57,13 @@ Write-Host "Docs path: $DocsPath" -ForegroundColor Gray
 # Step 1: Generate CLI schema JSON
 Write-Host "[DOCS] Extracting CLI schema..." -ForegroundColor Blue
 $prevEncoding = [Console]::OutputEncoding
-[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
-$SchemaJsonLines = & $CliPath --cli-schema
-[Console]::OutputEncoding = $prevEncoding
+try {
+    [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+    $SchemaJsonLines = & $CliPath --cli-schema
+}
+finally {
+    [Console]::OutputEncoding = $prevEncoding
+}
 if ($LASTEXITCODE -ne 0) {
     Write-Error "Failed to extract CLI schema"
     exit 1

--- a/scripts/generate-llm-docs.ps1
+++ b/scripts/generate-llm-docs.ps1
@@ -56,7 +56,10 @@ Write-Host "Docs path: $DocsPath" -ForegroundColor Gray
 
 # Step 1: Generate CLI schema JSON
 Write-Host "[DOCS] Extracting CLI schema..." -ForegroundColor Blue
+$prevEncoding = [Console]::OutputEncoding
+[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
 $SchemaJsonLines = & $CliPath --cli-schema
+[Console]::OutputEncoding = $prevEncoding
 if ($LASTEXITCODE -ne 0) {
     Write-Error "Failed to extract CLI schema"
     exit 1
@@ -252,7 +255,7 @@ foreach ($skillName in $SkillNames) {
         continue
     }
     
-    $templateContent = Get-Content $templatePath -Raw
+    $templateContent = [System.IO.File]::ReadAllText($templatePath, [System.Text.UTF8Encoding]::new($false))
     $commandPaths = $SkillCommandMap[$skillName]
     $description = $SkillDescriptions[$skillName]
     
@@ -296,7 +299,7 @@ $DefaultSkillsPath = Join-Path $ProjectRoot ".github\plugin\skills\winapp-cli"
 if ($SkillsDir -eq $DefaultSkillsPath) {
     $PluginJsonPath = Join-Path $ProjectRoot ".github\plugin\plugin.json"
     if (Test-Path $PluginJsonPath) {
-        $pluginJson = Get-Content $PluginJsonPath -Raw | ConvertFrom-Json
+        $pluginJson = [System.IO.File]::ReadAllText($PluginJsonPath, [System.Text.UTF8Encoding]::new($false)) | ConvertFrom-Json
         $pluginJson.version = $CliVersion
         $pluginJsonContent = $pluginJson | ConvertTo-Json -Depth 10
         # Normalize line endings

--- a/scripts/validate-llm-docs.ps1
+++ b/scripts/validate-llm-docs.ps1
@@ -53,7 +53,10 @@ if (-not (Test-Path $SchemaPath)) {
 
 # Generate fresh schema and compare
 Write-Host "[VALIDATE] Generating fresh schema from CLI..." -ForegroundColor Blue
+$prevEncoding = [Console]::OutputEncoding
+[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
 $FreshSchemaLines = & $CliPath --cli-schema
+[Console]::OutputEncoding = $prevEncoding
 if ($LASTEXITCODE -ne 0) {
     Write-Error "Failed to extract CLI schema"
     exit 1
@@ -62,7 +65,7 @@ if ($LASTEXITCODE -ne 0) {
 # Join array lines into single string (CLI outputs pretty-printed JSON with newlines)
 $FreshSchema = $FreshSchemaLines -join "`n"
 
-$CommittedSchema = Get-Content $SchemaPath -Raw
+$CommittedSchema = [System.IO.File]::ReadAllText($SchemaPath, [System.Text.UTF8Encoding]::new($false))
 
 # Normalize line endings for comparison
 $FreshSchemaNormalized = $FreshSchema -replace "`r`n", "`n"
@@ -165,11 +168,11 @@ try {
     # which may legitimately contain the same string (e.g. "MyApp_1.0.0_x64").
     $TempSchemaPath = Join-Path $TempDocsPath "cli-schema.json"
     if (Test-Path $TempSchemaPath) {
-        $tempSchemaObj = (Get-Content $TempSchemaPath -Raw) | ConvertFrom-Json -Depth 100
+        $tempSchemaObj = ([System.IO.File]::ReadAllText($TempSchemaPath, [System.Text.UTF8Encoding]::new($false))) | ConvertFrom-Json -Depth 100
         $freshCliVersion = $tempSchemaObj.version
         if ($freshCliVersion -and $freshCliVersion -ne $BaseVersion) {
             Get-ChildItem -Path $TempSkills -Filter "*.md" -Recurse -File -ErrorAction SilentlyContinue | ForEach-Object {
-                $content = Get-Content $_.FullName -Raw
+                $content = [System.IO.File]::ReadAllText($_.FullName, [System.Text.UTF8Encoding]::new($false))
                 $content = $content -replace "(?m)^(version:\s*)$([regex]::Escape($freshCliVersion))$", "`${1}$BaseVersion"
                 [System.IO.File]::WriteAllText($_.FullName, $content)
             }
@@ -190,8 +193,8 @@ try {
         }
         
         if (Test-Path $FreshSkill) {
-            $freshContent = (Get-Content $FreshSkill -Raw) -replace "`r`n", "`n"
-            $committedContent = (Get-Content $CommittedSkill -Raw) -replace "`r`n", "`n"
+            $freshContent = ([System.IO.File]::ReadAllText($FreshSkill, [System.Text.UTF8Encoding]::new($false))) -replace "`r`n", "`n"
+            $committedContent = ([System.IO.File]::ReadAllText($CommittedSkill, [System.Text.UTF8Encoding]::new($false))) -replace "`r`n", "`n"
             
             if ($freshContent -ne $committedContent) {
                 Write-Host "::error::skill '$skillName' is out of sync!" -ForegroundColor Red

--- a/scripts/validate-llm-docs.ps1
+++ b/scripts/validate-llm-docs.ps1
@@ -54,9 +54,13 @@ if (-not (Test-Path $SchemaPath)) {
 # Generate fresh schema and compare
 Write-Host "[VALIDATE] Generating fresh schema from CLI..." -ForegroundColor Blue
 $prevEncoding = [Console]::OutputEncoding
-[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
-$FreshSchemaLines = & $CliPath --cli-schema
-[Console]::OutputEncoding = $prevEncoding
+try {
+    [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+    $FreshSchemaLines = & $CliPath --cli-schema
+}
+finally {
+    [Console]::OutputEncoding = $prevEncoding
+}
 if ($LASTEXITCODE -ne 0) {
     Write-Error "Failed to extract CLI schema"
     exit 1


### PR DESCRIPTION
fixes #425 

This worked locally for me - but @nmetulev you should double check on your machine.