### PR TITLE
Remove DevTools mode references from docs and code

### DIFF
--- a/.github/plugin/skills/winapp-cli/ui-automation/SKILL.md
+++ b/.github/plugin/skills/winapp-cli/ui-automation/SKILL.md
@@ -171,7 +171,7 @@ winapp ui invoke btn-open-e6f7 -w <dialog-hwnd>
 Note: The filename input in standard file dialogs typically has AutomationId `1148`. Use `inspect -w <dialog-hwnd> --interactive` to discover the actual slugs.
 
 ## Related skills
-- `winapp-setup` for adding Windows SDK and DevTools to your project
+- `winapp-setup` for adding Windows SDK to your project
 - `winapp-package` for packaging apps as MSIX
 
 ## Troubleshooting
@@ -190,7 +190,7 @@ Note: The filename input in standard file dialogs typically has AutomationId `11
 
 ### `winapp ui status`
 
-Connect to a target app, auto-detect mode (UIA or DevTools), and display connection info.
+Connect to a target app and display connection info.
 
 #### Options
 <!-- auto-generated from cli-schema.json -->
@@ -432,7 +432,7 @@ Wait for an element to appear, disappear, or have a property reach a target valu
 | `--json` | Format output as JSON | (none) |
 | `--property` | Property name to read or filter on | (none) |
 | `--timeout` | Timeout in milliseconds | `5000` |
-| `--value` | Wait for element value to equal this string. Uses smart fallback (TextPattern ΓåÆ ValuePattern ΓåÆ Name). Combine with --property to check a specific property instead. | (none) |
+| `--value` | Wait for element value to equal this string. Uses smart fallback (TextPattern -> ValuePattern -> Name). Combine with --property to check a specific property instead. | (none) |
 | `--window` | Target window by HWND (stable handle from list output). Takes precedence over --app. | (none) |
 
 ### `winapp ui list-windows`

--- a/docs/cli-schema.json
+++ b/docs/cli-schema.json
@@ -1651,7 +1651,7 @@
       }
     },
     "ui": {
-      "description": "Inspect and interact with any running Windows app using UI Automation (UIA). Auto-detects DevTools mode for WinUI 3 apps with the WinApp NuGet. Works with WPF, WinForms, Win32, Electron, and WinUI 3 apps.",
+      "description": "Inspect and interact with any running Windows app using UI Automation (UIA). Works with WPF, WinForms, Win32, Electron, and WinUI 3 apps.",
       "hidden": false,
       "subcommands": {
         "click": {
@@ -3024,7 +3024,7 @@
           }
         },
         "status": {
-          "description": "Connect to a target app, auto-detect mode (UIA or DevTools), and display connection info.",
+          "description": "Connect to a target app and display connection info.",
           "hidden": false,
           "options": {
             "--app": {

--- a/docs/fragments/skills/winapp-cli/ui-automation.md
+++ b/docs/fragments/skills/winapp-cli/ui-automation.md
@@ -166,7 +166,7 @@ winapp ui invoke btn-open-e6f7 -w <dialog-hwnd>
 Note: The filename input in standard file dialogs typically has AutomationId `1148`. Use `inspect -w <dialog-hwnd> --interactive` to discover the actual slugs.
 
 ## Related skills
-- `winapp-setup` for adding Windows SDK and DevTools to your project
+- `winapp-setup` for adding Windows SDK to your project
 - `winapp-package` for packaging apps as MSIX
 
 ## Troubleshooting

--- a/docs/npm-usage.md
+++ b/docs/npm-usage.md
@@ -694,7 +694,7 @@ function uiSetValue(options?: UiSetValueOptions): Promise<WinappResult>
 
 ### `uiStatus()`
 
-Connect to a target app, auto-detect mode (UIA or DevTools), and display connection info.
+Connect to a target app and display connection info.
 
 ```typescript
 function uiStatus(options?: UiStatusOptions): Promise<WinappResult>
@@ -731,7 +731,7 @@ function uiWaitFor(options?: UiWaitForOptions): Promise<WinappResult>
 | `json` | `boolean \| undefined` | No | Format output as JSON |
 | `property` | `string \| undefined` | No | Property name to read or filter on |
 | `timeout` | `number \| undefined` | No | Timeout in milliseconds |
-| `value` | `string \| undefined` | No | Wait for element value to equal this string. Uses smart fallback (TextPattern → ValuePattern → Name). Combine with --property to check a specific property instead. |
+| `value` | `string \| undefined` | No | Wait for element value to equal this string. Uses smart fallback (TextPattern -> ValuePattern -> Name). Combine with --property to check a specific property instead. |
 | `window` | `number \| undefined` | No | Target window by HWND (stable handle from list output). Takes precedence over --app. |
 
 *Also accepts [CommonOptions](#commonoptions) (`quiet`, `verbose`, `cwd`).*
@@ -1477,7 +1477,7 @@ type ManifestTemplates = "packaged" | "sparse"
 | `json` | `boolean \| undefined` | No | Format output as JSON |
 | `property` | `string \| undefined` | No | Property name to read or filter on |
 | `timeout` | `number \| undefined` | No | Timeout in milliseconds |
-| `value` | `string \| undefined` | No | Wait for element value to equal this string. Uses smart fallback (TextPattern → ValuePattern → Name). Combine with --property to check a specific property instead. |
+| `value` | `string \| undefined` | No | Wait for element value to equal this string. Uses smart fallback (TextPattern -> ValuePattern -> Name). Combine with --property to check a specific property instead. |
 | `window` | `number \| undefined` | No | Target window by HWND (stable handle from list output). Takes precedence over --app. |
 | `quiet` | `boolean \| undefined` | No | Suppress progress messages. |
 | `verbose` | `boolean \| undefined` | No | Enable verbose output. |

--- a/docs/ui-automation.md
+++ b/docs/ui-automation.md
@@ -6,12 +6,8 @@ Used by AI agents and developers for UI testing, debugging, and automation.
 ## Overview
 
 `winapp ui` provides commands for inspecting and interacting with Windows app UIs.
-Two modes are available, auto-detected per session:
-
-- **UIA mode** — Works with any Windows app (WPF, WinForms, Win32, Electron, WinUI 3).
-  Uses Windows UI Automation. Safe by design — no global input injection.
-- **DevTools mode** — For WinUI 3 apps with the DevTools assembly. Provides full XAML tree
-  access, property writing, input simulation, hot-reload, and more. (Future)
+Uses Windows UI Automation (UIA). Works with any Windows app — WPF, WinForms, Win32, Electron, and WinUI 3.
+Safe by design — no global input injection.
 
 ## Quick Start
 
@@ -354,7 +350,7 @@ winapp ui list-windows                                      # all windows (no fi
 | "Selector matched N elements" | Ambiguous legacy selector | Use slugs from `inspect` output, or append `[0]`, `[1]` to legacy selectors |
 | "Element may have changed" | Slug hash doesn't match current element | Re-run `inspect` or `search` to get fresh slugs |
 | "does not support any invoke pattern" | Element can't be invoked | Use `inspect` on the element to find an invokable child |
-| "Pipe not ready" | DevTools NuGet but UseWinAppTools() not called | Add `window.UseWinAppTools()` to startup |
+
 | "No UIA window found" | UIA can't see the process | Use `list-windows` to find the HWND, then `-w` |
 | "Window has zero size" | Window is minimized | App will be auto-restored |
 | Popup/dropdown not in screenshot | PrintWindow doesn't capture overlays | Use `--capture-screen` flag |

--- a/docs/ui-automation.md
+++ b/docs/ui-automation.md
@@ -350,7 +350,6 @@ winapp ui list-windows                                      # all windows (no fi
 | "Selector matched N elements" | Ambiguous legacy selector | Use slugs from `inspect` output, or append `[0]`, `[1]` to legacy selectors |
 | "Element may have changed" | Slug hash doesn't match current element | Re-run `inspect` or `search` to get fresh slugs |
 | "does not support any invoke pattern" | Element can't be invoked | Use `inspect` on the element to find an invokable child |
-
 | "No UIA window found" | UIA can't see the process | Use `list-windows` to find the HWND, then `-w` |
 | "Window has zero size" | Window is minimized | App will be auto-restored |
 | Popup/dropdown not in screenshot | PrintWindow doesn't capture overlays | Use `--capture-screen` flag |

--- a/src/winapp-CLI/WinApp.Cli/Commands/UiCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/UiCommand.cs
@@ -26,7 +26,6 @@ internal class UiCommand : Command, IShortDescription
         UiListWindowsCommand listWindowsCommand,
         UiGetFocusedCommand getFocusedCommand)
         : base("ui", "Inspect and interact with any running Windows app using UI Automation (UIA). " +
-               "Auto-detects DevTools mode for WinUI 3 apps with the WinApp NuGet. " +
                "Works with WPF, WinForms, Win32, Electron, and WinUI 3 apps.")
     {
         Subcommands.Add(statusCommand);

--- a/src/winapp-CLI/WinApp.Cli/Commands/UiStatusCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/UiStatusCommand.cs
@@ -18,7 +18,7 @@ internal class UiStatusCommand : Command, IShortDescription
     public string ShortDescription => "Connect to a running app and show connection info";
 
     public UiStatusCommand()
-        : base("status", "Connect to a target app, auto-detect mode (UIA or DevTools), and display connection info.")
+        : base("status", "Connect to a target app and display connection info.")
     {
         Options.Add(SharedUiOptions.AppOption);
         Options.Add(SharedUiOptions.WindowOption);

--- a/src/winapp-CLI/WinApp.Cli/Models/UiElement.cs
+++ b/src/winapp-CLI/WinApp.Cli/Models/UiElement.cs
@@ -4,7 +4,7 @@
 namespace WinApp.Cli.Models;
 
 /// <summary>
-/// Represents a UI element discovered via UIA or DevTools inspection.
+/// Represents a UI element discovered via UIA inspection.
 /// </summary>
 internal sealed class UiElement
 {

--- a/src/winapp-npm/src/winapp-commands.ts
+++ b/src/winapp-npm/src/winapp-commands.ts
@@ -946,7 +946,7 @@ export interface UiStatusOptions extends CommonOptions {
 }
 
 /**
- * Connect to a target app, auto-detect mode (UIA or DevTools), and display connection info.
+ * Connect to a target app and display connection info.
  */
 export async function uiStatus(options: UiStatusOptions = {}): Promise<WinappResult> {
   const args: string[] = ['ui', 'status'];
@@ -975,7 +975,7 @@ export interface UiWaitForOptions extends CommonOptions {
   property?: string;
   /** Timeout in milliseconds */
   timeout?: number;
-  /** Wait for element value to equal this string. Uses smart fallback (TextPattern → ValuePattern → Name). Combine with --property to check a specific property instead. */
+  /** Wait for element value to equal this string. Uses smart fallback (TextPattern -> ValuePattern -> Name). Combine with --property to check a specific property instead. */
   value?: string;
   /** Target window by HWND (stable handle from list output). Takes precedence over --app. */
   window?: number;


### PR DESCRIPTION
DevTools mode for WinUI 3 apps is not being pursued.