### PR TITLE
Fix #467: ambiguous '-app' parsing and silent partial process matches

### DIFF
--- a/src/winapp-CLI/WinApp.Cli.Tests/OptionTypoValidatorTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/OptionTypoValidatorTests.cs
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using WinApp.Cli.Commands;
+using WinApp.Cli.Helpers;
+
+namespace WinApp.Cli.Tests;
+
+[TestClass]
+public class OptionTypoValidatorTests : BaseCommandTests
+{
+    [TestMethod]
+    public void FlagsSingleDashLongOptionAsTypo()
+    {
+        var rootCommand = GetRequiredService<WinAppRootCommand>();
+        var args = new[] { "ui", "inspect", "-app", "tauri-app", "--depth", "6" };
+        var parseResult = rootCommand.Parse(args);
+
+        var typo = OptionTypoValidator.FindLikelyLongOptionTypo(args, parseResult);
+
+        Assert.AreEqual("-app", typo);
+    }
+
+    [TestMethod]
+    public void FlagsAttachedValueForm()
+    {
+        var rootCommand = GetRequiredService<WinAppRootCommand>();
+        var args = new[] { "ui", "inspect", "-app=tauri-app" };
+        var parseResult = rootCommand.Parse(args);
+
+        var typo = OptionTypoValidator.FindLikelyLongOptionTypo(args, parseResult);
+
+        Assert.AreEqual("-app", typo);
+    }
+
+    [TestMethod]
+    public void DoesNotFlagValidShortOption()
+    {
+        var rootCommand = GetRequiredService<WinAppRootCommand>();
+        var args = new[] { "ui", "inspect", "-a", "tauri-app", "--depth", "6" };
+        var parseResult = rootCommand.Parse(args);
+
+        var typo = OptionTypoValidator.FindLikelyLongOptionTypo(args, parseResult);
+
+        Assert.IsNull(typo);
+    }
+
+    [TestMethod]
+    public void DoesNotFlagValidLongOption()
+    {
+        var rootCommand = GetRequiredService<WinAppRootCommand>();
+        var args = new[] { "ui", "inspect", "--app", "tauri-app" };
+        var parseResult = rootCommand.Parse(args);
+
+        var typo = OptionTypoValidator.FindLikelyLongOptionTypo(args, parseResult);
+
+        Assert.IsNull(typo);
+    }
+
+    [TestMethod]
+    public void DoesNotFlagUnknownShortClusterWithoutMatchingLong()
+    {
+        var rootCommand = GetRequiredService<WinAppRootCommand>();
+        // "-xyz" doesn't correspond to any "--xyz" option, so it's not a confident typo.
+        var args = new[] { "ui", "inspect", "-xyz" };
+        var parseResult = rootCommand.Parse(args);
+
+        var typo = OptionTypoValidator.FindLikelyLongOptionTypo(args, parseResult);
+
+        Assert.IsNull(typo);
+    }
+
+    [TestMethod]
+    public void IgnoresTokensAfterDoubleDash()
+    {
+        var rootCommand = GetRequiredService<WinAppRootCommand>();
+        var args = new[] { "ui", "inspect", "--app", "x", "--", "-app" };
+        var parseResult = rootCommand.Parse(args);
+
+        var typo = OptionTypoValidator.FindLikelyLongOptionTypo(args, parseResult);
+
+        Assert.IsNull(typo);
+    }
+
+    [TestMethod]
+    public void IgnoresNegativeNumbers()
+    {
+        var rootCommand = GetRequiredService<WinAppRootCommand>();
+        var args = new[] { "ui", "inspect", "--app", "x", "-42" };
+        var parseResult = rootCommand.Parse(args);
+
+        var typo = OptionTypoValidator.FindLikelyLongOptionTypo(args, parseResult);
+
+        Assert.IsNull(typo);
+    }
+}

--- a/src/winapp-CLI/WinApp.Cli.Tests/OptionTypoValidatorTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/OptionTypoValidatorTests.cs
@@ -14,7 +14,7 @@ public class OptionTypoValidatorTests : BaseCommandTests
     {
         var rootCommand = GetRequiredService<WinAppRootCommand>();
         var args = new[] { "ui", "inspect", "-app", "tauri-app", "--depth", "6" };
-        var parseResult = rootCommand.Parse(args);
+        var parseResult = rootCommand.Parse(args, WinAppParserConfiguration.Default);
 
         var typo = OptionTypoValidator.FindLikelyLongOptionTypo(args, parseResult);
 
@@ -26,7 +26,7 @@ public class OptionTypoValidatorTests : BaseCommandTests
     {
         var rootCommand = GetRequiredService<WinAppRootCommand>();
         var args = new[] { "ui", "inspect", "-app=tauri-app" };
-        var parseResult = rootCommand.Parse(args);
+        var parseResult = rootCommand.Parse(args, WinAppParserConfiguration.Default);
 
         var typo = OptionTypoValidator.FindLikelyLongOptionTypo(args, parseResult);
 
@@ -38,7 +38,7 @@ public class OptionTypoValidatorTests : BaseCommandTests
     {
         var rootCommand = GetRequiredService<WinAppRootCommand>();
         var args = new[] { "ui", "inspect", "-a", "tauri-app", "--depth", "6" };
-        var parseResult = rootCommand.Parse(args);
+        var parseResult = rootCommand.Parse(args, WinAppParserConfiguration.Default);
 
         var typo = OptionTypoValidator.FindLikelyLongOptionTypo(args, parseResult);
 
@@ -50,7 +50,7 @@ public class OptionTypoValidatorTests : BaseCommandTests
     {
         var rootCommand = GetRequiredService<WinAppRootCommand>();
         var args = new[] { "ui", "inspect", "--app", "tauri-app" };
-        var parseResult = rootCommand.Parse(args);
+        var parseResult = rootCommand.Parse(args, WinAppParserConfiguration.Default);
 
         var typo = OptionTypoValidator.FindLikelyLongOptionTypo(args, parseResult);
 
@@ -63,7 +63,7 @@ public class OptionTypoValidatorTests : BaseCommandTests
         var rootCommand = GetRequiredService<WinAppRootCommand>();
         // "-xyz" doesn't correspond to any "--xyz" option, so it's not a confident typo.
         var args = new[] { "ui", "inspect", "-xyz" };
-        var parseResult = rootCommand.Parse(args);
+        var parseResult = rootCommand.Parse(args, WinAppParserConfiguration.Default);
 
         var typo = OptionTypoValidator.FindLikelyLongOptionTypo(args, parseResult);
 
@@ -75,7 +75,7 @@ public class OptionTypoValidatorTests : BaseCommandTests
     {
         var rootCommand = GetRequiredService<WinAppRootCommand>();
         var args = new[] { "ui", "inspect", "--app", "x", "--", "-app" };
-        var parseResult = rootCommand.Parse(args);
+        var parseResult = rootCommand.Parse(args, WinAppParserConfiguration.Default);
 
         var typo = OptionTypoValidator.FindLikelyLongOptionTypo(args, parseResult);
 
@@ -87,7 +87,7 @@ public class OptionTypoValidatorTests : BaseCommandTests
     {
         var rootCommand = GetRequiredService<WinAppRootCommand>();
         var args = new[] { "ui", "inspect", "--app", "x", "-42" };
-        var parseResult = rootCommand.Parse(args);
+        var parseResult = rootCommand.Parse(args, WinAppParserConfiguration.Default);
 
         var typo = OptionTypoValidator.FindLikelyLongOptionTypo(args, parseResult);
 

--- a/src/winapp-CLI/WinApp.Cli/Commands/CompleteCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/CompleteCommand.cs
@@ -3,6 +3,7 @@
 
 using System.CommandLine;
 using System.CommandLine.Completions;
+using WinApp.Cli.Helpers;
 
 namespace WinApp.Cli.Commands;
 
@@ -111,7 +112,7 @@ internal class CompleteCommand : Command, IShortDescription
             return 0;
         }
 
-        var completionParseResult = rootCommand.Parse(argsText);
+        var completionParseResult = rootCommand.Parse(argsText, WinAppParserConfiguration.Default);
         var completions = completionParseResult.GetCompletions(argsPosition);
 
         // Build a set of alias names to exclude from completions.

--- a/src/winapp-CLI/WinApp.Cli/Helpers/OptionTypoValidator.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/OptionTypoValidator.cs
@@ -10,9 +10,11 @@ namespace WinApp.Cli.Helpers;
 /// Detects single-dash option typos like <c>-app</c> when a long option <c>--app</c> exists.
 /// </summary>
 /// <remarks>
-/// System.CommandLine treats <c>-app</c> as the short option <c>-a</c> with attached value <c>pp</c>
-/// (POSIX bundling). When a user clearly meant <c>--app</c>, that silent reinterpretation can lead
-/// to surprising results (see issue #467). This helper surfaces such cases as an explicit error.
+/// POSIX short-option bundling is disabled in <see cref="WinAppParserConfiguration"/>, so without
+/// this guard the parser would treat <c>-app</c> as the positional <c>selector</c> argument and then
+/// emit a confusing "Unrecognized command or argument" error pointing at the next token. This helper
+/// catches the case before invocation and surfaces a clearer "Did you mean --app?" message.
+/// See issue #467.
 /// </remarks>
 internal static class OptionTypoValidator
 {

--- a/src/winapp-CLI/WinApp.Cli/Helpers/OptionTypoValidator.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/OptionTypoValidator.cs
@@ -1,0 +1,110 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using System.CommandLine;
+using System.CommandLine.Parsing;
+
+namespace WinApp.Cli.Helpers;
+
+/// <summary>
+/// Detects single-dash option typos like <c>-app</c> when a long option <c>--app</c> exists.
+/// </summary>
+/// <remarks>
+/// System.CommandLine treats <c>-app</c> as the short option <c>-a</c> with attached value <c>pp</c>
+/// (POSIX bundling). When a user clearly meant <c>--app</c>, that silent reinterpretation can lead
+/// to surprising results (see issue #467). This helper surfaces such cases as an explicit error.
+/// </remarks>
+internal static class OptionTypoValidator
+{
+    /// <summary>
+    /// Returns the offending token (e.g., "-app") when it looks like a long-option typo, or null.
+    /// </summary>
+    public static string? FindLikelyLongOptionTypo(IReadOnlyList<string> args, ParseResult parseResult)
+    {
+        var leaf = parseResult.CommandResult.Command;
+
+        // Honor commands that intentionally pass through unknown tokens (e.g. tool, ms-store).
+        if (!leaf.TreatUnmatchedTokensAsErrors)
+        {
+            return null;
+        }
+
+        var longNames = CollectLongOptionNames(parseResult.CommandResult);
+        if (longNames.Count == 0)
+        {
+            return null;
+        }
+
+        var afterDoubleDash = false;
+        foreach (var token in args)
+        {
+            if (afterDoubleDash) { continue; }
+            if (token == "--") { afterDoubleDash = true; continue; }
+
+            // Only consider tokens like "-abc..." (single dash, 2+ chars after).
+            if (token.Length <= 2 || token[0] != '-' || token[1] == '-')
+            {
+                continue;
+            }
+
+            var rest = token.AsSpan(1);
+            if (!char.IsLetter(rest[0]))
+            {
+                continue;
+            }
+
+            // Stop at '=' so "-app=foo" still flags "-app" against "--app".
+            var end = rest.IndexOf('=');
+            if (end < 0) { end = rest.Length; }
+
+            var nameSpan = rest[..end];
+            var allValid = true;
+            for (var i = 0; i < nameSpan.Length; i++)
+            {
+                var c = nameSpan[i];
+                if (!char.IsLetterOrDigit(c) && c != '-')
+                {
+                    allValid = false;
+                    break;
+                }
+            }
+            if (!allValid)
+            {
+                continue;
+            }
+
+            var candidate = "--" + nameSpan.ToString();
+            if (longNames.Contains(candidate))
+            {
+                return "-" + nameSpan.ToString();
+            }
+        }
+
+        return null;
+    }
+
+    private static HashSet<string> CollectLongOptionNames(CommandResult leaf)
+    {
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        SymbolResult? cursor = leaf;
+        while (cursor is CommandResult cr)
+        {
+            foreach (var opt in cr.Command.Options)
+            {
+                if (opt.Name.StartsWith("--", StringComparison.Ordinal))
+                {
+                    names.Add(opt.Name);
+                }
+                foreach (var alias in opt.Aliases)
+                {
+                    if (alias.StartsWith("--", StringComparison.Ordinal))
+                    {
+                        names.Add(alias);
+                    }
+                }
+            }
+            cursor = cr.Parent;
+        }
+        return names;
+    }
+}

--- a/src/winapp-CLI/WinApp.Cli/Helpers/WinAppParserConfiguration.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/WinAppParserConfiguration.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using System.CommandLine;
+
+namespace WinApp.Cli.Helpers;
+
+/// <summary>
+/// Centralised <see cref="ParserConfiguration"/> used for every winapp command-line parse.
+/// </summary>
+/// <remarks>
+/// POSIX bundling is disabled because winapp uses a Windows-style CLI that does not advertise
+/// short-option clustering (e.g. <c>-abc</c>) or attached-value short options (e.g. <c>-w7932630</c>),
+/// and the silent reinterpretation of <c>-app</c> as <c>-a pp</c> is a usability trap (issue #467).
+/// </remarks>
+internal static class WinAppParserConfiguration
+{
+    public static ParserConfiguration Default { get; } = new()
+    {
+        EnablePosixBundling = false
+    };
+}

--- a/src/winapp-CLI/WinApp.Cli/Program.cs
+++ b/src/winapp-CLI/WinApp.Cli/Program.cs
@@ -112,14 +112,19 @@ internal static class Program
         // Catch single-dash typos like "-app" before invocation so the user gets a clear
         // "Did you mean --app?" message instead of System.CommandLine's confusing
         // "Unrecognized command or argument" pointing at the wrong token (issue #467).
-        var typo = OptionTypoValidator.FindLikelyLongOptionTypo(args, parseResult);
-        if (typo is not null)
+        // Only run when parsing already failed — otherwise a command that legitimately
+        // accepts a "-foo"-shaped positional value would get a false-positive typo error.
+        if (parseResult.Errors.Count > 0)
         {
-            var suggested = "-" + typo;
-            Console.Error.WriteLine($"Unknown option '{typo}'. Did you mean '{suggested}'?");
-            Console.Error.WriteLine(
-                "(Single-dash flags are reserved for short aliases like '-a'. Long options use a double dash.)");
-            return 1;
+            var typo = OptionTypoValidator.FindLikelyLongOptionTypo(args, parseResult);
+            if (typo is not null)
+            {
+                var suggested = "-" + typo;
+                Console.Error.WriteLine($"Unknown option '{typo}'. Did you mean '{suggested}'?");
+                Console.Error.WriteLine(
+                    "(Single-dash flags are reserved for short aliases like '-a'. Long options use a double dash.)");
+                return 1;
+            }
         }
 
         // Set WINAPP_CLI_CALLER env var from --caller option so telemetry picks it up

--- a/src/winapp-CLI/WinApp.Cli/Program.cs
+++ b/src/winapp-CLI/WinApp.Cli/Program.cs
@@ -109,6 +109,18 @@ internal static class Program
 
         var parseResult = rootCommand.Parse(args);
 
+        // Catch single-dash typos like "-app" that POSIX bundling silently reinterprets as
+        // "-a pp" — see issue #467.
+        var typo = OptionTypoValidator.FindLikelyLongOptionTypo(args, parseResult);
+        if (typo is not null)
+        {
+            var suggested = "-" + typo;
+            Console.Error.WriteLine($"Unknown option '{typo}'. Did you mean '{suggested}'?");
+            Console.Error.WriteLine(
+                $"Single-dash flags are short aliases (e.g. '-a'). '{typo}' would otherwise be parsed as the short option '{typo[..2]}' with attached value '{typo[2..]}'.");
+            return 1;
+        }
+
         // Set WINAPP_CLI_CALLER env var from --caller option so telemetry picks it up
         var caller = parseResult.GetValue(WinAppRootCommand.CallerOption);
         if (!string.IsNullOrWhiteSpace(caller))

--- a/src/winapp-CLI/WinApp.Cli/Program.cs
+++ b/src/winapp-CLI/WinApp.Cli/Program.cs
@@ -103,21 +103,22 @@ internal static class Program
             }
 
             // Show help by invoking with --help
-            await rootCommand.Parse(["--help"]).InvokeAsync();
+            await rootCommand.Parse(["--help"], WinAppParserConfiguration.Default).InvokeAsync();
             return 0;
         }
 
-        var parseResult = rootCommand.Parse(args);
+        var parseResult = rootCommand.Parse(args, WinAppParserConfiguration.Default);
 
-        // Catch single-dash typos like "-app" that POSIX bundling silently reinterprets as
-        // "-a pp" — see issue #467.
+        // Catch single-dash typos like "-app" before invocation so the user gets a clear
+        // "Did you mean --app?" message instead of System.CommandLine's confusing
+        // "Unrecognized command or argument" pointing at the wrong token (issue #467).
         var typo = OptionTypoValidator.FindLikelyLongOptionTypo(args, parseResult);
         if (typo is not null)
         {
             var suggested = "-" + typo;
             Console.Error.WriteLine($"Unknown option '{typo}'. Did you mean '{suggested}'?");
             Console.Error.WriteLine(
-                $"Single-dash flags are short aliases (e.g. '-a'). '{typo}' would otherwise be parsed as the short option '{typo[..2]}' with attached value '{typo[2..]}'.");
+                "(Single-dash flags are reserved for short aliases like '-a'. Long options use a double dash.)");
             return 1;
         }
 

--- a/src/winapp-CLI/WinApp.Cli/Services/UiSessionService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/UiSessionService.cs
@@ -76,7 +76,7 @@ internal sealed class UiSessionService(
         var selected = foreground != default ? foreground : PickLargestWindow(windows);
 
         var reason = foreground != default ? "foreground" : "largest";
-        logger.LogDebug("Auto-selected HWND {Hwnd} ({Reason}) from {Count} windows for '{App}'", selected.Hwnd, reason, windows.Count, app);
+        logger.LogInformation("Auto-selected HWND {Hwnd} ({Reason}) from {Count} windows for '{App}' — pass -w {Hwnd} to target this window explicitly.", selected.Hwnd, reason, windows.Count, app, selected.Hwnd);
 
         return CreateSession(selected.Pid, selected.Hwnd, selected.Title);
     }
@@ -256,7 +256,7 @@ internal sealed class UiSessionService(
         catch { }
     }
 
-    private static Process? TryResolveProcess(string app)
+    private Process? TryResolveProcess(string app)
     {
         // Try as PID
         if (int.TryParse(app, out var pid))
@@ -333,6 +333,7 @@ internal sealed class UiSessionService(
             {
                 var result = partialMatches[0];
                 partialMatches = []; // prevent disposal
+                LogPartialMatch(app, result);
                 return result;
             }
 
@@ -350,6 +351,7 @@ internal sealed class UiSessionService(
                 {
                     var result = withWindow[0];
                     partialMatches = partialMatches.Where(p => p != result).ToArray();
+                    LogPartialMatch(app, result);
                     return result;
                 }
             }
@@ -360,6 +362,22 @@ internal sealed class UiSessionService(
         }
 
         return null;
+    }
+
+    private void LogPartialMatch(string input, Process matched)
+    {
+        // Surface partial-name matches so users notice when a short/typoed --app value
+        // resolved to an unrelated process (issue #467).
+        try
+        {
+            logger.LogInformation(
+                "Partial process-name match: '{Input}' resolved to '{ProcessName}' (PID {Pid}). Pass the full process name or PID to disambiguate.",
+                input, matched.ProcessName, matched.Id);
+        }
+        catch
+        {
+            // Process metadata can be unavailable for protected processes; ignore logging failures.
+        }
     }
 
     private static uint GetPidFromHwnd(long hwnd)

--- a/src/winapp-CLI/WinApp.Cli/Services/UiSessionService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/UiSessionService.cs
@@ -76,7 +76,7 @@ internal sealed class UiSessionService(
         var selected = foreground != default ? foreground : PickLargestWindow(windows);
 
         var reason = foreground != default ? "foreground" : "largest";
-        logger.LogInformation("Auto-selected HWND {Hwnd} ({Reason}) from {Count} windows for '{App}' — pass -w {Hwnd} to target this window explicitly.", selected.Hwnd, reason, windows.Count, app, selected.Hwnd);
+        logger.LogInformation("Auto-selected HWND {Hwnd} ({Reason}) from {Count} windows for '{App}' — pass -w {ExplicitHwnd} to target this window explicitly.", selected.Hwnd, reason, windows.Count, app, selected.Hwnd);
 
         return CreateSession(selected.Pid, selected.Hwnd, selected.Title);
     }


### PR DESCRIPTION
Fixes #467.

## Problem

`winapp ui inspect -app tauri-app --depth 6` was silently inspecting the wrong app (e.g. Microsoft Teams) instead of the Tauri app, with no indication anything was wrong.

Two compounding issues:

1. **POSIX short-option bundling.** `-a` is a registered short alias of `--app`, so System.CommandLine parsed `-app` as the short option `-a` with attached value `pp` (POSIX `-aValue` form). Result: `app="pp"`, `selector="tauri-app"`. Zero unmatched tokens, so `TreatUnmatchedTokensAsErrors` had nothing to reject.
2. **Silent partial process-name matching.** `UiSessionService.TryResolveProcess("pp")` falls back to `p.ProcessName.Contains("pp", OrdinalIgnoreCase)`. Many running processes match (`ApplicationFrameHost`, etc.); whichever happens to have a foreground/main window wins. The selection was logged at `Debug` only, so users had no signal that a partial match had occurred.

## Fix

- **Disable POSIX bundling globally** via a shared `WinAppParserConfiguration.Default` (`EnablePosixBundling = false`), wired into the two production parse sites (`Program.cs`, `CompleteCommand.cs`). Tests use long-form options exclusively and are unaffected. Searched the repo for attached-value short-option usage (`-w7932630`, `-aFoo`, etc.) — none in docs, samples, scripts, or skills.
- **Add `OptionTypoValidator`** as defense-in-depth. With bundling off, the parser would otherwise consume `-app` as the positional `selector` argument and emit `Unrecognized command or argument 'tauri-app'` — which points at the wrong token. The validator inspects the parsed command's long-option namespace, detects single-dash tokens that match a known long option (e.g. `-app` ↔ `--app`), and exits with a clearer message before invocation:
  ```
  Unknown option '-app'. Did you mean '--app'?
  (Single-dash flags are reserved for short aliases like '-a'. Long options use a double dash.)
  ```
  Honors `TreatUnmatchedTokensAsErrors=false` so pass-through commands like `tool` and `ms-store` are unaffected. Skips negative numbers and tokens after `--`.
- **Promote partial-match logging from `Debug` → `Information`** in `UiSessionService` so users see when a short/typoed `--app` value resolved to an unrelated process, with the matched PID/process name and a hint to use `-w <HWND>` or the full process name to disambiguate. Same change for the auto-window-selection path when one process owns multiple windows.

## Verification

- New `OptionTypoValidatorTests` (7 cases): typo detection, attached-value form (`-app=foo`), valid short/long options, unknown clusters with no matching long, `--` terminator, negative numbers.
- Full test suite: 771/771 passing.
- Manual smoke tests:
  - `-app something` → friendly typo error, exit 1 ✅
  - `-a something` (valid short) → works ✅
  - `--app something` → works ✅
  - `--help` and `ui inspect --help` → unaffected ✅
- `scripts/build-cli.ps1` regenerated CLI schema and skills cleanly with no surface changes.