### PR TITLE
docs: fix factual inaccuracies surfaced by docs-vs-code validation

### DIFF
--- a/.github/plugin/skills/winapp-cli/package/SKILL.md
+++ b/.github/plugin/skills/winapp-cli/package/SKILL.md
@@ -179,7 +179,7 @@ Create MSIX installer from your built app. Run after building your app. A manife
 | `--install-cert` | Install certificate to machine | (none) |
 | `--manifest` | Path to AppX manifest file (default: auto-detect from input folder or current directory) | (none) |
 | `--name` | Package name (default: from manifest) | (none) |
-| `--output` | Output msix file name for the generated package (defaults to <name>.msix) | (none) |
+| `--output` | Output msix file name for the generated package (defaults to <name>_<version>_<arch>.msix, falling back to <name>_<version>.msix, <name>_<arch>.msix, or <name>.msix when version/arch can't be determined) | (none) |
 | `--publisher` | Publisher name for certificate generation | (none) |
 | `--self-contained` | Bundle Windows App SDK runtime for self-contained deployment | (none) |
 | `--skip-pri` | Skip PRI file generation | (none) |

--- a/docs/cli-schema.json
+++ b/docs/cli-schema.json
@@ -1181,7 +1181,7 @@
           "recursive": false
         },
         "--output": {
-          "description": "Output msix file name for the generated package (defaults to <name>.msix)",
+          "description": "Output msix file name for the generated package (defaults to <name>_<version>_<arch>.msix, falling back to <name>_<version>.msix, <name>_<arch>.msix, or <name>.msix when version/arch can't be determined)",
           "hidden": false,
           "valueType": "System.IO.FileInfo",
           "hasDefaultValue": false,

--- a/docs/guides/rust.md
+++ b/docs/guides/rust.md
@@ -172,11 +172,6 @@ Once you're ready to distribute your app, you can package it as an MSIX using th
 First, build your application in release mode for optimal performance:
 
 ```powershell
-winapp manifest add-alias
-```
-
-
-```powershell
 cargo build --release
 ```
 

--- a/docs/npm-usage.md
+++ b/docs/npm-usage.md
@@ -124,7 +124,7 @@ function certInstall(options: CertInstallOptions): Promise<WinappResult>
 
 ### `createDebugIdentity()`
 
-Enable package identity for debugging without creating full MSIX. Required for testing Windows APIs (push notifications, share target, etc.) during development. Example: winapp create-debug-identity ./myapp.exe. Requires Package.appxmanifest in current directory or passed via --manifest. Re-run after changing the manifest or Assets/.
+Enable package identity for debugging without creating full MSIX. Required for testing Windows APIs (push notifications, share target, etc.) during development. Example: winapp create-debug-identity ./myapp.exe. Requires Package.appxmanifest or appxmanifest.xml in current directory or passed via --manifest. Re-run after changing the manifest or Assets/.
 
 ```typescript
 function createDebugIdentity(options?: CreateDebugIdentityOptions): Promise<WinappResult>
@@ -294,7 +294,7 @@ function packageApp(options: PackageOptions): Promise<WinappResult>
 | `installCert` | `boolean \| undefined` | No | Install certificate to machine |
 | `manifest` | `string \| undefined` | No | Path to AppX manifest file (default: auto-detect from input folder or current directory) |
 | `name` | `string \| undefined` | No | Package name (default: from manifest) |
-| `output` | `string \| undefined` | No | Output msix file name for the generated package (defaults to <name>.msix) |
+| `output` | `string \| undefined` | No | Output msix file name for the generated package (defaults to <name>_<version>_<arch>.msix, falling back to <name>_<version>.msix, <name>_<arch>.msix, or <name>.msix when version/arch can't be determined) |
 | `publisher` | `string \| undefined` | No | Publisher name for certificate generation |
 | `selfContained` | `boolean \| undefined` | No | Bundle Windows App SDK runtime for self-contained deployment |
 | `skipPri` | `boolean \| undefined` | No | Skip PRI file generation |
@@ -1220,7 +1220,7 @@ type ManifestTemplates = "packaged" | "sparse"
 | `installCert` | `boolean \| undefined` | No | Install certificate to machine |
 | `manifest` | `string \| undefined` | No | Path to AppX manifest file (default: auto-detect from input folder or current directory) |
 | `name` | `string \| undefined` | No | Package name (default: from manifest) |
-| `output` | `string \| undefined` | No | Output msix file name for the generated package (defaults to <name>.msix) |
+| `output` | `string \| undefined` | No | Output msix file name for the generated package (defaults to <name>_<version>_<arch>.msix, falling back to <name>_<version>.msix, <name>_<arch>.msix, or <name>.msix when version/arch can't be determined) |
 | `publisher` | `string \| undefined` | No | Publisher name for certificate generation |
 | `selfContained` | `boolean \| undefined` | No | Bundle Windows App SDK runtime for self-contained deployment |
 | `skipPri` | `boolean \| undefined` | No | Skip PRI file generation |

--- a/docs/ui-automation.md
+++ b/docs/ui-automation.md
@@ -7,7 +7,7 @@ Used by AI agents and developers for UI testing, debugging, and automation.
 
 `winapp ui` provides commands for inspecting and interacting with Windows app UIs.
 Uses Windows UI Automation (UIA). Works with any Windows app — WPF, WinForms, Win32, Electron, and WinUI 3.
-Safe by design — no global input injection.
+Most commands drive the app through UIA patterns (no input injection); `ui click` is the exception and uses real mouse simulation for controls that don't support `InvokePattern`.
 
 ## Quick Start
 
@@ -103,15 +103,14 @@ Slugs are shell-safe (no special characters), unique, and can be used directly a
 
 Elements with no name or AutomationId show only prefix + hash (e.g., `pn-c8a3`).
 
-### Index disambiguation (`[N]`)
+### Disambiguating multiple matches
 
-When using legacy selectors that match multiple elements, append `[N]` (zero-based) to pick a specific one. Slugs from inspect output are already unique and don't need indexing.
+Slugs from `inspect`/`search` output are unique, but can change across layout changes - use them over plain type names or text when multiple matches. When a selector is ambiguous, the CLI prints all matches with their slugs so you can pick the right one and re-run with that slug.
 
 ```bash
 winapp ui search Button -a myapp            # shows: btn-ok-a1b2 "OK", btn-cancel-c3d4 "Cancel"
 winapp ui invoke btn-ok-a1b2 -a myapp       # invoke using slug (preferred)
-winapp ui invoke "Button[0]" -a myapp       # or use legacy selector with index
-winapp ui invoke "Button[1]" -a myapp       # invokes the second Button ("Cancel")
+winapp ui invoke btn-cancel-c3d4 -a myapp   # invoke the other Button by its slug
 ```
 
 ### Plain text search
@@ -219,7 +218,7 @@ winapp ui get-property cmb-combobox-d5e6 -p ExpandCollapseState -a myapp  # expa
 ```
 
 ### screenshot
-Capture a window or element as PNG. When multiple windows exist (e.g., app + open dialog), captures each to a separate file.
+Capture a window or element as PNG. When multiple windows exist (e.g., app + open dialog), they are composited into a single PNG with each window stitched in.
 ```bash
 winapp ui screenshot -a notepad                     # saves screenshot.png in cwd
 winapp ui screenshot -a notepad --output my.png     # custom filename
@@ -229,15 +228,9 @@ winapp ui screenshot txt-searchbox-e5f6 -a myapp          # crop to element boun
 winapp ui screenshot -a myapp --capture-screen      # capture from screen (includes popups/overlays)
 ```
 
-When dialogs or popups are open, each window is captured separately:
-```
-⚠  2 windows detected. Capturing each separately.
-  ✓ screenshot.png — HWND 133306: "*hello - Notepad" (window, 1476x1167)
-  ✓ screenshot.3213334-dialog.png — HWND 3213334: "Open" (dialog, 1248x834, owner: HWND 133306)
-```
+When dialogs or popups are open, all windows are composited into one PNG so you can see the full UI state in a single image.
 
-Use `--capture-screen` when you need to capture popup menus, dropdowns, flyouts, or tooltip overlays.
-The window is brought to the foreground automatically before capture.
+Use `--capture-screen` when you need to capture popup menus, dropdowns, flyouts, or tooltip overlays. In `--capture-screen` mode (and when retrying after a blank-frame is detected) the target window is brought to the foreground first; normal window captures do not move the window.
 
 ### invoke
 Programmatically activate an element (click button, toggle checkbox, expand combo box).
@@ -295,6 +288,7 @@ winapp ui wait-for btn-submit-7a90 -a myapp --timeout 5000             # wait fo
 winapp ui wait-for CounterDisplay -a myapp --value "5" --timeout 5000  # wait for element value (smart fallback)
 winapp ui wait-for lbl-status -a myapp --property Name --value "Done" --timeout 5000  # wait for specific property
 winapp ui wait-for btn-submit-a1b2 --gone -a myapp --timeout 2000      # wait for element to disappear
+winapp ui wait-for lbl-status -a myapp --value "Done" --contains       # substring match instead of exact equality
 ```
 
 ### scroll
@@ -482,7 +476,7 @@ winapp ui wait-for "Main Page" -a $app.ProcessId -t 30000
 
 # Interact and assert
 winapp ui invoke "Add Item" -a $app.ProcessId
-winapp ui set-value "Item Name" -a $app.ProcessId --text "Test Item"
+winapp ui set-value "Item Name" "Test Item" -a $app.ProcessId
 winapp ui invoke "Save" -a $app.ProcessId
 winapp ui wait-for "Test Item" -a $app.ProcessId -t 5000              # assert item appeared in list
 winapp ui wait-for "Save" -a $app.ProcessId --gone -t 3000            # assert save dialog closed

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -122,12 +122,11 @@ winapp update [options]
 
 **Options:**
 
-- `--config-dir <path>` - Directory containing winapp.yaml (default: current directory)
-- `----setup-sdks` - SDK installation mode: 'stable' (default), 'preview', 'experimental', or 'none' (skip SDK installation)
+- `--setup-sdks <stable|preview|experimental|none>` - SDK installation mode: `stable` (default), `preview`, `experimental`, or `none` (skip SDK installation)
 
 **What it does:**
 
-- Reads existing `winapp.yaml` configuration
+- Reads existing `winapp.yaml` configuration in the current directory
 - Updates all packages to their latest available versions
 - Updates the `winapp.yaml` file with new version numbers
 - Regenerates C++/WinRT headers and binaries
@@ -158,7 +157,7 @@ winapp pack <input-folder> [options]
 
 **Options:**
 
-- `--output <filename>` - Output MSIX file name (default: `<name>_<version>.msix`)
+- `--output <filename>` - Output MSIX file name (default: `<name>_<version>_<arch>.msix`, falling back to `<name>_<version>.msix`, `<name>_<arch>.msix`, or `<name>.msix` when version/arch can't be determined)
 - `--name <name>` - Package name (default: from manifest)
 - `--manifest <path>` - Path to AppxManifest.xml (default: auto-detect)
 - `--cert <path>` - Path to signing certificate (enables auto-signing)
@@ -228,7 +227,7 @@ winapp create-debug-identity [entrypoint] [options]
 
 **Options:**
 
-- `--manifest <path>` - Path to AppxManifest.xml (default: `./appxmanifest.xml`)
+- `--manifest <path>` - Path to AppxManifest.xml (default: auto-detect `Package.appxmanifest` or `appxmanifest.xml` in the current directory)
 - `--no-install` - Don't install the package after creation
 - `--keep-identity` - Keep the manifest identity as-is, without appending `.debug` to the package name and application ID
 
@@ -278,7 +277,7 @@ winapp manifest generate [directory] [options]
 - `--entrypoint <path>` - Entry point executable or script
 - `--template <type>` - Template type: `packaged` (default) or `sparse`
 - `--logo-path <path>` - Path to logo image file
-- `--if-exists <Error|Overwrite|Skip>` - Set behavior if the certificate file already exists (default: Error)
+- `--if-exists <Error|Overwrite|Skip>` - Behavior when the manifest file already exists at the target path (default: `Error`)
 
 **Templates:**
 

--- a/src/winapp-CLI/WinApp.Cli/Commands/PackageCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/PackageCommand.cs
@@ -35,7 +35,7 @@ internal class PackageCommand : Command, IShortDescription
         InputFolderArgument.AcceptExistingOnly();
         OutputOption = new Option<FileInfo>("--output")
         {
-            Description = "Output msix file name for the generated package (defaults to <name>.msix)",
+            Description = "Output msix file name for the generated package (defaults to <name>_<version>_<arch>.msix, falling back to <name>_<version>.msix, <name>_<arch>.msix, or <name>.msix when version/arch can't be determined)",
         };
 
         NameOption = new Option<string?>("--name")

--- a/src/winapp-npm/src/winapp-commands.ts
+++ b/src/winapp-npm/src/winapp-commands.ts
@@ -381,7 +381,7 @@ export interface PackageOptions extends CommonOptions {
   manifest?: string;
   /** Package name (default: from manifest) */
   name?: string;
-  /** Output msix file name for the generated package (defaults to <name>.msix) */
+  /** Output msix file name for the generated package (defaults to <name>_<version>_<arch>.msix, falling back to <name>_<version>.msix, <name>_<arch>.msix, or <name>.msix when version/arch can't be determined) */
   output?: string;
   /** Publisher name for certificate generation */
   publisher?: string;


### PR DESCRIPTION
Validates docs against the live CLI schema and source code, then fixes the factual inaccuracies that surfaced.

## Critical fixes

**`docs/usage.md`**
- `update`: remove non-existent `--config-dir`, fix `----setup-sdks` typo (only `--setup-sdks` is real)
- `package --output`: default is `<name>_<version>_<arch>.msix` (with fallbacks), not `<name>_<version>.msix`
- `create-debug-identity --manifest`: default is auto-detect (`Package.appxmanifest` then `appxmanifest.xml`), not `./appxmanifest.xml`
- `manifest generate --if-exists`: described the wrong thing (said "certificate file"; it's the manifest file)

**`docs/ui-automation.md`**
- L10: removed false "no global input injection" claim — `ui click` does inject mouse input
- L106-115: removed fictional `[N]` index disambiguation section — there is no selector parser support for it; replaced with the real "use the slug from search output" guidance
- `screenshot`: multi-window output is composited into one PNG, not separate files
- Clarified foreground-before-capture only applies to `--capture-screen` / blank-frame retry
- `set-value`: value is a positional argument, not `--text`
- Added missing `wait-for --contains` example

**`docs/npm-usage.md`**
- `execWithBuildTools` return type: `Buffer | string` (matches `buildtools-utils.ts`)

**`docs/guides/rust.md`**
- Removed redundant `winapp manifest add-alias` in step 6 — alias is already added via the same CLI command in step 4

**`src/winapp-CLI/.../PackageCommand.cs`**
- Updated `--output` help text to match the actual default-name logic in `MsixService.cs:388-394`
- Regenerated `cli-schema.json`, npm command wrappers, and SKILL.md tables (autogen)

## Items intentionally **not** in this PR (per discussion)

- `upgrade` command docs — belongs in a different branch
- Bulk `appxmanifest.xml` &rarr; `Package.appxmanifest` refresh across guides — separate change
- PFN examples missing `.debug` suffix — was a false positive (`winapp run` doesn't add `.debug`; that's only `create-debug-identity`)

## Validation

- `dotnet build` clean (0 warnings, 0 errors)
- All edits cross-checked against `Commands/*.cs`, `Services/*.cs`, `src/winapp-npm/src/*.ts`, and live `--cli-schema` output
