### PR TITLE
fix(ui): escape ClassName/process name in list-windows to prevent Spectre markup errors

### DIFF
--- a/src/winapp-CLI/WinApp.Cli/Commands/UiListWindowsCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/UiListWindowsCommand.cs
@@ -120,12 +120,14 @@ internal class UiListWindowsCommand : Command, IShortDescription
                 var fgHwnd = (nint)Windows.Win32.PInvoke.GetForegroundWindow();
                 foreach (var w in windows)
                 {
-                    var procName = GetProcessNameSafe(w.Pid);
+                    var procName = Markup.Escape(GetProcessNameSafe(w.Pid));
                     var title = string.IsNullOrEmpty(w.Title) ? "(no title)" : Markup.Escape(w.Title);
                     var info = UiSessionService.GetWindowInfo(w.Hwnd);
+                    var label = Markup.Escape(info.Label);
+                    var className = Markup.Escape(info.ClassName);
                     var fg = w.Hwnd == fgHwnd ? ", [green]foreground[/]" : "";
                     var owner = info.OwnerHwnd != 0 ? $", owner: HWND {info.OwnerHwnd}" : "";
-                    ansiConsole.MarkupLine($"  HWND [cyan]{w.Hwnd}[/]: \"{title}\" [grey]({info.Label}, {info.Width}x{info.Height}{fg}{owner}) [[{info.ClassName}]] ({procName}, PID {w.Pid})[/]");
+                    ansiConsole.MarkupLine($"  HWND [cyan]{w.Hwnd}[/]: \"{title}\" [grey]({label}, {info.Width}x{info.Height}{fg}{owner}) [[{className}]] ({procName}, PID {w.Pid})[/]");
                 }
 
                 logger.LogInformation("Found {Count} windows", windows.Count);


### PR DESCRIPTION
Fixes #469

## Root cause

`winapp ui list-windows` prints each window via Spectre.Console `MarkupLine`. The format string interpolates `info.ClassName` (and `procName`, `info.Label`) without escaping. `info.ClassName` is wrapped in `[[ ]]` which only escapes the *outer* brackets — any brackets inside the value pass through as raw markup.

When `GetClassName` returns a name containing brackets (e.g. CLR/DCOM-hosted windows that report `[DefaultDomain;;<guid>]`), Spectre parses `[DefaultDomain;;<guid>]` as a style/color tag and throws:

> Could not find color or style 'DefaultDomain;;5b431c9f-d55d-446d-9ed0-c94aee3d2cab'.

Because the throw happens on the *next* iteration after a long string of successful prints, the user sees all windows listed followed by a stray error — exactly what the screenshot shows.

This isn't always reproducible: it only fires when at least one currently-open window has a bracketed class name, which depends on what's running on the box.

## Fix

`Markup.Escape` `ClassName`, `Label`, and the process name before interpolation. Title was already escaped.

## Verification

- `dotnet build` clean
- `winapp ui list-windows` runs cleanly on my box (exit 0, no error trailer)
