### PR TITLE
Fix #472: don't expand to other windows when --window is explicit

### DIFF
--- a/src/winapp-CLI/WinApp.Cli.Tests/UiSessionServiceTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/UiSessionServiceTests.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.Logging.Abstractions;
+using WinApp.Cli.Models;
+using WinApp.Cli.Services;
+
+namespace WinApp.Cli.Tests;
+
+[TestClass]
+public class UiSessionServiceTests
+{
+    [DllImport("kernel32.dll")]
+    private static extern nint GetConsoleWindow();
+
+    [TestMethod]
+    public void UiSessionInfo_IsExplicitWindow_DefaultsToFalse()
+    {
+        var info = new UiSessionInfo();
+        Assert.IsFalse(info.IsExplicitWindow);
+    }
+
+    [TestMethod]
+    public async Task ResolveSessionAsync_ByHwnd_SetsIsExplicitWindowTrue()
+    {
+        var consoleHwnd = GetConsoleWindow();
+        if (consoleHwnd == 0)
+        {
+            Assert.Inconclusive("No console window available — cannot exercise --window resolution.");
+        }
+
+        var service = CreateService();
+
+        var session = await service.ResolveSessionAsync(app: null, hwnd: consoleHwnd, CancellationToken.None);
+
+        Assert.IsTrue(session.IsExplicitWindow,
+            "Sessions resolved via --window must be marked explicit so inspect/search/find don't expand to other windows (#472).");
+        Assert.AreEqual((long)consoleHwnd, session.WindowHandle);
+    }
+
+    [TestMethod]
+    public async Task ResolveSessionAsync_ByPid_LeavesIsExplicitWindowFalse()
+    {
+        var service = CreateService();
+        var currentProcess = System.Diagnostics.Process.GetCurrentProcess();
+
+        var session = await service.ResolveSessionAsync(
+            app: currentProcess.Id.ToString(),
+            hwnd: null,
+            CancellationToken.None);
+
+        Assert.IsFalse(session.IsExplicitWindow,
+            "Only --window should mark a session as explicit; --app/PID resolution must leave it false.");
+        Assert.AreEqual(currentProcess.Id, session.ProcessId);
+    }
+
+    private static UiSessionService CreateService()
+        => new(new StubUiAutomation(), NullLogger<UiSessionService>.Instance);
+
+    /// <summary>
+    /// Minimal IUiAutomationService stub: returns no windows so the resolver doesn't try to
+    /// auto-select on top of the underlying process lookup.
+    /// </summary>
+    private sealed class StubUiAutomation : IUiAutomationService
+    {
+        public List<(nint Hwnd, int Pid, string Title)> FindWindowsByTitle(string titleQuery) => [];
+        public List<(nint Hwnd, int Pid, string Title)> FindWindowsByPid(int pid) => [];
+
+        public Task<UiElement[]> InspectAsync(UiSessionInfo session, string? elementId, int depth, CancellationToken ct) => Task.FromResult<UiElement[]>([]);
+        public Task<UiElement[]> InspectAncestorsAsync(UiSessionInfo session, string elementId, CancellationToken ct) => Task.FromResult<UiElement[]>([]);
+        public Task<UiElement[]> SearchAsync(UiSessionInfo session, SelectorExpression selector, int maxResults, CancellationToken ct) => Task.FromResult<UiElement[]>([]);
+        public Task<UiElement?> FindSingleElementAsync(UiSessionInfo session, SelectorExpression selector, CancellationToken ct) => Task.FromResult<UiElement?>(null);
+        public Task<Dictionary<string, object?>> GetPropertiesAsync(UiSessionInfo session, UiElement element, string? propertyName, CancellationToken ct) => Task.FromResult(new Dictionary<string, object?>());
+        public Task<(byte[] Pixels, int Width, int Height)> ScreenshotAsync(UiSessionInfo session, string? elementId, bool captureScreen, CancellationToken ct) => Task.FromResult((Array.Empty<byte>(), 0, 0));
+        public Task<string> InvokeAsync(UiSessionInfo session, UiElement element, CancellationToken ct) => Task.FromResult("");
+        public Task SetValueAsync(UiSessionInfo session, UiElement element, string text, CancellationToken ct) => Task.CompletedTask;
+        public Task FocusAsync(UiSessionInfo session, UiElement element, CancellationToken ct) => Task.CompletedTask;
+        public Task ScrollIntoViewAsync(UiSessionInfo session, UiElement element, CancellationToken ct) => Task.CompletedTask;
+        public Task ScrollContainerAsync(UiSessionInfo session, UiElement element, string? direction, string? to, CancellationToken ct) => Task.CompletedTask;
+        public Task<UiElement?> GetFocusedElementAsync(UiSessionInfo session, CancellationToken ct) => Task.FromResult<UiElement?>(null);
+        public Task<string?> GetTextAsync(UiSessionInfo session, UiElement element, CancellationToken ct) => Task.FromResult<string?>(null);
+    }
+}
+

--- a/src/winapp-CLI/WinApp.Cli/Models/UiSessionInfo.cs
+++ b/src/winapp-CLI/WinApp.Cli/Models/UiSessionInfo.cs
@@ -14,4 +14,11 @@ internal sealed class UiSessionInfo
     public string? WindowTitle { get; set; }
     /// <summary>Specific window handle when process has multiple windows.</summary>
     public long WindowHandle { get; set; }
+
+    /// <summary>
+    /// True when the user explicitly targeted this window via <c>--window/-w</c>. When set,
+    /// inspect/search/find operations must not silently expand to other top-level windows owned
+    /// by the same process. See issue #472.
+    /// </summary>
+    public bool IsExplicitWindow { get; set; }
 }

--- a/src/winapp-CLI/WinApp.Cli/Services/UiAutomationService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/UiAutomationService.cs
@@ -132,8 +132,9 @@ internal sealed partial class UiAutomationService : IUiAutomationService
             el.WindowHandle = session.WindowHandle;
         }
 
-        // Also walk popup/owned windows (when inspecting full tree, not scoped to element)
-        if (string.IsNullOrEmpty(elementId))
+        // Also walk popup/owned windows (when inspecting full tree, not scoped to element,
+        // and the user did not explicitly target a single HWND — see issue #472).
+        if (string.IsNullOrEmpty(elementId) && !session.IsExplicitWindow)
         {
             var mainHwnd = (nint)session.WindowHandle;
             var allWindows = GetAllAppWindows(session);
@@ -388,8 +389,9 @@ internal sealed partial class UiAutomationService : IUiAutomationService
             }
         }
 
-        // If no results on main window, search popup/owned windows
-        if (mainResults.Count == 0)
+        // If no results on main window, search popup/owned windows — unless the user
+        // explicitly scoped the session to a single HWND via --window (issue #472).
+        if (mainResults.Count == 0 && !session.IsExplicitWindow)
         {
             var allWindows = GetAllAppWindows(session);
             var mainHwnd = (nint)session.WindowHandle;
@@ -467,11 +469,14 @@ internal sealed partial class UiAutomationService : IUiAutomationService
                 slugResult.WindowHandle = session.WindowHandle;
                 return Task.FromResult<UiElement?>(slugResult);
             }
-            // Not found on main window — search other windows
-            var otherResult = FindElementOnOtherWindows(session, selector);
-            if (otherResult is not null)
+            // Not found on main window — search other windows (unless --window scoped us to one)
+            if (!session.IsExplicitWindow)
             {
-                return Task.FromResult<UiElement?>(otherResult);
+                var otherResult = FindElementOnOtherWindows(session, selector);
+                if (otherResult is not null)
+                {
+                    return Task.FromResult<UiElement?>(otherResult);
+                }
             }
             return Task.FromResult<UiElement?>(null);
         }
@@ -525,10 +530,14 @@ return Task.FromResult<UiElement?>(null);
             }
 
             // Element not found on main window — search popup/owned windows
-            var otherResult = FindElementOnOtherWindows(session, selector);
-            if (otherResult is not null)
+            // (unless --window scoped us to a single HWND).
+            if (!session.IsExplicitWindow)
             {
-                return Task.FromResult<UiElement?>(otherResult);
+                var otherResult = FindElementOnOtherWindows(session, selector);
+                if (otherResult is not null)
+                {
+                    return Task.FromResult<UiElement?>(otherResult);
+                }
             }
             return Task.FromResult<UiElement?>(null);
         }

--- a/src/winapp-CLI/WinApp.Cli/Services/UiSessionService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/UiSessionService.cs
@@ -191,6 +191,7 @@ internal sealed class UiSessionService(
         }
 
         var session = CreateSession((int)pid, (nint)hwnd, null);
+        session.IsExplicitWindow = true;
         RefreshWindowTitle(session);
         return session;
     }


### PR DESCRIPTION
Fixes #472.

## Problem

`winapp ui inspect --window <HWND>` (and `ui search` / `ui find`) returned elements from **other** top-level windows of the same process, not just the explicitly targeted HWND.

Root cause: `UiAutomationService` calls `GetAllAppWindows(session)` / `FindElementOnOtherWindows` whenever the user didn't pass a selector, gated only on `string.IsNullOrEmpty(elementId)`. `WindowHandle` alone can't distinguish an explicit `--window` from an auto-selected one — it's set in both cases — so explicit `--window` callers got the same fan-out as `--app`-only callers.

## Fix

- Add `UiSessionInfo.IsExplicitWindow` (default `false`).
- Set it to `true` only in `UiSessionService.ResolveByHwnd` (the `--window` path). All other resolution paths leave it `false`.
- Gate the three popup/other-window expansion sites in `UiAutomationService` on `!session.IsExplicitWindow`:
  - `InspectAsync` — popup expansion via `GetAllAppWindows`
  - `SearchAsync` — popup fallback when no main results
  - `FindSingleElementAsync` — both `FindElementOnOtherWindows` calls

## Tests

New `UiSessionServiceTests` (3 tests, no new dependencies — inline `IUiAutomationService` stub + `NullLogger`):
- `UiSessionInfo.IsExplicitWindow` defaults to `false`
- `ResolveSessionAsync` by HWND sets the flag `true`
- `ResolveSessionAsync` by PID leaves it `false`

Full suite: 767/767 passing. `scripts/build-cli.ps1` clean (schema/skills regenerated, no diff in those files).
