### PR TITLE
docs: make execution alias step explicit for console apps in .NET and Rust guides

### DIFF
--- a/docs/guides/dotnet.md
+++ b/docs/guides/dotnet.md
@@ -126,7 +126,7 @@ To fix this, you'll add an execution alias to the manifest and tell the run inte
    winapp manifest add-alias
    ```
 
-   This adds a `uap5:ExecutionAlias` to `appxmanifest.xml` (defaulting to your project's exe name) so the app can be launched by name from a terminal.
+   This adds a `uap5:ExecutionAlias` to `Package.appxmanifest` (defaulting to your project's exe name) so the app can be launched by name from a terminal.
 
 2. Tell the `dotnet run` integration to use the alias. Open `dotnet-app.csproj` and add the following inside any `<PropertyGroup>` (or create a new `<PropertyGroup>` if needed):
 

--- a/docs/guides/dotnet.md
+++ b/docs/guides/dotnet.md
@@ -128,7 +128,7 @@ To fix this, you'll add an execution alias to the manifest and tell the run inte
 
    This adds a `uap5:ExecutionAlias` to `appxmanifest.xml` (defaulting to your project's exe name) so the app can be launched by name from a terminal.
 
-2. Tell the `dotnet run` integration to use the alias. Open `dotnet-app.csproj` and add the following inside the existing `<PropertyGroup>`:
+2. Tell the `dotnet run` integration to use the alias. Open `dotnet-app.csproj` and add the following inside any `<PropertyGroup>` (or create a new `<PropertyGroup>` if needed):
 
    ```xml
    <WinAppRunUseExecutionAlias>true</WinAppRunUseExecutionAlias>

--- a/docs/guides/dotnet.md
+++ b/docs/guides/dotnet.md
@@ -112,6 +112,30 @@ dotnet list package
 
 You should see `Microsoft.WindowsAppSDK` and `Microsoft.Windows.SDK.BuildTools` in the output.
 
+### Add Execution Alias (for console apps)
+
+Because we're building a console app, we need to make sure `dotnet run` keeps console output in the current terminal. By default, `dotnet run` launches the packaged app via AUMID activation, which opens a new window — and the window closes immediately when the console app finishes, swallowing any output.
+
+To fix this, you'll add an execution alias to the manifest and tell the run integration to launch via that alias instead.
+
+> **Skip this step if you're building a UI app** (WPF, WinForms, WinUI). Those apps render their own window, so the default AUMID launch is what you want.
+
+1. Add the execution alias to your manifest:
+
+   ```powershell
+   winapp manifest add-alias
+   ```
+
+   This adds a `uap5:ExecutionAlias` to `appxmanifest.xml` (defaulting to your project's exe name) so the app can be launched by name from a terminal.
+
+2. Tell the `dotnet run` integration to use the alias. Open `dotnet-app.csproj` and add the following inside the existing `<PropertyGroup>`:
+
+   ```xml
+   <WinAppRunUseExecutionAlias>true</WinAppRunUseExecutionAlias>
+   ```
+
+   With this property set, `dotnet run` launches the app via its execution alias and inherits the current terminal's stdin/stdout/stderr so you see console output inline.
+
 ## 5. Debug with Identity
 
 Since `winapp init` added the `Microsoft.Windows.SDK.BuildTools.WinApp` NuGet package to your project, you can simply run:
@@ -123,8 +147,6 @@ dotnet run
 This automatically invokes `winapp run` under the hood — creating a loose layout package, registering it with Windows, and launching your app with full package identity.
 
 > **Note**: You may see NuGet vulnerability warnings (NU1900) about package sources. These are safe to ignore — they don't affect your build.
-
-> **Console apps:** By default, AUMID activation opens a new window. For console applications that need stdin/stdout in the current terminal, add `<WinAppRunUseExecutionAlias>true</WinAppRunUseExecutionAlias>` to your `.csproj` and ensure your manifest has a `uap5:ExecutionAlias`. You can add one with `winapp manifest add-alias`.
 
 You should see output similar to:
 ```
@@ -254,37 +276,16 @@ dotnet build -c Release
 > **Note**: You may see NuGet vulnerability warnings (NU1900). These are safe to ignore and don't affect your build output.
 
 ### Add Execution Alias (for console apps)
-To allow users to run your app from the command line after installation (like `dotnet-app`), add an execution alias to the `appxmanifest.xml`. If you are building a WPF or WinForms app, this step is not necessary — those apps launch from the Start menu instead.
 
-Open `appxmanifest.xml` and add the `uap5` namespace to the `<Package>` tag if it's missing, and then add the extension inside `<Applications><Application><Extensions>...`:
+If you followed step 4 above, you already added an execution alias to your manifest with `winapp manifest add-alias`, and you can skip this section.
 
-```xml
-<Package
-  ...
-  xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
-  xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5"
-  IgnorableNamespaces="uap uap2 uap3 rescap desktop desktop6 uap10">
+If you're packaging a console app and didn't add it earlier, add it now so users can run your app by name from any terminal after installing the MSIX:
 
-  ...
-  <Applications>
-    <Application ...>
-      ...
-
-      <!-- Add this Extensions element in your manifest 
-           along with the xmlns:uap5 namespace above -->
-      <Extensions>
-        <uap5:Extension Category="windows.appExecutionAlias">
-          <uap5:AppExecutionAlias>
-            <uap5:ExecutionAlias Alias="dotnet-app.exe" />
-          </uap5:AppExecutionAlias>
-        </uap5:Extension>
-      </Extensions>
-
-      ...
-    </Application>
-  </Applications>
-</Package>
+```powershell
+winapp manifest add-alias
 ```
+
+> **Skip this step if you're building a UI app** (WPF, WinForms, WinUI). Those apps launch from the Start menu instead.
 
 ### Generate a Development Certificate
 

--- a/docs/guides/rust.md
+++ b/docs/guides/rust.md
@@ -120,7 +120,7 @@ Add the alias:
 winapp manifest add-alias
 ```
 
-This adds a `uap5:ExecutionAlias` entry to `appxmanifest.xml`.
+This adds a `uap5:ExecutionAlias` entry to `Package.appxmanifest`.
 
 ## 5. Debug with Identity
 

--- a/docs/guides/rust.md
+++ b/docs/guides/rust.md
@@ -105,38 +105,20 @@ This command will:
 You can open `appxmanifest.xml` to further customize properties like the display name, publisher, and capabilities.
 
 ### Add Execution Alias (for console apps)
-An execution alias lets users run your app by name from any terminal (like `rust-app`). It also enables `winapp run --with-alias` during development, which keeps console output in the current terminal instead of opening a new window.
 
-You can add one automatically:
+Because `cargo new` creates a console app, we need to add an execution alias to the manifest. Without it, `winapp run` launches the app via AUMID activation, which opens a new window — and that window closes immediately when a console app finishes, swallowing any output.
+
+The alias also lets users run your app by name from any terminal (like `rust-app`) after they install the MSIX.
+
+> **Skip this step if you're building a UI app** (a Rust app that renders its own window). Those apps work fine with the default AUMID launch.
+
+Add the alias:
 
 ```powershell
 winapp manifest add-alias
 ```
 
-Or manually: open `appxmanifest.xml` and add the `uap5` namespace to the `<Package>` tag if it's missing, and then add the extension inside `<Applications><Application><Extensions>...`:
-
-```diff
-<Package
-  ...
-  xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
-+ xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5"
-  IgnorableNamespaces="uap uap2 uap3 rescap desktop desktop6 uap10">
-
-  ...
-  <Applications>
-    <Application ...>
-      ...
-+     <Extensions>
-+       <uap5:Extension Category="windows.appExecutionAlias">
-+         <uap5:AppExecutionAlias>
-+           <uap5:ExecutionAlias Alias="rust-app.exe" />
-+         </uap5:AppExecutionAlias>
-+       </uap5:Extension>
-+     </Extensions>
-    </Application>
-  </Applications>
-</Package>
-```
+This adds a `uap5:ExecutionAlias` to `appxmanifest.xml` (defaulting to your project's exe name).
 
 ## 5. Debug with Identity
 

--- a/docs/guides/rust.md
+++ b/docs/guides/rust.md
@@ -108,7 +108,7 @@ You can open `appxmanifest.xml` to further customize properties like the display
 
 Because `cargo new` creates a console app, we need to add an execution alias to the manifest. Without it, `winapp run` launches the app via AUMID activation, which opens a new window — and that window closes immediately when a console app finishes, swallowing any output.
 
-The alias also lets users run your app by name from any terminal (like `rust-app`) after they install the MSIX.
+The alias also lets users run your app by name from any terminal after they install the MSIX. The manifest registers an alias like `rust-app.exe` (defaulting to your project's exe name), which users can invoke as `rust-app` or `rust-app.exe`.
 
 > **Skip this step if you're building a UI app** (a Rust app that renders its own window). Those apps work fine with the default AUMID launch.
 
@@ -118,7 +118,7 @@ Add the alias:
 winapp manifest add-alias
 ```
 
-This adds a `uap5:ExecutionAlias` to `appxmanifest.xml` (defaulting to your project's exe name).
+This adds a `uap5:ExecutionAlias` entry to `appxmanifest.xml`.
 
 ## 5. Debug with Identity
 


### PR DESCRIPTION
Fixes #470

## Problem

Both the .NET and Rust guides build console apps by default (`dotnet new console` / `cargo new`), but the execution-alias step was framed as an optional side-note. Users skip it and then `dotnet run` (or `winapp run --with-alias`) launches the packaged app via AUMID activation — opening a new window that closes immediately when a console app finishes, swallowing all stdout.

The repro in the issue was just ""follow the .NET guide"" — exactly what happens when the alias step is easy to miss.

## Changes

### `docs/guides/dotnet.md`
- Promote alias setup to its own subsection in step 4 (after `winapp init`), covering **both** `winapp manifest add-alias` **and** adding `<WinAppRunUseExecutionAlias>true</WinAppRunUseExecutionAlias>` to the `.csproj`.
- Remove the buried ""Console apps:"" blockquote from step 5 (now redundant — handled before users hit `dotnet run`).
- Slim step 7's duplicate alias section to a one-liner pointing back to step 4 (with a fallback `winapp manifest add-alias` for users who skipped it). Removed the long manual XML snippet.

### `docs/guides/rust.md`
- Reframe the existing alias section in step 4 to clearly state it's **required for console apps** (which is the `cargo new` default), with explicit ""skip if UI app"" guidance.
- Remove the long manual XML alternative — `winapp manifest add-alias` does the same thing in one command.

The actual CLI/MSBuild support (`--with-alias`, `WinAppRunUseExecutionAlias`, `winapp manifest add-alias`) already works correctly. This is purely a guide/framing fix.

## Verification

- Re-read both guide flows end-to-end after the edits.
- Confirmed `winapp manifest add-alias` and the `WinAppRunUseExecutionAlias` MSBuild property still match the live CLI / NuGet targets (`dotnet-run-support.md`, `ManifestAddAliasCommand.cs`, sample `samples/dotnet-app/dotnet-app.csproj`).
