### PR TITLE
fix(restore): no-op gracefully when winapp.yaml is missing on non-.NET projects

### DIFF
--- a/.github/plugin/skills/winapp-cli/setup/SKILL.md
+++ b/.github/plugin/skills/winapp-cli/setup/SKILL.md
@@ -155,7 +155,7 @@ For full debugging scenarios and IDE setup, see the [Debugging Guide](https://gi
 
 ### `winapp init`
 
-Start here for initializing a Windows app with required setup. Sets up everything needed for Windows app development: creates Package.appxmanifest with default assets, creates winapp.yaml for version management, and downloads Windows SDK and Windows App SDK packages and generates projections. Interactive by default (use --use-defaults to skip prompts). Use 'restore' instead if you cloned a repo that already has winapp.yaml. Use 'manifest generate' if you only need a manifest, or 'cert generate' if you need a development certificate for code signing.
+Start here for initializing a Windows app with required setup. Sets up everything needed for Windows app development: creates Package.appxmanifest with default assets, downloads Windows SDK and Windows App SDK packages, and generates projections. When SDK packages are managed (--setup-sdks stable/preview/experimental), also creates winapp.yaml to pin versions for 'restore'/'update'; with --setup-sdks none (e.g., for Rust/Tauri projects that bring their own SDK bindings), no winapp.yaml is created. Interactive by default (use --use-defaults to skip prompts). Use 'restore' instead if you cloned a repo that already has winapp.yaml. Use 'manifest generate' if you only need a manifest, or 'cert generate' if you need a development certificate for code signing.
 
 #### Arguments
 <!-- auto-generated from cli-schema.json -->

--- a/docs/cli-schema.json
+++ b/docs/cli-schema.json
@@ -626,7 +626,7 @@
       }
     },
     "init": {
-      "description": "Start here for initializing a Windows app with required setup. Sets up everything needed for Windows app development: creates Package.appxmanifest with default assets, creates winapp.yaml for version management, and downloads Windows SDK and Windows App SDK packages and generates projections. Interactive by default (use --use-defaults to skip prompts). Use 'restore' instead if you cloned a repo that already has winapp.yaml. Use 'manifest generate' if you only need a manifest, or 'cert generate' if you need a development certificate for code signing.",
+      "description": "Start here for initializing a Windows app with required setup. Sets up everything needed for Windows app development: creates Package.appxmanifest with default assets, downloads Windows SDK and Windows App SDK packages, and generates projections. When SDK packages are managed (--setup-sdks stable/preview/experimental), also creates winapp.yaml to pin versions for 'restore'/'update'; with --setup-sdks none (e.g., for Rust/Tauri projects that bring their own SDK bindings), no winapp.yaml is created. Interactive by default (use --use-defaults to skip prompts). Use 'restore' instead if you cloned a repo that already has winapp.yaml. Use 'manifest generate' if you only need a manifest, or 'cert generate' if you need a development certificate for code signing.",
       "hidden": false,
       "arguments": {
         "base-directory": {

--- a/docs/guides/rust.md
+++ b/docs/guides/rust.md
@@ -102,6 +102,8 @@ This command will:
 - Create `appxmanifest.xml` — the manifest that defines your app's identity
 - Create `Assets` folder — icons required for MSIX packaging and Store submission
 
+> **Note:** Because no SDK packages are being managed, no `winapp.yaml` is created — Rust uses the `windows` crate via Cargo, so there's nothing for `winapp restore`/`update` to track.
+
 You can open `appxmanifest.xml` to further customize properties like the display name, publisher, and capabilities.
 
 ### Add Execution Alias (for console apps)

--- a/docs/guides/tauri.md
+++ b/docs/guides/tauri.md
@@ -157,6 +157,8 @@ This command will:
 - Create `appxmanifest.xml` — the manifest that defines your app's identity
 - Create `Assets` folder — icons required for MSIX packaging and Store submission
 
+> **Note:** Because no SDK packages are being managed, no `winapp.yaml` is created — Tauri uses Rust's `windows` crate via Cargo, so there's nothing for `winapp restore`/`update` to track.
+
 You can open `appxmanifest.xml` to further customize properties like the display name, publisher, and capabilities.
 
 ## 4. Debug with Identity

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -35,7 +35,7 @@ winapp init [base-directory] [options]
 
 **What it does:**
 
-- Creates `winapp.yaml` configuration file
+- Creates `winapp.yaml` configuration file (only when SDK packages are managed; skipped with `--setup-sdks none`)
 - Downloads Windows SDK and Windows App SDK packages
 - Generates C++/WinRT headers and binaries
 - Creates AppxManifest.xml

--- a/src/winapp-CLI/WinApp.Cli.Tests/WorkspaceSetupServiceTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/WorkspaceSetupServiceTests.cs
@@ -168,7 +168,7 @@ public class WorkspaceSetupServiceTests : BaseCommandTests
     }
 
     [TestMethod]
-    public async Task SetupWorkspace_WithRequireExistingConfig_FailsWhenConfigMissing()
+    public async Task SetupWorkspace_WithRequireExistingConfig_NoOpsWhenConfigMissing()
     {
         // Arrange - Don't create any config file
         var workspaceSetupService = GetRequiredService<IWorkspaceSetupService>();
@@ -176,7 +176,7 @@ public class WorkspaceSetupServiceTests : BaseCommandTests
         {
             BaseDirectory = _tempDirectory,
             ConfigDir = _tempDirectory,
-            RequireExistingConfig = true, // This should fail when config doesn't exist
+            RequireExistingConfig = true, // Restore-style call
             UseDefaults = true,
             NoGitignore = true
         };
@@ -185,7 +185,11 @@ public class WorkspaceSetupServiceTests : BaseCommandTests
         var exitCode = await workspaceSetupService.SetupWorkspaceAsync(options, TestContext.CancellationToken);
 
         // Assert
-        Assert.AreEqual(1, exitCode, "Setup should fail when config is required but missing");
+        // Restore on a non-.NET project with no winapp.yaml is a graceful no-op:
+        // a project that doesn't declare SDK package versions has nothing to restore.
+        // (.NET projects without yaml are still rejected — handled separately by the
+        // csproj-detection branch in SetupWorkspaceAsync.)
+        Assert.AreEqual(0, exitCode, "Restore should be a no-op (exit 0) when no winapp.yaml exists on a non-.NET project");
     }
 }
 

--- a/src/winapp-CLI/WinApp.Cli/Commands/InitCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/InitCommand.cs
@@ -55,7 +55,7 @@ internal class InitCommand : Command, IShortDescription
         };
     }
 
-    public InitCommand() : base("init", "Start here for initializing a Windows app with required setup. Sets up everything needed for Windows app development: creates Package.appxmanifest with default assets, creates winapp.yaml for version management, and downloads Windows SDK and Windows App SDK packages and generates projections. Interactive by default (use --use-defaults to skip prompts). Use 'restore' instead if you cloned a repo that already has winapp.yaml. Use 'manifest generate' if you only need a manifest, or 'cert generate' if you need a development certificate for code signing.")
+    public InitCommand() : base("init", "Start here for initializing a Windows app with required setup. Sets up everything needed for Windows app development: creates Package.appxmanifest with default assets, downloads Windows SDK and Windows App SDK packages, and generates projections. When SDK packages are managed (--setup-sdks stable/preview/experimental), also creates winapp.yaml to pin versions for 'restore'/'update'; with --setup-sdks none (e.g., for Rust/Tauri projects that bring their own SDK bindings), no winapp.yaml is created. Interactive by default (use --use-defaults to skip prompts). Use 'restore' instead if you cloned a repo that already has winapp.yaml. Use 'manifest generate' if you only need a manifest, or 'cert generate' if you need a development certificate for code signing.")
     {
         Arguments.Add(BaseDirectoryArgument);
         Options.Add(ConfigDirOption);

--- a/src/winapp-CLI/WinApp.Cli/Services/WorkspaceSetupService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/WorkspaceSetupService.cs
@@ -813,9 +813,13 @@ internal class WorkspaceSetupService(
         // Step 1: Handle configuration requirements
         if (options.RequireExistingConfig && !configService.Exists())
         {
-            logger.LogInformation("winapp.yaml not found in {ConfigDir}", options.ConfigDir);
-            logger.LogInformation("Run 'winapp init' to initialize a new workspace or navigate to a directory with winapp.yaml");
-            return (1, config, hadExistingConfig, shouldGenerateManifest, manifestGenerationInfo, shouldEnableDeveloperMode, recommendedTfm);
+            // Non-.NET project with no winapp.yaml — nothing to restore.
+            // (.NET projects without yaml are handled earlier in SetupWorkspaceAsync.)
+            // This is a no-op rather than an error: a project that doesn't declare
+            // SDK package versions in winapp.yaml has nothing for restore to do.
+            logger.LogInformation("{UISymbol} No winapp.yaml found in {ConfigDir}. Nothing to restore.", UiSymbols.Note, options.ConfigDir);
+            logger.LogInformation("If this project needs Windows SDK packages, run 'winapp init' to set them up.");
+            return (0, config, hadExistingConfig, shouldGenerateManifest, manifestGenerationInfo, shouldEnableDeveloperMode, recommendedTfm);
         }
 
         // Step 2: Load or prepare configuration


### PR DESCRIPTION
Fixes #474

## What was broken

Running `winapp restore` on a project with no `winapp.yaml` exited 1 with ""winapp.yaml not found"". This bit Rust / Tauri users especially hard: the Rust guide tells them to pick ""Do not setup SDKs"" during init (because Rust uses the `windows` crate, not C++ headers), which leaves the project without a yaml — so any later `winapp restore` failed.

## Path not taken (and why)

The first attempt was to make `winapp init --setup-sdks none` write an empty `winapp.yaml`. Rejected: an empty file invites the user to delete it (""this is empty, why is it here?""), putting us right back in the broken state. The fragile contract is the file's existence; better to fix the consumer.

## Fix

Treat `restore` as idempotent. A non-.NET project with no winapp.yaml has nothing to restore — print an informational message and exit 0. This mirrors the existing behavior of `update`, which already no-ops in this scenario (`UpdateCommand.cs:117-120`).

Before:
```
> winapp restore
winapp.yaml not found in <dir>
Run 'winapp init' to initialize a new workspace or navigate to a directory with winapp.yaml
[exit 1]
```

After:
```
> winapp restore
📝 No winapp.yaml found in <dir>. Nothing to restore.
If this project needs Windows SDK packages, run 'winapp init' to set them up.
✅ Restore completed successfully
[exit 0]
```

The .NET-project-without-yaml case is unaffected: still rejected with the existing dedicated message in `SetupWorkspaceAsync` (line 70-75) telling the user to run `dotnet restore`.

## Tests

- Updated `SetupWorkspace_WithRequireExistingConfig_FailsWhenConfigMissing` → `...NoOpsWhenConfigMissing` to match the new contract.
- Full test suite passes (764/764).

## Manual verification

End-to-end Rust scenario from the guide:
- `cargo new` → `winapp init --setup-sdks none` → `winapp manifest add-alias` → `cargo build` → `winapp run --with-alias` → `winapp pack` — all succeed.
- `winapp restore` on a fresh project (no yaml): exit 0, friendly message.
- `winapp restore` on a project with a populated yaml: still installs packages normally.
