### PR TITLE
Fix #463 and #464: surface progress and stop lying about why init skipped SDK setup

### DIFF
--- a/docs/npm-usage.md
+++ b/docs/npm-usage.md
@@ -124,7 +124,7 @@ function certInstall(options: CertInstallOptions): Promise<WinappResult>
 
 ### `createDebugIdentity()`
 
-Enable package identity for debugging without creating full MSIX. Required for testing Windows APIs (push notifications, share target, etc.) during development. Example: winapp create-debug-identity ./myapp.exe. Requires Package.appxmanifest in current directory or passed via --manifest. Re-run after changing the manifest or Assets/.
+Enable package identity for debugging without creating full MSIX. Required for testing Windows APIs (push notifications, share target, etc.) during development. Example: winapp create-debug-identity ./myapp.exe. Requires Package.appxmanifest or appxmanifest.xml in current directory or passed via --manifest. Re-run after changing the manifest or Assets/.
 
 ```typescript
 function createDebugIdentity(options?: CreateDebugIdentityOptions): Promise<WinappResult>

--- a/src/winapp-CLI/WinApp.Cli.Tests/DotNetServiceTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/DotNetServiceTests.cs
@@ -1012,7 +1012,53 @@ public class DotNetServiceTests : BaseCommandTests
             new FileInfo("dummy.csproj"), "Microsoft.WindowsAppSDK", TestContext.CancellationToken);
 
         // Assert
-        Assert.IsFalse(result, "Should return false when package is only a transitive dependency");
+        Assert.IsFalse(result, "Should return false when package is only a transitive dependency");    }
+
+    [TestMethod]
+    public async Task HasPackageReferenceAsync_FastPath_DetectsInlinePackageReference_WithoutDotnetRestore()
+    {
+        // Arrange — write an SDK-style csproj with an inline PackageReference. Use a non-existent
+        // SDK so a `dotnet list package` fallback would fail; success here proves the XML fast path
+        // returned true without invoking dotnet (#463).
+        var csprojPath = Path.Combine(_testTempDirectory, "Inline.csproj");
+        await File.WriteAllTextAsync(csprojPath, """
+<Project Sdk="DefinitelyNotARealSdk/0.0.0">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.0" />
+  </ItemGroup>
+</Project>
+""", TestContext.CancellationToken);
+
+        // Act
+        var result = await _dotNetService.HasPackageReferenceAsync(
+            new FileInfo(csprojPath), "Microsoft.WindowsAppSDK", TestContext.CancellationToken);
+
+        // Assert
+        Assert.IsTrue(result, "XML fast path should detect inline <PackageReference Include=\"Microsoft.WindowsAppSDK\"/>.");
+    }
+
+    [TestMethod]
+    public async Task HasPackageReferenceAsync_FastPath_CaseInsensitiveOnIncludeAttribute()
+    {
+        // Arrange
+        var csprojPath = Path.Combine(_testTempDirectory, "Cased.csproj");
+        await File.WriteAllTextAsync(csprojPath, """
+<Project Sdk="DefinitelyNotARealSdk/0.0.0">
+  <ItemGroup>
+    <PackageReference Include="microsoft.windowsappsdk" Version="1.6.0" />
+  </ItemGroup>
+</Project>
+""", TestContext.CancellationToken);
+
+        // Act
+        var result = await _dotNetService.HasPackageReferenceAsync(
+            new FileInfo(csprojPath), "Microsoft.WindowsAppSDK", TestContext.CancellationToken);
+
+        // Assert
+        Assert.IsTrue(result, "XML fast path should be case-insensitive on the Include attribute.");
     }
 
     #endregion

--- a/src/winapp-CLI/WinApp.Cli/Services/DotNetService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/DotNetService.cs
@@ -464,6 +464,14 @@ internal partial class DotNetService : IDotNetService
         {
             return false;
         }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+        catch (System.Security.SecurityException)
+        {
+            return false;
+        }
     }
 
     /// <inheritdoc />

--- a/src/winapp-CLI/WinApp.Cli/Services/DotNetService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/DotNetService.cs
@@ -418,6 +418,16 @@ internal partial class DotNetService : IDotNetService
 
     public async Task<bool> HasPackageReferenceAsync(FileInfo csprojPath, string packageName, CancellationToken cancellationToken = default)
     {
+        // Fast path: many .csproj files declare PackageReference inline. A direct XML scan avoids
+        // an implicit `dotnet restore` (which can take 30s+ on a fresh machine — see #463).
+        // We only short-circuit on a positive match; absence still requires the slow path because
+        // the package may come from Directory.Packages.props (CPM), Directory.Build.props, an SDK,
+        // or another import that only MSBuild evaluation can resolve.
+        if (TryFindPackageReferenceInCsproj(csprojPath, packageName))
+        {
+            return true;
+        }
+
         var packageList = await GetPackageListAsync(csprojPath, includeTransitive: false, cancellationToken);
         if (packageList?.Projects is null)
         {
@@ -428,6 +438,32 @@ internal partial class DotNetService : IDotNetService
             .SelectMany(p => p.Frameworks ?? [])
             .SelectMany(f => f.TopLevelPackages ?? [])
             .Any(pkg => string.Equals(pkg.Id, packageName, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static bool TryFindPackageReferenceInCsproj(FileInfo csprojPath, string packageName)
+    {
+        if (!csprojPath.Exists)
+        {
+            return false;
+        }
+
+        try
+        {
+            var doc = System.Xml.Linq.XDocument.Load(csprojPath.FullName);
+            // PackageReference items live in the default (no-prefix) MSBuild namespace; new-style
+            // SDK csproj files have no xmlns, so XName.LocalName is what we want either way.
+            return doc.Descendants()
+                .Where(e => string.Equals(e.Name.LocalName, "PackageReference", StringComparison.Ordinal))
+                .Any(e => string.Equals((string?)e.Attribute("Include"), packageName, StringComparison.OrdinalIgnoreCase));
+        }
+        catch (System.Xml.XmlException)
+        {
+            return false;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
     }
 
     /// <inheritdoc />

--- a/src/winapp-CLI/WinApp.Cli/Services/WorkspaceSetupService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/WorkspaceSetupService.cs
@@ -1011,24 +1011,42 @@ internal class WorkspaceSetupService(
         // For init (not restore), prompt for SDK installation choice if not specified
         if (!options.RequireExistingConfig && !options.ConfigOnly && options.SdkInstallMode == null)
         {
-            // If the .NET project already references WinAppSDK, skip the prompt and default to None
-            if (isDotNetProject && csprojFile != null && await dotNetService.HasPackageReferenceAsync(csprojFile, DotNetService.WINAPP_SDK_NUGET_PACKAGE, cancellationToken))
+            // If the .NET project already references WinAppSDK, skip the prompt and default to None.
+            // This call may take a while on a fresh machine because `dotnet list package` triggers
+            // an implicit restore — surface a spinner so the user knows we're doing something (#463).
+            if (isDotNetProject && csprojFile != null)
             {
-                options.SdkInstallMode = SdkInstallMode.None;
-                logger.LogDebug("{UISymbol} Project already references {PackageName}, skipping SDK setup", UiSymbols.Check, DotNetService.WINAPP_SDK_NUGET_PACKAGE);
-                return;
+                var alreadyReferencesWinAppSdk = await RunWithStatusAsync(
+                    "Detecting project SDK references...",
+                    ct => dotNetService.HasPackageReferenceAsync(csprojFile, DotNetService.WINAPP_SDK_NUGET_PACKAGE, ct),
+                    cancellationToken);
+                if (alreadyReferencesWinAppSdk)
+                {
+                    options.SdkInstallMode = SdkInstallMode.None;
+                    logger.LogInformation("{UISymbol} Project already references {PackageName}; skipping Windows App SDK setup.", UiSymbols.Check, DotNetService.WINAPP_SDK_NUGET_PACKAGE);
+                    return;
+                }
             }
             // Determine which packages to show versions for
             var packages = isDotNetProject
                 ? [BuildToolsService.WINAPP_SDK_PACKAGE]
                 : new[] { BuildToolsService.CPP_SDK_PACKAGE, BuildToolsService.WINAPP_SDK_PACKAGE };
 
-            // Fetch versions for all modes in parallel (failures are non-fatal)
+            // Fetch versions for all modes in parallel (failures are non-fatal). On a fresh machine
+            // these NuGet feed calls can take many seconds; show a spinner so the prompt doesn't
+            // appear to hang (#463).
             var modes = new[] { SdkInstallMode.Stable, SdkInstallMode.Preview, SdkInstallMode.Experimental };
-            var versionTasks = modes
-                .SelectMany(mode => packages.Select(pkg => (Mode: mode, Package: pkg, Task: SafeGetLatestVersionAsync(pkg, mode, cancellationToken))))
-                .ToList();
-            await Task.WhenAll(versionTasks.Select(v => v.Task));
+            var versionTasks = await RunWithStatusAsync(
+                "Fetching latest SDK versions...",
+                async ct =>
+                {
+                    var tasks = modes
+                        .SelectMany(mode => packages.Select(pkg => (Mode: mode, Package: pkg, Task: SafeGetLatestVersionAsync(pkg, mode, ct))))
+                        .ToList();
+                    await Task.WhenAll(tasks.Select(v => v.Task));
+                    return tasks;
+                },
+                cancellationToken);
 
             // Build a lookup: (mode) → version label
             var versionsByMode = modes.ToDictionary(
@@ -1391,6 +1409,32 @@ internal class WorkspaceSetupService(
     {
         var msixDir = new DirectoryInfo(Path.Combine(packagePath.FullName, "tools", "MSIX"));
         return msixDir.Exists ? msixDir : null;
+    }
+
+    /// <summary>
+    /// Runs <paramref name="work"/> while showing a Spectre.Console spinner with <paramref name="message"/>.
+    /// In non-interactive contexts (redirected output, no Information logging), falls back to a single
+    /// log line so the user still sees what's happening (#463).
+    /// </summary>
+    private async Task<T> RunWithStatusAsync<T>(string message, Func<CancellationToken, Task<T>> work, CancellationToken cancellationToken)
+    {
+        if (Environment.UserInteractive
+            && !Console.IsOutputRedirected
+            && logger.IsEnabled(LogLevel.Information)
+            && ansiConsole.Profile.Capabilities.Interactive)
+        {
+            T result = default!;
+            await ansiConsole.Status()
+                .Spinner(Spinner.Known.Dots)
+                .StartAsync(message, async _ =>
+                {
+                    result = await work(cancellationToken);
+                });
+            return result;
+        }
+
+        logger.LogInformation("{Message}", message);
+        return await work(cancellationToken);
     }
 
     /// <summary>

--- a/src/winapp-CLI/WinApp.Cli/Services/WorkspaceSetupService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/WorkspaceSetupService.cs
@@ -167,7 +167,10 @@ internal class WorkspaceSetupService(
         {
             if (options.SdkInstallMode == SdkInstallMode.None)
             {
-                logger.LogDebug("{UISymbol} SDK installation skipped by user choice", UiSymbols.Skip);
+                // The "why we're skipping" message is emitted by AskSdkInstallModeAsync (interactive
+                // choice, --setup-sdks none) or — for .NET — by the early-exit when the project
+                // already references WinAppSDK. Don't repeat a generic / potentially-misleading
+                // "by user choice" line here (#464).
                 logger.LogInformation("Configuration processed (SDK installation skipped)");
             }
             else
@@ -203,7 +206,10 @@ internal class WorkspaceSetupService(
         }
         else if (options.SdkInstallMode == SdkInstallMode.None)
         {
-            logger.LogInformation("{UISymbol} SDK installation skipped by user choice", UiSymbols.Skip);
+            // For .NET projects: AskSdkInstallModeAsync already logged the actual reason we're
+            // skipping (auto-skipped because WinAppSDK is already referenced, or the user picked
+            // "Do not setup", or --setup-sdks=none was passed). Don't append a misleading
+            // "by user choice" line on top of that (#464).
         }
 
         // Prompt to install the WinApp CLI package before entering the live display context


### PR DESCRIPTION
Closes #463 and #464.

## #463 — `winapp init` can be silent for ~30s on a fresh machine

After answering "No" to the manifest-overwrite prompt, `AskSdkInstallModeAsync` performed two slow operations with no visible output:

1. `dotNetService.HasPackageReferenceAsync(csproj, "Microsoft.WindowsAppSDK")` runs `dotnet list package --format json`, which triggers an implicit `dotnet restore` on a cold NuGet cache (30s+ for projects like AI Dev Gallery).
2. A `Task.WhenAll` over 6 parallel NuGet feed queries (3 modes × 2 packages) used to label the SDK install prompt.

Both happened before any prompt was rendered, and the early-exit when the project already references WinAppSDK only logged at Debug level — so the user saw nothing at all.

**Fixes:**

- `DotNetService.HasPackageReferenceAsync`: try a fast `XDocument` scan of the `.csproj` for an inline `<PackageReference Include="…"/>` first. Only positive matches short-circuit; absence still falls back to `dotnet list package` because Directory.Packages.props / SDK-imported packages aren't visible in the raw csproj.
- `WorkspaceSetupService`: wrap the slow ops in a Spectre `Status` spinner ("Detecting project SDK references…" / "Fetching latest SDK versions…"), with a log-line fallback when output is redirected or Information logging is off.
- Promote the "project already references WinAppSDK; skipping setup" log from Debug to Information.

## #464 — `winapp init` says "SDK installation skipped by user choice" when it wasn't

`WorkspaceSetupService` always printed `SDK installation skipped by user choice` whenever `options.SdkInstallMode == None`. That fires even when the .NET path auto-sets None because the project already references WinAppSDK — not a user choice.

**Fix:** delete the trailing "by user choice" line. The actual reason is now logged at the decision site:

- `AskSdkInstallModeAsync` logs the auto-skip line ("Project already references Microsoft.WindowsAppSDK; skipping Windows App SDK setup.") in the .NET case.
- The interactive prompt logs `Setup SDKs: Do not setup SDKs` when the user picks that option.
- `--setup-sdks=none` is the user's own input and needs no echo.

The matching unreachable `LogDebug` for non-.NET projects was removed for the same reason.

## Tests

- New unit tests for the XML fast path in `HasPackageReferenceAsync` (inline `PackageReference` + case-insensitive `Include` attribute).
- Full suite: 766/766 passing.
- `scripts/build-cli.ps1 -SkipMsix -SkipNpm -SkipTests` clean (an unrelated stale regen of `docs/npm-usage.md` came along).
