### PR TITLE
fix(get-winapp-path): fall back to global cache when local missing (#475)

### DIFF
--- a/src/winapp-CLI/WinApp.Cli.Tests/GetWinappPathCommandTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/GetWinappPathCommandTests.cs
@@ -61,15 +61,25 @@ public class GetWinappPathCommandTests : BaseCommandTests
         // Assert
         Assert.AreEqual(0, exitCode, "Missing local .winapp should not be a fatal error; the global cache is a sensible fallback.");
 
-        var output = TestAnsiConsole.Output;
-        StringAssert.Contains(output, globalDir.FullName,
+        var stdout = TestAnsiConsole.Output;
+        StringAssert.Contains(stdout, globalDir.FullName,
             "Should fall back to the global .winapp path (#475) instead of returning a non-existent local path.");
 
         var nonExistentLocal = Path.Combine(_tempDirectory.FullName, ".winapp");
         Assert.IsFalse(File.Exists(nonExistentLocal) || Directory.Exists(nonExistentLocal),
             "Sanity check: the local .winapp should not exist for this test.");
-        Assert.IsFalse(output.Contains(nonExistentLocal),
+        Assert.IsFalse(stdout.Contains(nonExistentLocal),
             "Must not print the non-existent <cwd>/.winapp path that scripts can't use (#475).");
+
+        // The warning must go to stderr so `path = $(winapp get-winapp-path)` in scripts
+        // captures only the path. Verifying both sides keeps stdout script-friendly.
+        var stderr = ConsoleStdErr.ToString();
+        StringAssert.Contains(stderr, "No local .winapp directory found",
+            "Should warn (on stderr) that no local .winapp directory was found before falling back.");
+        StringAssert.Contains(stderr, globalDir.FullName,
+            "Warning should mention the global cache path being used as the fallback.");
+        Assert.IsFalse(stdout.Contains("No local .winapp directory found"),
+            "Warning text must not pollute stdout — scripts capturing stdout should get only the path.");
     }
 
     [TestMethod]

--- a/src/winapp-CLI/WinApp.Cli.Tests/GetWinappPathCommandTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/GetWinappPathCommandTests.cs
@@ -1,0 +1,92 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using WinApp.Cli.Commands;
+using WinApp.Cli.Services;
+
+namespace WinApp.Cli.Tests;
+
+[TestClass]
+public class GetWinappPathCommandTests : BaseCommandTests
+{
+    [TestInitialize]
+    public void SetupGetWinappPathTests()
+    {
+        // The default TestConsole width (80) wraps long Windows paths and breaks substring
+        // assertions. Use a wide profile so the path lands on a single line.
+        TestAnsiConsole.Profile.Width = 500;
+    }
+
+    /// <summary>
+    /// Override the global cache to point at the real ~/.winapp. This ensures
+    /// <c>GetLocalWinappDirectory</c>'s walk-up treats that path (if present on the dev
+    /// machine) as the global cache and skips it, so tests behave the same on dev and CI.
+    /// </summary>
+    private DirectoryInfo PointGlobalAtUserProfileWinapp()
+    {
+        var userProfileWinapp = new DirectoryInfo(Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            ".winapp"));
+        GetRequiredService<IWinappDirectoryService>().SetCacheDirectoryForTesting(userProfileWinapp);
+        return userProfileWinapp;
+    }
+
+    [TestMethod]
+    public async Task GetWinappPath_LocalDirectoryExists_PrintsLocalPath()
+    {
+        // BaseCommandTests.SetupBase already creates _testWinappDirectory at _tempDirectory/.winapp
+        PointGlobalAtUserProfileWinapp();
+        var command = GetRequiredService<GetWinappPathCommand>();
+
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, []);
+
+        Assert.AreEqual(0, exitCode);
+        StringAssert.Contains(TestAnsiConsole.Output, _testWinappDirectory.FullName,
+            "Should print the resolved local .winapp path when it exists.");
+    }
+
+    [TestMethod]
+    public async Task GetWinappPath_LocalDirectoryMissing_FallsBackToGlobal_WithWarning()
+    {
+        // Arrange — remove the local .winapp the base setup created so the resolver returns a
+        // non-existent path (the #475 bug repro).
+        _testWinappDirectory.Delete(recursive: true);
+        var globalDir = PointGlobalAtUserProfileWinapp();
+
+        var command = GetRequiredService<GetWinappPathCommand>();
+
+        // Act
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, []);
+
+        // Assert
+        Assert.AreEqual(0, exitCode, "Missing local .winapp should not be a fatal error; the global cache is a sensible fallback.");
+
+        var output = TestAnsiConsole.Output;
+        StringAssert.Contains(output, globalDir.FullName,
+            "Should fall back to the global .winapp path (#475) instead of returning a non-existent local path.");
+
+        var nonExistentLocal = Path.Combine(_tempDirectory.FullName, ".winapp");
+        Assert.IsFalse(File.Exists(nonExistentLocal) || Directory.Exists(nonExistentLocal),
+            "Sanity check: the local .winapp should not exist for this test.");
+        Assert.IsFalse(output.Contains(nonExistentLocal),
+            "Must not print the non-existent <cwd>/.winapp path that scripts can't use (#475).");
+    }
+
+    [TestMethod]
+    public async Task GetWinappPath_GlobalDirectoryMissing_ReturnsErrorExitCode()
+    {
+        // Arrange — point the global directory at a path that doesn't exist.
+        var directoryService = GetRequiredService<IWinappDirectoryService>();
+        var nonExistentGlobal = new DirectoryInfo(Path.Combine(_tempDirectory.FullName, "no-such-global"));
+        directoryService.SetCacheDirectoryForTesting(nonExistentGlobal);
+
+        var command = GetRequiredService<GetWinappPathCommand>();
+
+        // Act
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["--global"]);
+
+        // Assert — explicit --global request for a missing directory should still fail loudly.
+        Assert.AreNotEqual(0, exitCode,
+            "An explicit --global request for a missing directory should return a non-zero exit code.");
+    }
+}

--- a/src/winapp-CLI/WinApp.Cli/Commands/GetWinappPathCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/GetWinappPathCommand.cs
@@ -61,7 +61,12 @@ internal class GetWinappPathCommand : Command, IShortDescription
                     if (!winappDir.Exists)
                     {
                         var globalDir = winappDirectoryService.GetGlobalWinappDirectory();
-                        logger.LogWarning("{UISymbol} No local .winapp directory found; falling back to the global cache at {GlobalDir}.", UiSymbols.Warning, globalDir.FullName);
+                        // Write the warning to stderr so stdout stays script-friendly
+                        // (callers do `path = $(winapp get-winapp-path)`). Going through
+                        // ILogger.LogWarning would route via the static AnsiConsole and
+                        // pollute stdout (TextWriterLogger only sends >= Error to stderr).
+                        parseResult.InvocationConfiguration.Error.WriteLine(
+                            $"{UiSymbols.Warning} No local .winapp directory found; falling back to the global cache at {globalDir.FullName}.");
                         winappDir = globalDir;
                         directoryType = "Global (fallback)";
                     }

--- a/src/winapp-CLI/WinApp.Cli/Commands/GetWinappPathCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/GetWinappPathCommand.cs
@@ -52,12 +52,8 @@ internal class GetWinappPathCommand : Command, IShortDescription
                     winappDir = winappDirectoryService.GetLocalWinappDirectory();
                     directoryType = "Local";
 
-                    // #475: GetLocalWinappDirectory falls back to <baseDir>/.winapp when no
-                    // .winapp folder is found by walking upward, even though that path doesn't
-                    // actually exist. Returning a non-existent path makes scripts that rely on
-                    // this command point at empty directories. Fall back to the global cache
-                    // (which is also where 'winapp install' would put packages without a local
-                    // .winapp) and warn the user.
+                    // Fall back to the global cache (which is also where 'winapp install' would
+                    // put packages without a local .winapp) and warn the user. See #475.
                     if (!winappDir.Exists)
                     {
                         var globalDir = winappDirectoryService.GetGlobalWinappDirectory();

--- a/src/winapp-CLI/WinApp.Cli/Commands/GetWinappPathCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/GetWinappPathCommand.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Microsoft.Extensions.Logging;
+using Spectre.Console;
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using WinApp.Cli.Helpers;
@@ -28,7 +29,7 @@ internal class GetWinappPathCommand : Command, IShortDescription
         Options.Add(GlobalOption);
     }
 
-    public class Handler(IWinappDirectoryService winappDirectoryService, ILogger<GetWinappPathCommand> logger) : AsynchronousCommandLineAction
+    public class Handler(IWinappDirectoryService winappDirectoryService, IAnsiConsole console, ILogger<GetWinappPathCommand> logger) : AsynchronousCommandLineAction
     {
         public override Task<int> InvokeAsync(ParseResult parseResult, CancellationToken cancellationToken = default)
         {
@@ -50,6 +51,20 @@ internal class GetWinappPathCommand : Command, IShortDescription
                     // Get the local .winapp directory
                     winappDir = winappDirectoryService.GetLocalWinappDirectory();
                     directoryType = "Local";
+
+                    // #475: GetLocalWinappDirectory falls back to <baseDir>/.winapp when no
+                    // .winapp folder is found by walking upward, even though that path doesn't
+                    // actually exist. Returning a non-existent path makes scripts that rely on
+                    // this command point at empty directories. Fall back to the global cache
+                    // (which is also where 'winapp install' would put packages without a local
+                    // .winapp) and warn the user.
+                    if (!winappDir.Exists)
+                    {
+                        var globalDir = winappDirectoryService.GetGlobalWinappDirectory();
+                        logger.LogWarning("{UISymbol} No local .winapp directory found; falling back to the global cache at {GlobalDir}.", UiSymbols.Warning, globalDir.FullName);
+                        winappDir = globalDir;
+                        directoryType = "Global (fallback)";
+                    }
                 }
 
                 // For global directories, check if they exist
@@ -60,8 +75,10 @@ internal class GetWinappPathCommand : Command, IShortDescription
                     return Task.FromResult(1);
                 }
 
-                // Output just the path for easy consumption by scripts
-                logger.LogInformation("{WinappDir}", winappDir);
+                // Output just the path for easy consumption by scripts. Use IAnsiConsole
+                // directly (rather than ILogger) so the path lands cleanly on stdout without
+                // any logger formatting and so tests can capture it via TestAnsiConsole.
+                console.WriteLine(winappDir.FullName);
 
                 var status = winappDir.Exists ? "exists" : "does not exist";
                 logger.LogDebug("{UISymbol} {DirectoryType} .winapp directory: {WinappDir} ({Status})", UiSymbols.Folder, directoryType, winappDir, status);


### PR DESCRIPTION
## Summary

Fixes #475.

Previously, winapp get-winapp-path (without `--global`) would print `<cwd>\.winapp` even when no local `.winapp` directory existed anywhere up the directory tree. Build scripts that consumed the output ended up pointing at non-existent folders, since installed packages had actually landed in the global cache.

## Behavior change

When the resolved local `.winapp` directory does not exist, the command now:

1. Emits a warning (`WinappDirectoryService` + `UiSymbols.Warning`) explaining that no local `.winapp` was found.
2. Falls back to the global cache path (`%USERPROFILE%\.winapp` by default).
3. Returns exit code `0` and prints the global path on stdout, so scripts continue to work.

When `--global` is explicitly requested but the global directory is missing, behavior is unchanged: the command still returns a non-zero exit code with an error.

## Repro (before fix)

```
PS> cd (New-Item -ItemType Directory ""C:\Users\nikolame\AppData\Local\Temp\repro-475-$([guid]::NewGuid())"")
PS> winapp get-winapp-path
C:\Users\me\AppData\Local\Temp\repro-475-...\\.winapp     # <-- non-existent
```

## After fix

```
PS> winapp get-winapp-path
WARN  No local .winapp directory found; falling back to the global cache at C:\Users\me\.winapp.
C:\Users\me\.winapp
```

## Implementation notes

- Switched the path emission in `GetWinappPathCommand` from `logger.LogInformation` to `IAnsiConsole.WriteLine` so the path is the only thing on stdout and is cleanly captured by tests via `TestAnsiConsole`. (Non-error log levels in `TextWriterLogger` use the static `AnsiConsole`, which bypasses both the injected writer and the DI `IAnsiConsole`, so they aren't visible to test assertions.)
- Added `GetWinappPathCommandTests` with three cases: local exists, local missing -> global fallback, `--global` missing -> error.

## Validation

- New tests: 3 passing.
- Full suite: 767/767 passing.
- Manual repro: empty temp dir prints warning + global path, `exit 0`.

Closes #475