### PR TITLE
FIx 466: Show status messages for nuget package failures

### DIFF
--- a/src/winapp-CLI/WinApp.Cli.Tests/FakeDotNetService.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/FakeDotNetService.cs
@@ -26,6 +26,12 @@ internal class FakeDotNetService : IDotNetService
     /// </summary>
     public DotNetPackageListJson? PackageListResult { get; set; }
 
+    /// <summary>
+    /// Packages listed here will cause <see cref="AddOrUpdatePackageReferenceAsync"/> to throw,
+    /// simulating failures from <c>dotnet add package</c>.
+    /// </summary>
+    public HashSet<string> PackagesToThrowOnAdd { get; } = new(StringComparer.OrdinalIgnoreCase);
+
     // Delegate file-based operations to real implementation
     public IReadOnlyList<FileInfo> FindCsproj(DirectoryInfo directory) => _real.FindCsproj(directory);
     public string? GetTargetFramework(FileInfo csprojPath) => _real.GetTargetFramework(csprojPath);
@@ -53,6 +59,11 @@ internal class FakeDotNetService : IDotNetService
     // Fake CLI-based operations
     public Task<string> AddOrUpdatePackageReferenceAsync(FileInfo csprojPath, string packageName, string? version, CancellationToken cancellationToken = default)
     {
+        if (PackagesToThrowOnAdd.Contains(packageName))
+        {
+            throw new InvalidOperationException($"Simulated dotnet add package failure for {packageName}");
+        }
+
         AddedPackages.Add((csprojPath.FullName, packageName, version));
         return Task.FromResult(version ?? "1.0.0");
     }

--- a/src/winapp-CLI/WinApp.Cli.Tests/WorkspaceSetupServiceTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/WorkspaceSetupServiceTests.cs
@@ -955,5 +955,37 @@ public class WorkspaceSetupServiceMergedPathTests : BaseCommandTests
             "Init should succeed (exit code 0) even when NuGet version lookup fails for the WinApp integration package");
     }
 
+    [TestMethod]
+    public async Task SetupWorkspace_DotNet_InitSucceeds_WhenOptionalWinAppPackageAddFails()
+    {
+        // Arrange
+        await CreateCsprojAsync(_tempDirectory, "TestApp", "net10.0-windows10.0.26100.0");
+        _fakeDotNetService.PackagesToThrowOnAdd.Add(DotNetService.WINDOWS_SDK_BUILD_TOOLS_WINAPP_PACKAGE);
+
+        var workspaceSetupService = GetRequiredService<IWorkspaceSetupService>();
+        var options = new WorkspaceSetupOptions
+        {
+            BaseDirectory = _tempDirectory,
+            ConfigDir = _tempDirectory,
+            SdkInstallMode = SdkInstallMode.None,
+            UseDefaults = true,
+            RequireExistingConfig = false,
+            NoGitignore = true
+        };
+
+        // Act
+        var exitCode = await workspaceSetupService.SetupWorkspaceAsync(options, TestContext.CancellationToken);
+
+        // Assert
+        Assert.AreEqual(0, exitCode,
+            "Init should succeed (exit code 0) when optional WinApp package add fails");
+
+        var combinedOutput = TestAnsiConsole.Output + ConsoleStdOut.ToString() + ConsoleStdErr.ToString();
+        Assert.IsTrue(
+            combinedOutput.Contains("Failed to add optional NuGet packages", StringComparison.OrdinalIgnoreCase) &&
+            combinedOutput.Contains(DotNetService.WINDOWS_SDK_BUILD_TOOLS_WINAPP_PACKAGE, StringComparison.OrdinalIgnoreCase),
+            $"Output should include the optional package failure message. Output:\n{combinedOutput}");
+    }
+
     #endregion
 }

--- a/src/winapp-CLI/WinApp.Cli/Services/WorkspaceSetupService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/WorkspaceSetupService.cs
@@ -334,6 +334,7 @@ internal class WorkspaceSetupService(
                     partialResult = await taskContext.AddSubTaskAsync("Adding NuGet packages to project", async (taskContext, cancellationToken) =>
                     {
                         usedVersions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                        var failedPackages = new List<string>();
 
                         // When SdkInstallMode is None, still use Stable versions for build tools packages
                         var versionQueryMode = sdkInstallMode == SdkInstallMode.None ? SdkInstallMode.Stable : sdkInstallMode;
@@ -402,7 +403,18 @@ internal class WorkspaceSetupService(
                                 {
                                     return (1, $"Failed to add {packageName} package reference");
                                 }
+                                failedPackages.Add(packageName);
                             }
+                        }
+
+                        if (failedPackages.Count > 0)
+                        {
+                            var failedList = string.Join(", ", failedPackages);
+                            if (usedVersions.Count > 0)
+                            {
+                                return (0, $"NuGet packages added to [underline]{csprojFile.Name}[/], but failed to add: {failedList}");
+                            }
+                            return (1, $"Failed to add NuGet packages: {failedList}");
                         }
 
                         return (0, $"NuGet packages added to [underline]{csprojFile.Name}[/]");

--- a/src/winapp-CLI/WinApp.Cli/Services/WorkspaceSetupService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/WorkspaceSetupService.cs
@@ -420,7 +420,10 @@ internal class WorkspaceSetupService(
                             {
                                 return (0, $"NuGet packages added to [underline]{csprojFile.Name}[/], but failed to add: {failedList}");
                             }
-                            return (1, $"Failed to add NuGet packages: {failedList}");
+
+                            // Only optional package failures reach this point. Required package failures
+                            // already return non-zero in the catch block above, so do not abort init here.
+                            return (0, $"Failed to add optional NuGet packages: {failedList}");
                         }
 
                         return (0, $"NuGet packages added to [underline]{csprojFile.Name}[/]");


### PR DESCRIPTION
fixes #466 

Show when nuget package installs fail and display to user instead of doing nothing.