### PR TITLE
[Docs] Updating all of our documentation to use Package.appxmanifest rather than appxmanifest.xml

### DIFF
--- a/.github/plugin/skills/winapp-cli/frameworks/SKILL.md
+++ b/.github/plugin/skills/winapp-cli/frameworks/SKILL.md
@@ -48,7 +48,7 @@ Additional Electron guides:
 ### .NET (WPF, WinForms, Console)
 .NET projects have direct access to Windows APIs. Key differences:
 - Projects with NuGet references to `Microsoft.Windows.SDK.BuildTools` or `Microsoft.WindowsAppSDK` **don't need `winapp.yaml`** — winapp auto-detects SDK versions from the `.csproj`
-- The key prerequisite is `appxmanifest.xml`, not `winapp.yaml`
+- The key prerequisite is `Package.appxmanifest`, not `winapp.yaml`
 - No native addon step needed — unlike Electron, .NET can call Windows APIs directly
 - `winapp init` automatically adds the `Microsoft.Windows.SDK.BuildTools.WinApp` NuGet package, enabling `dotnet run` with automatic identity registration
 
@@ -101,7 +101,7 @@ C++ projects use winapp primarily for SDK projections (CppWinRT headers) and pac
 
 **Key rules:**
 - **GUI apps** (Flutter, Tauri, WPF): use `winapp run <build-output>` — launches via AUMID activation
-- **Console apps** (C++, Rust, .NET console): use `winapp run <build-output> --with-alias` — launches via execution alias to preserve stdin/stdout. Requires `uap5:ExecutionAlias` in `appxmanifest.xml`
+- **Console apps** (C++, Rust, .NET console): use `winapp run <build-output> --with-alias` — launches via execution alias to preserve stdin/stdout. Requires `uap5:ExecutionAlias` in `Package.appxmanifest`
 - **Electron**: different mechanism — uses `npx winapp node add-electron-debug-identity` because `electron.exe` is in `node_modules/`, not your build output
 - **Startup debugging (any framework)**: use `winapp create-debug-identity <exe>` so your IDE can F5-launch the exe with identity from the first instruction
 
@@ -109,7 +109,7 @@ For full debugging scenarios and IDE setup, see the [Debugging Guide](https://gi
 
 ## Related skills
 - **Setup**: `winapp-setup` — initial project setup with `winapp init`
-- **Manifest**: `winapp-manifest` — creating and customizing `appxmanifest.xml`
+- **Manifest**: `winapp-manifest` — creating and customizing `Package.appxmanifest`
 - **Signing**: `winapp-signing` — certificate generation and management
 - **Packaging**: `winapp-package` — creating MSIX installers from build output
 - **Identity**: `winapp-identity` — enabling package identity for Windows APIs during development

--- a/.github/plugin/skills/winapp-cli/identity/SKILL.md
+++ b/.github/plugin/skills/winapp-cli/identity/SKILL.md
@@ -14,7 +14,7 @@ Use this skill when:
 
 ## Prerequisites
 
-1. **`appxmanifest.xml`** in your project — from `winapp init` or `winapp manifest generate`
+1. **`Package.appxmanifest`** in your project — from `winapp init` or `winapp manifest generate`
 2. **Built executable** — the `.exe` your app runs from
 
 ## What is package identity?
@@ -39,7 +39,7 @@ A standard `.exe` (from `dotnet build`, `cmake`, etc.) does **not** have identit
 winapp create-debug-identity ./bin/Release/myapp.exe
 
 # Specify manifest location
-winapp create-debug-identity ./bin/Release/myapp.exe --manifest ./appxmanifest.xml
+winapp create-debug-identity ./bin/Release/myapp.exe --manifest ./Package.appxmanifest
 ```
 
 ### Keep the original package identity
@@ -59,7 +59,7 @@ winapp create-debug-identity ./myapp.exe --no-install
 
 ## What the command does
 
-1. **Reads `appxmanifest.xml`** — extracts identity, capabilities, and assets
+1. **Reads `Package.appxmanifest`** — extracts identity, capabilities, and assets
 2. **Creates a sparse package layout** in a temp directory
 3. **Appends `.debug`** to the package name (unless `--keep-identity`) to avoid conflicts
 4. **Registers with Windows** via `Add-AppxPackage -ExternalLocation` — makes your exe "identity-aware"
@@ -68,16 +68,16 @@ After running, launch your exe normally — Windows will recognize it as having 
 
 ## Recommended workflow
 
-1. **Setup** — `winapp init --use-defaults` (creates `appxmanifest.xml`)
+1. **Setup** — `winapp init --use-defaults` (creates `Package.appxmanifest`)
 2. **Generate development certificate** — `winapp cert generate`
 3. **Build** your app
 4. **Register identity** — `winapp create-debug-identity ./bin/myapp.exe`
 5. **Run** your app — identity-requiring APIs now work
-6. **Re-run step 4** whenever you change `appxmanifest.xml` or `Assets/`
+6. **Re-run step 4** whenever you change `Package.appxmanifest` or `Assets/`
 
 ## Tips
 
-- You must re-run `create-debug-identity` after any changes to `appxmanifest.xml` or image assets
+- You must re-run `create-debug-identity` after any changes to `Package.appxmanifest` or image assets
 - The debug identity persists across reboots until explicitly removed
 - To remove: `Get-AppxPackage *yourapp.debug* | Remove-AppxPackage`
 - If you have both a debug identity and an installed MSIX, they may conflict — use `--keep-identity` carefully
@@ -132,7 +132,7 @@ winapp create-debug-identity .\bin\Debug\myapp.exe
 For full details including IDE setup examples, see the [Debugging Guide](https://github.com/microsoft/WinAppCli/blob/main/docs/debugging.md).
 
 ## Related skills
-- Need a manifest? See `winapp-manifest` to generate `appxmanifest.xml`
+- Need a manifest? See `winapp-manifest` to generate `Package.appxmanifest`
 - Need a certificate? See `winapp-signing` — a trusted cert is required for identity registration
 - Ready for full MSIX distribution? See `winapp-package` to create an installer
 - Having issues? See `winapp-troubleshoot` for common error solutions
@@ -140,7 +140,7 @@ For full details including IDE setup examples, see the [Debugging Guide](https:/
 ## Troubleshooting
 | Error | Cause | Solution |
 |-------|-------|----------|
-| "appxmanifest.xml not found" | No manifest in current directory | Run `winapp init` or `winapp manifest generate`, or pass `--manifest` |
+| "Package.appxmanifest not found" | No manifest in current directory | Run `winapp init` or `winapp manifest generate`, or pass `--manifest` |
 | "Failed to add package identity" | Previous registration stale or cert untrusted | Run `winapp unregister` to remove stale packages, then `winapp cert install ./devcert.pfx` (admin) |
 | "Access denied" | Cert not trusted or permission issue | Run `winapp cert install ./devcert.pfx` as admin |
 | APIs still fail after registration | App launched before registration completed | Close app, re-run `create-debug-identity`, then relaunch |

--- a/.github/plugin/skills/winapp-cli/manifest/SKILL.md
+++ b/.github/plugin/skills/winapp-cli/manifest/SKILL.md
@@ -6,7 +6,7 @@ version: 0.2.2
 ## When to use
 
 Use this skill when:
-- **Creating `appxmanifest.xml`** for a project that doesn't have one yet
+- **Creating `Package.appxmanifest`** for a project that doesn't have one yet
 - **Generating app icon assets** from a single source image
 - **Understanding manifest structure** for package identity and capabilities
 
@@ -17,7 +17,7 @@ Use this skill when:
 
 ## Key concepts
 
-**`appxmanifest.xml`** is the key prerequisite for most winapp commands — it's more important than `winapp.yaml`. It declares:
+**`Package.appxmanifest`** is the key prerequisite for most winapp commands — it's more important than `winapp.yaml`. It declares:
 - **Package identity** — name, publisher, version
 - **App entry point** — which executable to launch
 - **Capabilities** — what the app can access (internet, file system, etc.)
@@ -55,7 +55,7 @@ winapp manifest generate --if-exists overwrite
 ```
 
 Output:
-- `appxmanifest.xml` — the manifest file
+- `Package.appxmanifest` — the manifest file
 - `Assets/` — default app icons in required sizes (Square44x44Logo, Square150x150Logo, Wide310x150Logo, etc.)
 
 ### Update app icons from a source image
@@ -68,7 +68,7 @@ winapp manifest update-assets ./my-logo.png
 winapp manifest update-assets ./my-logo.svg
 
 # Specify manifest location (if not in current directory)
-winapp manifest update-assets ./my-logo.png --manifest ./path/to/appxmanifest.xml
+winapp manifest update-assets ./my-logo.png --manifest ./path/to/Package.appxmanifest
 
 # Generate light theme variants from a separate image
 winapp manifest update-assets ./my-logo.png --light-image ./my-logo-light.png
@@ -95,7 +95,7 @@ winapp manifest add-alias
 winapp manifest add-alias --name myapp
 
 # Target a specific manifest file
-winapp manifest add-alias --manifest ./path/to/appxmanifest.xml
+winapp manifest add-alias --manifest ./path/to/Package.appxmanifest
 ```
 
 This adds a `uap5:AppExecutionAlias` extension to the manifest. If the alias already exists, the command reports it and exits successfully.
@@ -114,14 +114,14 @@ winapp manifest add-alias
 winapp manifest add-alias --name myapp
 
 # Target a specific manifest file
-winapp manifest add-alias --manifest ./path/to/appxmanifest.xml
+winapp manifest add-alias --manifest ./path/to/Package.appxmanifest
 ```
 
 This adds a `uap5:AppExecutionAlias` extension to the manifest. If the alias already exists, the command reports it and exits successfully.
 
 ## Manifest structure overview
 
-A typical `appxmanifest.xml` looks like:
+A typical `Package.appxmanifest` looks like:
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
@@ -160,10 +160,10 @@ Key fields to edit:
 
 - Always ensure `Identity.Publisher` matches your signing certificate — use `winapp cert generate --manifest` to auto-match
 - The `sparse` template adds `uap10:AllowExternalContent="true"` for apps that need identity but run outside the MSIX container
-- You can manually edit `appxmanifest.xml` after generation — it's a standard XML file
+- You can manually edit `Package.appxmanifest` after generation — it's a standard XML file
 - Image assets must match the paths referenced in the manifest — `update-assets` handles this automatically
 - For logos, transparent PNGs or SVGs work best. SVG source images are rendered as vectors directly at each target size, producing pixel-perfect results. Use a square image for best results across all sizes.
-- **`$targetnametoken$` placeholder:** When `winapp manifest generate` creates `appxmanifest.xml`, it sets `Application.Executable` to `$targetnametoken$.exe` by default. This is a valid placeholder that gets automatically resolved by `winapp package --executable <name>` at packaging time — you rarely need to override it during manifest generation. If `--executable` is provided to `winapp manifest generate`, winapp reads `FileVersionInfo` from the actual exe to auto-fill package name, description, publisher, and extract an icon, so the exe must already exist on disk.
+- **`$targetnametoken$` placeholder:** When `winapp manifest generate` creates `Package.appxmanifest`, it sets `Application.Executable` to `$targetnametoken$.exe` by default. This is a valid placeholder that gets automatically resolved by `winapp package --executable <name>` at packaging time — you rarely need to override it during manifest generation. If `--executable` is provided to `winapp manifest generate`, winapp reads `FileVersionInfo` from the actual exe to auto-fill package name, description, publisher, and extract an icon, so the exe must already exist on disk.
 
 ## Related skills
 
@@ -173,7 +173,7 @@ Key fields to edit:
 ## Troubleshooting
 | Error | Cause | Solution |
 |-------|-------|----------|
-| "Manifest already exists" | `appxmanifest.xml` present | Use `--if-exists overwrite` to replace, or edit existing file directly |
+| "Manifest already exists" | `Package.appxmanifest` present | Use `--if-exists overwrite` to replace, or edit existing file directly |
 | "Invalid source image" | Image too small or wrong format | Use PNG or SVG, at least 400x400 pixels |
 | "Publisher mismatch" during packaging | Manifest publisher ≠ cert publisher | Edit `Identity.Publisher` in manifest, or regenerate cert with `--manifest` |
 

--- a/.github/plugin/skills/winapp-cli/package/SKILL.md
+++ b/.github/plugin/skills/winapp-cli/package/SKILL.md
@@ -15,7 +15,7 @@ Use this skill when:
 
 Before packaging, you need:
 1. **Built app output** in a folder (e.g., `bin/Release/`, `dist/`, `build/`)
-2. **`appxmanifest.xml`** — from `winapp init` or `winapp manifest generate`
+2. **`Package.appxmanifest`** — from `winapp init` or `winapp manifest generate`
 3. **Certificate** (optional) — `devcert.pfx` from `winapp cert generate` for signing
 
 ## Usage
@@ -27,7 +27,7 @@ Before packaging, you need:
 winapp package ./bin/Release
 
 # Specify manifest location explicitly
-winapp package ./dist --manifest ./appxmanifest.xml
+winapp package ./dist --manifest ./Package.appxmanifest
 ```
 
 ### Package and sign in one step
@@ -69,7 +69,7 @@ winapp package ./dist --name "MyApp_1.0.0_x64" --cert ./devcert.pfx
 
 ## What the command does
 
-1. **Locates `appxmanifest.xml`** — looks in input folder, then current directory (or uses `--manifest`)
+1. **Locates `Package.appxmanifest`** — looks in input folder, then current directory (or uses `--manifest`)
 2. **Copies manifest + assets** into a staging layout alongside your app files
 3. **Generates `resources.pri`** — Package Resource Index for UWP-style resource lookup (skip with `--skip-pri`)
 4. **Runs `makeappx pack`** — creates the `.msix` package file
@@ -134,21 +134,21 @@ Use the `microsoft/setup-winapp` action to install winapp on GitHub-hosted runne
 ## Tips
 
 - The `package` command aliases to `pack` — both work identically
-- `appxmanifest.xml` Publisher must match the certificate publisher — use `winapp cert generate --manifest` to ensure they match
+- `Package.appxmanifest` Publisher must match the certificate publisher — use `winapp cert generate --manifest` to ensure they match
 - Use `--skip-pri` if your app doesn't use Windows resource loading (e.g., most Electron/Rust/C++ apps without UWP resources)
 - For framework-specific packaging paths (Electron, .NET, Rust, etc.), see the `winapp-frameworks` skill
-- The `--executable` flag overrides the entry point in the manifest — useful when your exe name differs from what's in `appxmanifest.xml`
+- The `--executable` flag overrides the entry point in the manifest — useful when your exe name differs from what's in `Package.appxmanifest`
 - For production distribution, use a certificate from a trusted CA and add `--timestamp` when signing with `winapp sign`
 
 ## Related skills
-- Need a manifest first? See `winapp-manifest` to generate `appxmanifest.xml`
+- Need a manifest first? See `winapp-manifest` to generate `Package.appxmanifest`
 - Need a certificate? See `winapp-signing` for certificate generation and management
 - Having issues? See `winapp-troubleshoot` for a command selection flowchart and error solutions
 
 ## Troubleshooting
 | Error | Cause | Solution |
 |-------|-------|----------|
-| "appxmanifest.xml not found" | No manifest in input folder or current dir | Run `winapp init` or `winapp manifest generate` first |
+| "Package.appxmanifest not found" | No manifest in input folder or current dir | Run `winapp init` or `winapp manifest generate` first |
 | "Publisher mismatch" | Cert publisher ≠ manifest publisher | Regenerate cert with `winapp cert generate --manifest`, or edit manifest |
 | "Package installation failed" | Cert not trusted or stale package | Run `winapp cert install ./devcert.pfx` (admin), then `Get-AppxPackage <name> \| Remove-AppxPackage` |
 | "makeappx not found" | Build tools not downloaded | Run `winapp update` or `winapp tool makeappx --help` to trigger download |

--- a/.github/plugin/skills/winapp-cli/setup/SKILL.md
+++ b/.github/plugin/skills/winapp-cli/setup/SKILL.md
@@ -28,7 +28,7 @@ You need an **existing app project** — `winapp init` does **not** create new p
 
 ## Key concepts
 
-**`appxmanifest.xml`** is the most important file winapp creates — it declares your app's identity, capabilities, and visual assets. Most winapp commands require it (`package`, `run`, `cert generate --manifest`).
+**`Package.appxmanifest`** is the most important file winapp creates — it declares your app's identity, capabilities, and visual assets. Most winapp commands require it (`package`, `run`, `cert generate --manifest`).
 
 **`winapp.yaml`** is only needed for SDK version management via `restore`/`update`. Projects that already reference Windows SDK packages (e.g., via NuGet in a `.csproj`) can use winapp commands without it.
 
@@ -53,7 +53,7 @@ winapp init --use-defaults --setup-sdks preview
 ```
 
 After `init`, your project will contain:
-- `appxmanifest.xml` — package identity and capabilities
+- `Package.appxmanifest` — package identity and capabilities
 - `Assets/` — default app icons (Square44x44Logo, Square150x150Logo, etc.)
 - `winapp.yaml` — SDK version pinning for `restore`/`update`
 - `.winapp/` — downloaded SDK packages and generated projections
@@ -90,7 +90,7 @@ This updates `winapp.yaml` with the latest versions and reinstalls packages.
 winapp run ./bin/Debug
 
 # Launch with custom manifest and pass arguments to the app
-winapp run ./dist --manifest ./out/AppxManifest.xml --args "--my-flag value"
+winapp run ./dist --manifest ./out/Package.appxmanifest --args "--my-flag value"
 
 # Register identity without launching (useful for attaching a debugger manually)
 winapp run ./bin/Debug --no-launch
@@ -124,7 +124,7 @@ For full debugging scenarios and IDE setup, see the [Debugging Guide](https://gi
 ## Recommended workflow
 
 1. **Initialize** — `winapp init --use-defaults` in your existing project
-2. **Configure** — edit `appxmanifest.xml` to add capabilities your app needs (e.g., `runFullTrust`, `internetClient`)
+2. **Configure** — edit `Package.appxmanifest` to add capabilities your app needs (e.g., `runFullTrust`, `internetClient`)
 3. **Build** — build your app as usual (dotnet build, cmake, npm run build, etc.)
 4. **Run with identity** — `winapp run ./bin/Debug` to register identity and launch for debugging
 5. **Package** — `winapp package ./bin/Release --cert ./devcert.pfx` to create MSIX
@@ -132,12 +132,12 @@ For full debugging scenarios and IDE setup, see the [Debugging Guide](https://gi
 ## Tips
 
 - Use `--use-defaults` (alias: `--no-prompt`) in CI/CD pipelines and scripts to avoid interactive prompts
-- If you only need `appxmanifest.xml` without SDK setup, use `winapp manifest generate` instead of `init`
+- If you only need `Package.appxmanifest` without SDK setup, use `winapp manifest generate` instead of `init`
 - `winapp init` is idempotent for the config file — re-running it won't overwrite an existing `winapp.yaml` unless you use `--config-only`
 - For Electron projects, prefer `npm install --save-dev @microsoft/winappcli` and use `npx winapp init` instead of the standalone CLI
 
 ## Related skills
-- After setup, see `winapp-manifest` to customize your `appxmanifest.xml`
+- After setup, see `winapp-manifest` to customize your `Package.appxmanifest`
 - Ready to package? See `winapp-package` to create an MSIX installer
 - Need a certificate? See `winapp-signing` for certificate generation
 - Not sure which command to use? See `winapp-troubleshoot` for a command selection flowchart

--- a/.github/plugin/skills/winapp-cli/signing/SKILL.md
+++ b/.github/plugin/skills/winapp-cli/signing/SKILL.md
@@ -17,7 +17,7 @@ Use this skill when:
 
 ## Key concepts
 
-**Publisher matching:** The publisher in your certificate (e.g., `CN=MyCompany`) must exactly match the `Publisher` attribute in `appxmanifest.xml`. Use `--manifest` when generating to auto-match.
+**Publisher matching:** The publisher in your certificate (e.g., `CN=MyCompany`) must exactly match the `Publisher` attribute in `Package.appxmanifest`. Use `--manifest` when generating to auto-match.
 
 **Dev vs. production certs:** `winapp cert generate` creates self-signed certificates for **local testing only**. For production distribution (Microsoft Store or enterprise), obtain a certificate from a trusted Certificate Authority.
 
@@ -28,11 +28,11 @@ Use this skill when:
 ### Generate a development certificate
 
 ```powershell
-# Auto-infer publisher from appxmanifest.xml in the current directory
+# Auto-infer publisher from Package.appxmanifest in the current directory
 winapp cert generate
 
 # Explicitly point to a manifest
-winapp cert generate --manifest ./path/to/appxmanifest.xml
+winapp cert generate --manifest ./path/to/Package.appxmanifest
 
 # Set publisher manually (when no manifest exists yet)
 winapp cert generate --publisher "CN=Contoso, O=Contoso Ltd, C=US"
@@ -85,21 +85,21 @@ Note: The `package` command can sign automatically when you pass `--cert`, so yo
 
 ## Tips
 
-- Always use `--manifest` (or have `appxmanifest.xml` in the working directory) when generating certs to ensure the publisher matches automatically
+- Always use `--manifest` (or have `Package.appxmanifest` in the working directory) when generating certs to ensure the publisher matches automatically
 - For CI/CD, store the PFX as a secret and pass the password via `--password` rather than using the default
 - `winapp cert install` modifies the machine certificate store — it persists across reboots and user sessions
 - Use `--timestamp` when signing production builds so the signature survives certificate expiration
 - You can also use the shorthand: `winapp package ./dist --generate-cert --install-cert` to do everything in one command
 
 ## Related skills
-- Need to create a manifest first? See `winapp-manifest` to generate `appxmanifest.xml` with correct publisher info
+- Need to create a manifest first? See `winapp-manifest` to generate `Package.appxmanifest` with correct publisher info
 - Ready to package? See `winapp-package` to create and sign an MSIX in one step
 - Having issues? See `winapp-troubleshoot` for common error solutions
 
 ## Troubleshooting
 | Error | Cause | Solution |
 |-------|-------|----------|
-| "Publisher mismatch" | Cert publisher ≠ manifest publisher | `winapp cert generate --manifest ./appxmanifest.xml` to re-generate with correct publisher |
+| "Publisher mismatch" | Cert publisher ≠ manifest publisher | `winapp cert generate --manifest ./Package.appxmanifest` to re-generate with correct publisher |
 | "Access denied" / "elevation required" | `cert install` needs admin | Run your terminal as Administrator |
 | "Certificate not trusted" | Cert not installed on machine | `winapp cert install ./devcert.pfx` (admin) |
 | "Certificate file already exists" | `devcert.pfx` already present | Use `--if-exists overwrite` or `--if-exists skip` |

--- a/.github/plugin/skills/winapp-cli/troubleshoot/SKILL.md
+++ b/.github/plugin/skills/winapp-cli/troubleshoot/SKILL.md
@@ -15,20 +15,20 @@ Use this skill when:
 | Error | Cause | Solution |
 |-------|-------|----------|
 | "winapp.yaml not found" | Running `restore` or `update` without config | Run `winapp init` first, or `cd` to the directory containing `winapp.yaml` |
-| "appxmanifest.xml not found" | Running `package`, `create-debug-identity`, or `cert generate --manifest` | Run `winapp init` or `winapp manifest generate` first, or pass `--manifest <path>` |
-| "Publisher mismatch" | Certificate publisher ≠ manifest publisher | Regenerate cert: `winapp cert generate --manifest`, or edit `appxmanifest.xml` `Identity.Publisher` to match |
+| "Package.appxmanifest not found" | Running `package`, `create-debug-identity`, or `cert generate --manifest` | Run `winapp init` or `winapp manifest generate` first, or pass `--manifest <path>` |
+| "Publisher mismatch" | Certificate publisher ≠ manifest publisher | Regenerate cert: `winapp cert generate --manifest`, or edit `Package.appxmanifest` `Identity.Publisher` to match |
 | "Access denied" / "elevation required" | `cert install` without admin | Run terminal as Administrator for `winapp cert install` |
 | "Package installation failed" | Cert not trusted, or stale package registration | `winapp cert install ./devcert.pfx` (admin), then `Get-AppxPackage <name> \| Remove-AppxPackage` |
 | "Certificate not trusted" | Dev cert not installed on machine | `winapp cert install ./devcert.pfx` (admin) |
 | "Build tools not found" | First run, tools not yet downloaded | Run `winapp update` to download tools; ensure internet access |
 | "Failed to add package identity" | Stale debug identity or untrusted cert | `Get-AppxPackage *yourapp* \| Remove-AppxPackage` to clean up, then `winapp cert install` and retry |
 | "Certificate file already exists" | `devcert.pfx` already present | Use `winapp cert generate --if-exists overwrite` or `--if-exists skip` |
-| "Manifest already exists" | `appxmanifest.xml` already present | Use `winapp manifest generate --if-exists overwrite` or edit manifest directly |
+| "Manifest already exists" | `Package.appxmanifest` already present | Use `winapp manifest generate --if-exists overwrite` or edit manifest directly |
 
 ## Command selection guide
 
 ```
-Does the project have an appxmanifest.xml?
+Does the project have a Package.appxmanifest?
 ├─ No → Do you want full setup (manifest + config + optional SDKs)?
 │       ├─ Yes → winapp init (adds Windows platform files to existing project)
 │       └─ No, just a manifest → winapp manifest generate
@@ -60,7 +60,7 @@ Does the project have an appxmanifest.xml?
 
 **Important notes:**
 - `winapp init` adds files to an **existing** project — it does not create a new project
-- The key prerequisite for most commands is `appxmanifest.xml`, not `winapp.yaml`
+- The key prerequisite for most commands is `Package.appxmanifest`, not `winapp.yaml`
 - `winapp.yaml` is only needed for SDK version management (`restore`/`update`)
 - Projects with NuGet package references (e.g., `.csproj` referencing `Microsoft.Windows.SDK.BuildTools`) can use winapp commands without `winapp.yaml`
 - For Electron projects, use the npm package (`npm install --save-dev @microsoft/winappcli`) which includes Node.js-specific commands under `npx winapp node`
@@ -86,17 +86,17 @@ For full details, see the [Debugging Guide](https://github.com/microsoft/WinAppC
 
 | Command | Requires | Creates/Modifies |
 |---------|----------|------------------|
-| `init` | Existing project (any framework) | `winapp.yaml`, `.winapp/`, `appxmanifest.xml`, `Assets/`, `.gitignore` update |
+| `init` | Existing project (any framework) | `winapp.yaml`, `.winapp/`, `Package.appxmanifest`, `Assets/`, `.gitignore` update |
 | `restore` | `winapp.yaml` | `.winapp/packages/`, generated projections |
 | `update` | `winapp.yaml` | Updates versions in `winapp.yaml`, reinstalls packages |
-| `manifest generate` | Nothing | `appxmanifest.xml`, `Assets/` |
-| `manifest update-assets` | `appxmanifest.xml` + source image | Regenerates `Assets/` icons |
-| `cert generate` | Nothing (or `appxmanifest.xml` for publisher) | `devcert.pfx` |
+| `manifest generate` | Nothing | `Package.appxmanifest`, `Assets/` |
+| `manifest update-assets` | `Package.appxmanifest` + source image | Regenerates `Assets/` icons |
+| `cert generate` | Nothing (or `Package.appxmanifest` for publisher) | `devcert.pfx` |
 | `cert install` | Certificate file + admin | Machine certificate store |
-| `create-debug-identity` | `appxmanifest.xml` + exe + trusted cert | Registers sparse package with Windows |
-| `run` | Build output folder + `appxmanifest.xml` | Registers loose layout package, launches app |
-| `unregister` | `appxmanifest.xml` (auto-detect or `--manifest`) | Removes dev-mode package registrations |
-| `package` | Build output + `appxmanifest.xml` | `.msix` file |
+| `create-debug-identity` | `Package.appxmanifest` + exe + trusted cert | Registers sparse package with Windows |
+| `run` | Build output folder + `Package.appxmanifest` | Registers loose layout package, launches app |
+| `unregister` | `Package.appxmanifest` (auto-detect or `--manifest`) | Removes dev-mode package registrations |
+| `package` | Build output + `Package.appxmanifest` | `.msix` file |
 | `sign` | File + certificate | Signed file (in-place) |
 | `create-external-catalog` | Directory with executables | `CodeIntegrityExternal.cat` |
 | `tool <name>` | Nothing (auto-downloads tools) | Runs SDK tool directly |
@@ -120,7 +120,7 @@ For full details, see the [Debugging Guide](https://github.com/microsoft/WinAppC
 
 ## Related skills
 - **Setup & init**: `winapp-setup` — adding Windows support to a project
-- **Manifest**: `winapp-manifest` — creating and editing `appxmanifest.xml`
+- **Manifest**: `winapp-manifest` — creating and editing `Package.appxmanifest`
 - **Signing**: `winapp-signing` — certificate generation and management
 - **Packaging**: `winapp-package` — creating MSIX installers
 - **Identity**: `winapp-identity` — enabling package identity for Windows APIs

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -86,7 +86,7 @@ winapp run .\build\Debug --no-launch
 
 **Step 2:** Configure your IDE to launch via the AUMID or the **execution alias** (not the exe directly). 
 * Launching with AUMID: Use the command `start shell:AppsFolder\<AUMID>`. `winapp run` outputs the AUMID when the app is registered.
-* Launching with the alias: The alias must be defined in the appxmanifest.xml (or Package.appxmanifest).
+* Launching with the alias: The alias must be defined in the Package.appxmanifest.
 
 > **Important:** Simply launching the exe in the build folder will **not** give it identity. The app must be started via AUMID activation or its execution alias. This is how loose layout packages work - identity is tied to the activation path, not the exe file.
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -86,7 +86,7 @@ winapp run .\build\Debug --no-launch
 
 **Step 2:** Configure your IDE to launch via the AUMID or the **execution alias** (not the exe directly). 
 * Launching with AUMID: Use the command `start shell:AppsFolder\<AUMID>`. `winapp run` outputs the AUMID when the app is registered.
-* Launching with the alias: The alias must be defined in the Package.appxmanifest.
+* Launching with the alias: The alias must be defined in your manifest (`Package.appxmanifest` preferred, `appxmanifest.xml` also supported).
 
 > **Important:** Simply launching the exe in the build folder will **not** give it identity. The app must be started via AUMID activation or its execution alias. This is how loose layout packages work - identity is tied to the activation path, not the exe file.
 

--- a/docs/dotnet-run-support.md
+++ b/docs/dotnet-run-support.md
@@ -131,7 +131,7 @@ Disable run support for a project:
 Specify manifest path:
 ```xml
 <PropertyGroup>
-  <WinAppManifestPath>$(MSBuildProjectDirectory)\custom\appxmanifest.xml</WinAppManifestPath>
+  <WinAppManifestPath>$(MSBuildProjectDirectory)\custom\Package.appxmanifest</WinAppManifestPath>
 </PropertyGroup>
 ```
 

--- a/docs/fragments/node-commands.md
+++ b/docs/fragments/node-commands.md
@@ -32,7 +32,7 @@ npx winapp node create-addon --template cs --name MyCsAddon
 
 ### `node add-electron-debug-identity`
 
-Add package identity to the Electron debug process using sparse packaging.  Creates a backup of `electron.exe`, generates a sparse MSIX manifest, adds identity to the executable, and registers the sparse package.  Requires an `Package.appxmanifest` (create one with `winapp init` or `winapp manifest generate`).
+Add package identity to the Electron debug process using sparse packaging.  Creates a backup of `electron.exe`, generates a sparse MSIX manifest, adds identity to the executable, and registers the sparse package.  Requires a `Package.appxmanifest` (create one with `winapp init` or `winapp manifest generate`).
 
 ```bash
 npx winapp node add-electron-debug-identity [options]

--- a/docs/fragments/node-commands.md
+++ b/docs/fragments/node-commands.md
@@ -32,7 +32,7 @@ npx winapp node create-addon --template cs --name MyCsAddon
 
 ### `node add-electron-debug-identity`
 
-Add package identity to the Electron debug process using sparse packaging.  Creates a backup of `electron.exe`, generates a sparse MSIX manifest, adds identity to the executable, and registers the sparse package.  Requires an `appxmanifest.xml` (create one with `winapp init` or `winapp manifest generate`).
+Add package identity to the Electron debug process using sparse packaging.  Creates a backup of `electron.exe`, generates a sparse MSIX manifest, adds identity to the executable, and registers the sparse package.  Requires an `Package.appxmanifest` (create one with `winapp init` or `winapp manifest generate`).
 
 ```bash
 npx winapp node add-electron-debug-identity [options]
@@ -42,7 +42,7 @@ npx winapp node add-electron-debug-identity [options]
 
 | Flag | Description |
 |------|-------------|
-| `--manifest <path>` | Path to custom `appxmanifest.xml` (default: `appxmanifest.xml` in current directory) |
+| `--manifest <path>` | Path to custom `Package.appxmanifest` (default: `Package.appxmanifest` in current directory) |
 | `--no-install` | Do not install the package after creation |
 | `--keep-identity` | Keep the manifest identity as-is, without appending `.debug` suffix |
 | `--verbose` | Enable verbose output |
@@ -53,7 +53,7 @@ npx winapp node add-electron-debug-identity [options]
 
 ```bash
 npx winapp node add-electron-debug-identity
-npx winapp node add-electron-debug-identity --manifest ./custom/appxmanifest.xml
+npx winapp node add-electron-debug-identity --manifest ./custom/Package.appxmanifest
 ```
 
 ---

--- a/docs/fragments/skills/winapp-cli/frameworks.md
+++ b/docs/fragments/skills/winapp-cli/frameworks.md
@@ -43,7 +43,7 @@ Additional Electron guides:
 ### .NET (WPF, WinForms, Console)
 .NET projects have direct access to Windows APIs. Key differences:
 - Projects with NuGet references to `Microsoft.Windows.SDK.BuildTools` or `Microsoft.WindowsAppSDK` **don't need `winapp.yaml`** — winapp auto-detects SDK versions from the `.csproj`
-- The key prerequisite is `appxmanifest.xml`, not `winapp.yaml`
+- The key prerequisite is `Package.appxmanifest`, not `winapp.yaml`
 - No native addon step needed — unlike Electron, .NET can call Windows APIs directly
 - `winapp init` automatically adds the `Microsoft.Windows.SDK.BuildTools.WinApp` NuGet package, enabling `dotnet run` with automatic identity registration
 
@@ -96,7 +96,7 @@ C++ projects use winapp primarily for SDK projections (CppWinRT headers) and pac
 
 **Key rules:**
 - **GUI apps** (Flutter, Tauri, WPF): use `winapp run <build-output>` — launches via AUMID activation
-- **Console apps** (C++, Rust, .NET console): use `winapp run <build-output> --with-alias` — launches via execution alias to preserve stdin/stdout. Requires `uap5:ExecutionAlias` in `appxmanifest.xml`
+- **Console apps** (C++, Rust, .NET console): use `winapp run <build-output> --with-alias` — launches via execution alias to preserve stdin/stdout. Requires `uap5:ExecutionAlias` in `Package.appxmanifest`
 - **Electron**: different mechanism — uses `npx winapp node add-electron-debug-identity` because `electron.exe` is in `node_modules/`, not your build output
 - **Startup debugging (any framework)**: use `winapp create-debug-identity <exe>` so your IDE can F5-launch the exe with identity from the first instruction
 
@@ -104,7 +104,7 @@ For full debugging scenarios and IDE setup, see the [Debugging Guide](https://gi
 
 ## Related skills
 - **Setup**: `winapp-setup` — initial project setup with `winapp init`
-- **Manifest**: `winapp-manifest` — creating and customizing `appxmanifest.xml`
+- **Manifest**: `winapp-manifest` — creating and customizing `Package.appxmanifest`
 - **Signing**: `winapp-signing` — certificate generation and management
 - **Packaging**: `winapp-package` — creating MSIX installers from build output
 - **Identity**: `winapp-identity` — enabling package identity for Windows APIs during development

--- a/docs/fragments/skills/winapp-cli/identity.md
+++ b/docs/fragments/skills/winapp-cli/identity.md
@@ -9,7 +9,7 @@ Use this skill when:
 
 ## Prerequisites
 
-1. **`appxmanifest.xml`** in your project — from `winapp init` or `winapp manifest generate`
+1. **`Package.appxmanifest`** in your project — from `winapp init` or `winapp manifest generate`
 2. **Built executable** — the `.exe` your app runs from
 
 ## What is package identity?
@@ -34,7 +34,7 @@ A standard `.exe` (from `dotnet build`, `cmake`, etc.) does **not** have identit
 winapp create-debug-identity ./bin/Release/myapp.exe
 
 # Specify manifest location
-winapp create-debug-identity ./bin/Release/myapp.exe --manifest ./appxmanifest.xml
+winapp create-debug-identity ./bin/Release/myapp.exe --manifest ./Package.appxmanifest
 ```
 
 ### Keep the original package identity
@@ -54,7 +54,7 @@ winapp create-debug-identity ./myapp.exe --no-install
 
 ## What the command does
 
-1. **Reads `appxmanifest.xml`** — extracts identity, capabilities, and assets
+1. **Reads `Package.appxmanifest`** — extracts identity, capabilities, and assets
 2. **Creates a sparse package layout** in a temp directory
 3. **Appends `.debug`** to the package name (unless `--keep-identity`) to avoid conflicts
 4. **Registers with Windows** via `Add-AppxPackage -ExternalLocation` — makes your exe "identity-aware"
@@ -63,16 +63,16 @@ After running, launch your exe normally — Windows will recognize it as having 
 
 ## Recommended workflow
 
-1. **Setup** — `winapp init --use-defaults` (creates `appxmanifest.xml`)
+1. **Setup** — `winapp init --use-defaults` (creates `Package.appxmanifest`)
 2. **Generate development certificate** — `winapp cert generate`
 3. **Build** your app
 4. **Register identity** — `winapp create-debug-identity ./bin/myapp.exe`
 5. **Run** your app — identity-requiring APIs now work
-6. **Re-run step 4** whenever you change `appxmanifest.xml` or `Assets/`
+6. **Re-run step 4** whenever you change `Package.appxmanifest` or `Assets/`
 
 ## Tips
 
-- You must re-run `create-debug-identity` after any changes to `appxmanifest.xml` or image assets
+- You must re-run `create-debug-identity` after any changes to `Package.appxmanifest` or image assets
 - The debug identity persists across reboots until explicitly removed
 - To remove: `Get-AppxPackage *yourapp.debug* | Remove-AppxPackage`
 - If you have both a debug identity and an installed MSIX, they may conflict — use `--keep-identity` carefully
@@ -127,7 +127,7 @@ winapp create-debug-identity .\bin\Debug\myapp.exe
 For full details including IDE setup examples, see the [Debugging Guide](https://github.com/microsoft/WinAppCli/blob/main/docs/debugging.md).
 
 ## Related skills
-- Need a manifest? See `winapp-manifest` to generate `appxmanifest.xml`
+- Need a manifest? See `winapp-manifest` to generate `Package.appxmanifest`
 - Need a certificate? See `winapp-signing` — a trusted cert is required for identity registration
 - Ready for full MSIX distribution? See `winapp-package` to create an installer
 - Having issues? See `winapp-troubleshoot` for common error solutions
@@ -135,7 +135,7 @@ For full details including IDE setup examples, see the [Debugging Guide](https:/
 ## Troubleshooting
 | Error | Cause | Solution |
 |-------|-------|----------|
-| "appxmanifest.xml not found" | No manifest in current directory | Run `winapp init` or `winapp manifest generate`, or pass `--manifest` |
+| "Package.appxmanifest not found" | No manifest in current directory | Run `winapp init` or `winapp manifest generate`, or pass `--manifest` |
 | "Failed to add package identity" | Previous registration stale or cert untrusted | Run `winapp unregister` to remove stale packages, then `winapp cert install ./devcert.pfx` (admin) |
 | "Access denied" | Cert not trusted or permission issue | Run `winapp cert install ./devcert.pfx` as admin |
 | APIs still fail after registration | App launched before registration completed | Close app, re-run `create-debug-identity`, then relaunch |

--- a/docs/fragments/skills/winapp-cli/manifest.md
+++ b/docs/fragments/skills/winapp-cli/manifest.md
@@ -1,7 +1,7 @@
 ## When to use
 
 Use this skill when:
-- **Creating `appxmanifest.xml`** for a project that doesn't have one yet
+- **Creating `Package.appxmanifest`** for a project that doesn't have one yet
 - **Generating app icon assets** from a single source image
 - **Understanding manifest structure** for package identity and capabilities
 
@@ -12,7 +12,7 @@ Use this skill when:
 
 ## Key concepts
 
-**`appxmanifest.xml`** is the key prerequisite for most winapp commands — it's more important than `winapp.yaml`. It declares:
+**`Package.appxmanifest`** is the key prerequisite for most winapp commands — it's more important than `winapp.yaml`. It declares:
 - **Package identity** — name, publisher, version
 - **App entry point** — which executable to launch
 - **Capabilities** — what the app can access (internet, file system, etc.)
@@ -50,7 +50,7 @@ winapp manifest generate --if-exists overwrite
 ```
 
 Output:
-- `appxmanifest.xml` — the manifest file
+- `Package.appxmanifest` — the manifest file
 - `Assets/` — default app icons in required sizes (Square44x44Logo, Square150x150Logo, Wide310x150Logo, etc.)
 
 ### Update app icons from a source image
@@ -63,7 +63,7 @@ winapp manifest update-assets ./my-logo.png
 winapp manifest update-assets ./my-logo.svg
 
 # Specify manifest location (if not in current directory)
-winapp manifest update-assets ./my-logo.png --manifest ./path/to/appxmanifest.xml
+winapp manifest update-assets ./my-logo.png --manifest ./path/to/Package.appxmanifest
 
 # Generate light theme variants from a separate image
 winapp manifest update-assets ./my-logo.png --light-image ./my-logo-light.png
@@ -90,7 +90,7 @@ winapp manifest add-alias
 winapp manifest add-alias --name myapp
 
 # Target a specific manifest file
-winapp manifest add-alias --manifest ./path/to/appxmanifest.xml
+winapp manifest add-alias --manifest ./path/to/Package.appxmanifest
 ```
 
 This adds a `uap5:AppExecutionAlias` extension to the manifest. If the alias already exists, the command reports it and exits successfully.
@@ -109,14 +109,14 @@ winapp manifest add-alias
 winapp manifest add-alias --name myapp
 
 # Target a specific manifest file
-winapp manifest add-alias --manifest ./path/to/appxmanifest.xml
+winapp manifest add-alias --manifest ./path/to/Package.appxmanifest
 ```
 
 This adds a `uap5:AppExecutionAlias` extension to the manifest. If the alias already exists, the command reports it and exits successfully.
 
 ## Manifest structure overview
 
-A typical `appxmanifest.xml` looks like:
+A typical `Package.appxmanifest` looks like:
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
@@ -155,10 +155,10 @@ Key fields to edit:
 
 - Always ensure `Identity.Publisher` matches your signing certificate — use `winapp cert generate --manifest` to auto-match
 - The `sparse` template adds `uap10:AllowExternalContent="true"` for apps that need identity but run outside the MSIX container
-- You can manually edit `appxmanifest.xml` after generation — it's a standard XML file
+- You can manually edit `Package.appxmanifest` after generation — it's a standard XML file
 - Image assets must match the paths referenced in the manifest — `update-assets` handles this automatically
 - For logos, transparent PNGs or SVGs work best. SVG source images are rendered as vectors directly at each target size, producing pixel-perfect results. Use a square image for best results across all sizes.
-- **`$targetnametoken$` placeholder:** When `winapp manifest generate` creates `appxmanifest.xml`, it sets `Application.Executable` to `$targetnametoken$.exe` by default. This is a valid placeholder that gets automatically resolved by `winapp package --executable <name>` at packaging time — you rarely need to override it during manifest generation. If `--executable` is provided to `winapp manifest generate`, winapp reads `FileVersionInfo` from the actual exe to auto-fill package name, description, publisher, and extract an icon, so the exe must already exist on disk.
+- **`$targetnametoken$` placeholder:** When `winapp manifest generate` creates `Package.appxmanifest`, it sets `Application.Executable` to `$targetnametoken$.exe` by default. This is a valid placeholder that gets automatically resolved by `winapp package --executable <name>` at packaging time — you rarely need to override it during manifest generation. If `--executable` is provided to `winapp manifest generate`, winapp reads `FileVersionInfo` from the actual exe to auto-fill package name, description, publisher, and extract an icon, so the exe must already exist on disk.
 
 ## Related skills
 
@@ -168,6 +168,6 @@ Key fields to edit:
 ## Troubleshooting
 | Error | Cause | Solution |
 |-------|-------|----------|
-| "Manifest already exists" | `appxmanifest.xml` present | Use `--if-exists overwrite` to replace, or edit existing file directly |
+| "Manifest already exists" | `Package.appxmanifest` present | Use `--if-exists overwrite` to replace, or edit existing file directly |
 | "Invalid source image" | Image too small or wrong format | Use PNG or SVG, at least 400x400 pixels |
 | "Publisher mismatch" during packaging | Manifest publisher ≠ cert publisher | Edit `Identity.Publisher` in manifest, or regenerate cert with `--manifest` |

--- a/docs/fragments/skills/winapp-cli/package.md
+++ b/docs/fragments/skills/winapp-cli/package.md
@@ -10,7 +10,7 @@ Use this skill when:
 
 Before packaging, you need:
 1. **Built app output** in a folder (e.g., `bin/Release/`, `dist/`, `build/`)
-2. **`appxmanifest.xml`** — from `winapp init` or `winapp manifest generate`
+2. **`Package.appxmanifest`** — from `winapp init` or `winapp manifest generate`
 3. **Certificate** (optional) — `devcert.pfx` from `winapp cert generate` for signing
 
 ## Usage
@@ -22,7 +22,7 @@ Before packaging, you need:
 winapp package ./bin/Release
 
 # Specify manifest location explicitly
-winapp package ./dist --manifest ./appxmanifest.xml
+winapp package ./dist --manifest ./Package.appxmanifest
 ```
 
 ### Package and sign in one step
@@ -64,7 +64,7 @@ winapp package ./dist --name "MyApp_1.0.0_x64" --cert ./devcert.pfx
 
 ## What the command does
 
-1. **Locates `appxmanifest.xml`** — looks in input folder, then current directory (or uses `--manifest`)
+1. **Locates `Package.appxmanifest`** — looks in input folder, then current directory (or uses `--manifest`)
 2. **Copies manifest + assets** into a staging layout alongside your app files
 3. **Generates `resources.pri`** — Package Resource Index for UWP-style resource lookup (skip with `--skip-pri`)
 4. **Runs `makeappx pack`** — creates the `.msix` package file
@@ -129,21 +129,21 @@ Use the `microsoft/setup-winapp` action to install winapp on GitHub-hosted runne
 ## Tips
 
 - The `package` command aliases to `pack` — both work identically
-- `appxmanifest.xml` Publisher must match the certificate publisher — use `winapp cert generate --manifest` to ensure they match
+- `Package.appxmanifest` Publisher must match the certificate publisher — use `winapp cert generate --manifest` to ensure they match
 - Use `--skip-pri` if your app doesn't use Windows resource loading (e.g., most Electron/Rust/C++ apps without UWP resources)
 - For framework-specific packaging paths (Electron, .NET, Rust, etc.), see the `winapp-frameworks` skill
-- The `--executable` flag overrides the entry point in the manifest — useful when your exe name differs from what's in `appxmanifest.xml`
+- The `--executable` flag overrides the entry point in the manifest — useful when your exe name differs from what's in `Package.appxmanifest`
 - For production distribution, use a certificate from a trusted CA and add `--timestamp` when signing with `winapp sign`
 
 ## Related skills
-- Need a manifest first? See `winapp-manifest` to generate `appxmanifest.xml`
+- Need a manifest first? See `winapp-manifest` to generate `Package.appxmanifest`
 - Need a certificate? See `winapp-signing` for certificate generation and management
 - Having issues? See `winapp-troubleshoot` for a command selection flowchart and error solutions
 
 ## Troubleshooting
 | Error | Cause | Solution |
 |-------|-------|----------|
-| "appxmanifest.xml not found" | No manifest in input folder or current dir | Run `winapp init` or `winapp manifest generate` first |
+| "Package.appxmanifest not found" | No manifest in input folder or current dir | Run `winapp init` or `winapp manifest generate` first |
 | "Publisher mismatch" | Cert publisher ≠ manifest publisher | Regenerate cert with `winapp cert generate --manifest`, or edit manifest |
 | "Package installation failed" | Cert not trusted or stale package | Run `winapp cert install ./devcert.pfx` (admin), then `Get-AppxPackage <name> \| Remove-AppxPackage` |
 | "makeappx not found" | Build tools not downloaded | Run `winapp update` or `winapp tool makeappx --help` to trigger download |

--- a/docs/fragments/skills/winapp-cli/setup.md
+++ b/docs/fragments/skills/winapp-cli/setup.md
@@ -23,7 +23,7 @@ You need an **existing app project** — `winapp init` does **not** create new p
 
 ## Key concepts
 
-**`appxmanifest.xml`** is the most important file winapp creates — it declares your app's identity, capabilities, and visual assets. Most winapp commands require it (`package`, `run`, `cert generate --manifest`).
+**`Package.appxmanifest`** is the most important file winapp creates — it declares your app's identity, capabilities, and visual assets. Most winapp commands require it (`package`, `run`, `cert generate --manifest`).
 
 **`winapp.yaml`** is only needed for SDK version management via `restore`/`update`. Projects that already reference Windows SDK packages (e.g., via NuGet in a `.csproj`) can use winapp commands without it.
 
@@ -48,7 +48,7 @@ winapp init --use-defaults --setup-sdks preview
 ```
 
 After `init`, your project will contain:
-- `appxmanifest.xml` — package identity and capabilities
+- `Package.appxmanifest` — package identity and capabilities
 - `Assets/` — default app icons (Square44x44Logo, Square150x150Logo, etc.)
 - `winapp.yaml` — SDK version pinning for `restore`/`update`
 - `.winapp/` — downloaded SDK packages and generated projections
@@ -85,7 +85,7 @@ This updates `winapp.yaml` with the latest versions and reinstalls packages.
 winapp run ./bin/Debug
 
 # Launch with custom manifest and pass arguments to the app
-winapp run ./dist --manifest ./out/AppxManifest.xml --args "--my-flag value"
+winapp run ./dist --manifest ./out/Package.appxmanifest --args "--my-flag value"
 
 # Register identity without launching (useful for attaching a debugger manually)
 winapp run ./bin/Debug --no-launch
@@ -119,7 +119,7 @@ For full debugging scenarios and IDE setup, see the [Debugging Guide](https://gi
 ## Recommended workflow
 
 1. **Initialize** — `winapp init --use-defaults` in your existing project
-2. **Configure** — edit `appxmanifest.xml` to add capabilities your app needs (e.g., `runFullTrust`, `internetClient`)
+2. **Configure** — edit `Package.appxmanifest` to add capabilities your app needs (e.g., `runFullTrust`, `internetClient`)
 3. **Build** — build your app as usual (dotnet build, cmake, npm run build, etc.)
 4. **Run with identity** — `winapp run ./bin/Debug` to register identity and launch for debugging
 5. **Package** — `winapp package ./bin/Release --cert ./devcert.pfx` to create MSIX
@@ -127,12 +127,12 @@ For full debugging scenarios and IDE setup, see the [Debugging Guide](https://gi
 ## Tips
 
 - Use `--use-defaults` (alias: `--no-prompt`) in CI/CD pipelines and scripts to avoid interactive prompts
-- If you only need `appxmanifest.xml` without SDK setup, use `winapp manifest generate` instead of `init`
+- If you only need `Package.appxmanifest` without SDK setup, use `winapp manifest generate` instead of `init`
 - `winapp init` is idempotent for the config file — re-running it won't overwrite an existing `winapp.yaml` unless you use `--config-only`
 - For Electron projects, prefer `npm install --save-dev @microsoft/winappcli` and use `npx winapp init` instead of the standalone CLI
 
 ## Related skills
-- After setup, see `winapp-manifest` to customize your `appxmanifest.xml`
+- After setup, see `winapp-manifest` to customize your `Package.appxmanifest`
 - Ready to package? See `winapp-package` to create an MSIX installer
 - Need a certificate? See `winapp-signing` for certificate generation
 - Not sure which command to use? See `winapp-troubleshoot` for a command selection flowchart

--- a/docs/fragments/skills/winapp-cli/signing.md
+++ b/docs/fragments/skills/winapp-cli/signing.md
@@ -12,7 +12,7 @@ Use this skill when:
 
 ## Key concepts
 
-**Publisher matching:** The publisher in your certificate (e.g., `CN=MyCompany`) must exactly match the `Publisher` attribute in `appxmanifest.xml`. Use `--manifest` when generating to auto-match.
+**Publisher matching:** The publisher in your certificate (e.g., `CN=MyCompany`) must exactly match the `Publisher` attribute in `Package.appxmanifest`. Use `--manifest` when generating to auto-match.
 
 **Dev vs. production certs:** `winapp cert generate` creates self-signed certificates for **local testing only**. For production distribution (Microsoft Store or enterprise), obtain a certificate from a trusted Certificate Authority.
 
@@ -23,11 +23,11 @@ Use this skill when:
 ### Generate a development certificate
 
 ```powershell
-# Auto-infer publisher from appxmanifest.xml in the current directory
+# Auto-infer publisher from Package.appxmanifest in the current directory
 winapp cert generate
 
 # Explicitly point to a manifest
-winapp cert generate --manifest ./path/to/appxmanifest.xml
+winapp cert generate --manifest ./path/to/Package.appxmanifest
 
 # Set publisher manually (when no manifest exists yet)
 winapp cert generate --publisher "CN=Contoso, O=Contoso Ltd, C=US"
@@ -80,21 +80,21 @@ Note: The `package` command can sign automatically when you pass `--cert`, so yo
 
 ## Tips
 
-- Always use `--manifest` (or have `appxmanifest.xml` in the working directory) when generating certs to ensure the publisher matches automatically
+- Always use `--manifest` (or have `Package.appxmanifest` in the working directory) when generating certs to ensure the publisher matches automatically
 - For CI/CD, store the PFX as a secret and pass the password via `--password` rather than using the default
 - `winapp cert install` modifies the machine certificate store — it persists across reboots and user sessions
 - Use `--timestamp` when signing production builds so the signature survives certificate expiration
 - You can also use the shorthand: `winapp package ./dist --generate-cert --install-cert` to do everything in one command
 
 ## Related skills
-- Need to create a manifest first? See `winapp-manifest` to generate `appxmanifest.xml` with correct publisher info
+- Need to create a manifest first? See `winapp-manifest` to generate `Package.appxmanifest` with correct publisher info
 - Ready to package? See `winapp-package` to create and sign an MSIX in one step
 - Having issues? See `winapp-troubleshoot` for common error solutions
 
 ## Troubleshooting
 | Error | Cause | Solution |
 |-------|-------|----------|
-| "Publisher mismatch" | Cert publisher ≠ manifest publisher | `winapp cert generate --manifest ./appxmanifest.xml` to re-generate with correct publisher |
+| "Publisher mismatch" | Cert publisher ≠ manifest publisher | `winapp cert generate --manifest ./Package.appxmanifest` to re-generate with correct publisher |
 | "Access denied" / "elevation required" | `cert install` needs admin | Run your terminal as Administrator |
 | "Certificate not trusted" | Cert not installed on machine | `winapp cert install ./devcert.pfx` (admin) |
 | "Certificate file already exists" | `devcert.pfx` already present | Use `--if-exists overwrite` or `--if-exists skip` |

--- a/docs/fragments/skills/winapp-cli/troubleshoot.md
+++ b/docs/fragments/skills/winapp-cli/troubleshoot.md
@@ -10,20 +10,20 @@ Use this skill when:
 | Error | Cause | Solution |
 |-------|-------|----------|
 | "winapp.yaml not found" | Running `restore` or `update` without config | Run `winapp init` first, or `cd` to the directory containing `winapp.yaml` |
-| "appxmanifest.xml not found" | Running `package`, `create-debug-identity`, or `cert generate --manifest` | Run `winapp init` or `winapp manifest generate` first, or pass `--manifest <path>` |
-| "Publisher mismatch" | Certificate publisher ≠ manifest publisher | Regenerate cert: `winapp cert generate --manifest`, or edit `appxmanifest.xml` `Identity.Publisher` to match |
+| "Package.appxmanifest not found" | Running `package`, `create-debug-identity`, or `cert generate --manifest` | Run `winapp init` or `winapp manifest generate` first, or pass `--manifest <path>` |
+| "Publisher mismatch" | Certificate publisher ≠ manifest publisher | Regenerate cert: `winapp cert generate --manifest`, or edit `Package.appxmanifest` `Identity.Publisher` to match |
 | "Access denied" / "elevation required" | `cert install` without admin | Run terminal as Administrator for `winapp cert install` |
 | "Package installation failed" | Cert not trusted, or stale package registration | `winapp cert install ./devcert.pfx` (admin), then `Get-AppxPackage <name> \| Remove-AppxPackage` |
 | "Certificate not trusted" | Dev cert not installed on machine | `winapp cert install ./devcert.pfx` (admin) |
 | "Build tools not found" | First run, tools not yet downloaded | Run `winapp update` to download tools; ensure internet access |
 | "Failed to add package identity" | Stale debug identity or untrusted cert | `Get-AppxPackage *yourapp* \| Remove-AppxPackage` to clean up, then `winapp cert install` and retry |
 | "Certificate file already exists" | `devcert.pfx` already present | Use `winapp cert generate --if-exists overwrite` or `--if-exists skip` |
-| "Manifest already exists" | `appxmanifest.xml` already present | Use `winapp manifest generate --if-exists overwrite` or edit manifest directly |
+| "Manifest already exists" | `Package.appxmanifest` already present | Use `winapp manifest generate --if-exists overwrite` or edit manifest directly |
 
 ## Command selection guide
 
 ```
-Does the project have an appxmanifest.xml?
+Does the project have a Package.appxmanifest?
 ├─ No → Do you want full setup (manifest + config + optional SDKs)?
 │       ├─ Yes → winapp init (adds Windows platform files to existing project)
 │       └─ No, just a manifest → winapp manifest generate
@@ -55,7 +55,7 @@ Does the project have an appxmanifest.xml?
 
 **Important notes:**
 - `winapp init` adds files to an **existing** project — it does not create a new project
-- The key prerequisite for most commands is `appxmanifest.xml`, not `winapp.yaml`
+- The key prerequisite for most commands is `Package.appxmanifest`, not `winapp.yaml`
 - `winapp.yaml` is only needed for SDK version management (`restore`/`update`)
 - Projects with NuGet package references (e.g., `.csproj` referencing `Microsoft.Windows.SDK.BuildTools`) can use winapp commands without `winapp.yaml`
 - For Electron projects, use the npm package (`npm install --save-dev @microsoft/winappcli`) which includes Node.js-specific commands under `npx winapp node`
@@ -81,17 +81,17 @@ For full details, see the [Debugging Guide](https://github.com/microsoft/WinAppC
 
 | Command | Requires | Creates/Modifies |
 |---------|----------|------------------|
-| `init` | Existing project (any framework) | `winapp.yaml`, `.winapp/`, `appxmanifest.xml`, `Assets/`, `.gitignore` update |
+| `init` | Existing project (any framework) | `winapp.yaml`, `.winapp/`, `Package.appxmanifest`, `Assets/`, `.gitignore` update |
 | `restore` | `winapp.yaml` | `.winapp/packages/`, generated projections |
 | `update` | `winapp.yaml` | Updates versions in `winapp.yaml`, reinstalls packages |
-| `manifest generate` | Nothing | `appxmanifest.xml`, `Assets/` |
-| `manifest update-assets` | `appxmanifest.xml` + source image | Regenerates `Assets/` icons |
-| `cert generate` | Nothing (or `appxmanifest.xml` for publisher) | `devcert.pfx` |
+| `manifest generate` | Nothing | `Package.appxmanifest`, `Assets/` |
+| `manifest update-assets` | `Package.appxmanifest` + source image | Regenerates `Assets/` icons |
+| `cert generate` | Nothing (or `Package.appxmanifest` for publisher) | `devcert.pfx` |
 | `cert install` | Certificate file + admin | Machine certificate store |
-| `create-debug-identity` | `appxmanifest.xml` + exe + trusted cert | Registers sparse package with Windows |
-| `run` | Build output folder + `appxmanifest.xml` | Registers loose layout package, launches app |
-| `unregister` | `appxmanifest.xml` (auto-detect or `--manifest`) | Removes dev-mode package registrations |
-| `package` | Build output + `appxmanifest.xml` | `.msix` file |
+| `create-debug-identity` | `Package.appxmanifest` + exe + trusted cert | Registers sparse package with Windows |
+| `run` | Build output folder + `Package.appxmanifest` | Registers loose layout package, launches app |
+| `unregister` | `Package.appxmanifest` (auto-detect or `--manifest`) | Removes dev-mode package registrations |
+| `package` | Build output + `Package.appxmanifest` | `.msix` file |
 | `sign` | File + certificate | Signed file (in-place) |
 | `create-external-catalog` | Directory with executables | `CodeIntegrityExternal.cat` |
 | `tool <name>` | Nothing (auto-downloads tools) | Runs SDK tool directly |
@@ -115,7 +115,7 @@ For full details, see the [Debugging Guide](https://github.com/microsoft/WinAppC
 
 ## Related skills
 - **Setup & init**: `winapp-setup` — adding Windows support to a project
-- **Manifest**: `winapp-manifest` — creating and editing `appxmanifest.xml`
+- **Manifest**: `winapp-manifest` — creating and editing `Package.appxmanifest`
 - **Signing**: `winapp-signing` — certificate generation and management
 - **Packaging**: `winapp-package` — creating MSIX installers
 - **Identity**: `winapp-identity` — enabling package identity for Windows APIs

--- a/docs/guides/cpp.md
+++ b/docs/guides/cpp.md
@@ -137,12 +137,12 @@ When prompted:
 - **Setup SDKs**: Select "Stable SDKs" to download Windows App SDK and generate C++ headers
 
 This command will:
-- Create `appxmanifest.xml` — the manifest that defines your app's identity
+- Create `Package.appxmanifest` — the manifest that defines your app's identity
 - Create `Assets` folder — icons required for MSIX packaging and Store submission
 - Create a `.winapp` folder with Windows App SDK headers and libraries
 - Create a `winapp.yaml` configuration file for pinning SDK versions
 
-You can open `appxmanifest.xml` to further customize properties like the display name, publisher, and capabilities.
+You can open `Package.appxmanifest` to further customize properties like the display name, publisher, and capabilities.
 
 ### Add Execution Alias (for console apps)
 
@@ -154,7 +154,7 @@ You can add one automatically:
 winapp manifest add-alias
 ```
 
-Or manually: open `appxmanifest.xml` and add the `uap5` namespace to the `<Package>` tag if it's missing, and then add the extension inside `<Applications><Application><Extensions>...`:
+Or manually: open `Package.appxmanifest` and add the `uap5` namespace to the `<Package>` tag if it's missing, and then add the extension inside `<Applications><Application><Extensions>...`:
 
 ```diff
 <Package
@@ -424,7 +424,7 @@ MSIX packages must be signed. For local testing, generate a self-signed developm
 winapp cert generate --if-exists skip
 ```
 
-> **Tip**: The certificate's publisher must match the `Publisher` in your `appxmanifest.xml`. The `cert generate` command reads this automatically from your manifest.
+> **Tip**: The certificate's publisher must match the `Publisher` in your `Package.appxmanifest`. The `cert generate` command reads this automatically from your manifest.
 
 ### Sign and Pack
 
@@ -435,7 +435,7 @@ Now you can package and sign:
 winapp pack .\dist --cert .\devcert.pfx 
 ```
 
-> **Tip**: The `pack` command automatically uses the appxmanifest.xml from your current directory and copies it to the target folder before packaging. The generated `.msix` file will be in the current directory.
+> **Tip**: The `pack` command automatically uses the Package.appxmanifest from your current directory and copies it to the target folder before packaging. The generated `.msix` file will be in the current directory.
 
 ### Install the Certificate
 
@@ -465,7 +465,7 @@ cpp-app
 
 You should see the "Package Family Name" output, confirming it's installed and running with identity.
 
-> **Tip**: If you need to repackage your app (e.g., after code changes), increment the `Version` in your `appxmanifest.xml` before running `winapp pack` again. Windows requires a higher version number to update an installed package.
+> **Tip**: If you need to repackage your app (e.g., after code changes), increment the `Version` in your `Package.appxmanifest` before running `winapp pack` again. Windows requires a higher version number to update an installed package.
 
 ## Tips
 1. Once you are ready for distribution, you can sign your MSIX with a code signing certificate from a Certificate Authority so your users don't have to install a self-signed certificate.

--- a/docs/guides/dotnet.md
+++ b/docs/guides/dotnet.md
@@ -98,11 +98,11 @@ When prompted:
 This command will:
 - Update the `TargetFramework` in your `.csproj` to a supported Windows TFM (if needed)
 - Add `Microsoft.WindowsAppSDK`, `Microsoft.Windows.SDK.BuildTools`, and `Microsoft.Windows.SDK.BuildTools.WinApp` NuGet package references to your `.csproj`
-- Create `appxmanifest.xml` and `Assets` folder for your app identity
+- Create `Package.appxmanifest` and `Assets` folder for your app identity
 
 > **Note:** Unlike native/C++ projects, the .NET flow does **not** create a `winapp.yaml` file. NuGet packages are managed directly via your `.csproj`. Use `dotnet restore` to restore packages after cloning.
 
-You can open `appxmanifest.xml` to further customize properties like the display name, publisher, and capabilities.
+You can open `Package.appxmanifest` to further customize properties like the display name, publisher, and capabilities.
 
 To verify the packages were added to your project:
 
@@ -254,9 +254,9 @@ dotnet build -c Release
 > **Note**: You may see NuGet vulnerability warnings (NU1900). These are safe to ignore and don't affect your build output.
 
 ### Add Execution Alias (for console apps)
-To allow users to run your app from the command line after installation (like `dotnet-app`), add an execution alias to the `appxmanifest.xml`. If you are building a WPF or WinForms app, this step is not necessary — those apps launch from the Start menu instead.
+To allow users to run your app from the command line after installation (like `dotnet-app`), add an execution alias to the `Package.appxmanifest`. If you are building a WPF or WinForms app, this step is not necessary — those apps launch from the Start menu instead.
 
-Open `appxmanifest.xml` and add the `uap5` namespace to the `<Package>` tag if it's missing, and then add the extension inside `<Applications><Application><Extensions>...`:
+Open `Package.appxmanifest` and add the `uap5` namespace to the `<Package>` tag if it's missing, and then add the extension inside `<Applications><Application><Extensions>...`:
 
 ```xml
 <Package
@@ -300,10 +300,10 @@ Now you can package and sign. Point the pack command to your build output folder
 
 ```powershell
 # package and sign the app with the generated certificate
-winapp pack .\bin\Release\net10.0-windows10.0.26100.0 --manifest .\appxmanifest.xml --cert .\devcert.pfx 
+winapp pack .\bin\Release\net10.0-windows10.0.26100.0 --manifest .\Package.appxmanifest --cert .\devcert.pfx 
 ```
 
-> Note: The `pack` command automatically uses the appxmanifest.xml from your current directory and copies it to the target folder before packaging. The generated .msix file will be in the current directory.
+> Note: The `pack` command automatically uses the Package.appxmanifest from your current directory and copies it to the target folder before packaging. The generated .msix file will be in the current directory.
 
 ### Install the Certificate
 
@@ -324,7 +324,7 @@ dotnet-app
 
 You should see the "Package Family Name" output, confirming it's installed and running with identity.
 
-> **Tip**: If you need to repackage your app (e.g., after code changes), increment the `Version` in your `appxmanifest.xml` before running `winapp pack` again. Windows requires a higher version number to update an installed package.
+> **Tip**: If you need to repackage your app (e.g., after code changes), increment the `Version` in your `Package.appxmanifest` before running `winapp pack` again. Windows requires a higher version number to update an installed package.
 
 ## Tips
 1. Once you are ready for distribution, you can sign your MSIX with a code signing certificate from a Certificate Authority so your users don't have to install a self-signed certificate.

--- a/docs/guides/electron/cpp-notification-addon.md
+++ b/docs/guides/electron/cpp-notification-addon.md
@@ -72,7 +72,7 @@ npx winapp node add-electron-debug-identity
 ```
 
 > [!NOTE]
-> This command is already part of the `postinstall` script we added in the setup guide, so it runs automatically after `npm install`. However, you need to run it manually whenever you modify `appxmanifest.xml`, update app assets, or reinstall dependencies.
+> This command is already part of the `postinstall` script we added in the setup guide, so it runs automatically after `npm install`. However, you need to run it manually whenever you modify `Package.appxmanifest`, update app assets, or reinstall dependencies.
 
 Now run your app:
 

--- a/docs/guides/electron/packaging.md
+++ b/docs/guides/electron/packaging.md
@@ -32,7 +32,7 @@ module.exports = {
 ```
 
 > [!IMPORTANT]
-> Verify that your `appxmanifest.xml` matches your packaged app structure:
+> Verify that your `Package.appxmanifest` matches your packaged app structure:
 > - The `Executable` attribute should point to the correct .exe file in your packaged output
 
 ## Generate a Development Certificate
@@ -76,12 +76,12 @@ This will create a production version of your app in the `./out/` folder. The ex
 Now use the winapp CLI to create and sign an MSIX package from your packaged app:
 
 ```bash
-npx winapp pack .\out\<your-app-folder> --output .\out --cert .\devcert.pfx --manifest .\appxmanifest.xml
+npx winapp pack .\out\<your-app-folder> --output .\out --cert .\devcert.pfx --manifest .\Package.appxmanifest
 ```
 
 Replace `<your-app-folder>` with the actual folder name created by Electron Forge (e.g., `my-windows-app-win32-x64` for x64 or `my-windows-app-win32-arm64` for ARM64).
 
-The `--manifest` option is optional. If not provided, it will look for an appxmanifest.xml in the folder being packaged, or in the current directory.
+The `--manifest` option is optional. If not provided, it will look for a Package.appxmanifest in the folder being packaged, or in the current directory.
 
 The `--cert` option is also optional. If not provided, the msix will not be signed.
 
@@ -94,7 +94,7 @@ The MSIX package will be created as `./out/<your-app-name>.msix`.
 > ```json
 > {
 >   "scripts": {
->     "package-msix": "npm run build-csAddon && npx electron-forge package && npx winapp pack ./out/my-windows-app-win32-x64 --output ./out --cert ./devcert.pfx --manifest appxmanifest.xml"
+>     "package-msix": "npm run build-csAddon && npx electron-forge package && npx winapp pack ./out/my-windows-app-win32-x64 --output ./out --cert ./devcert.pfx --manifest Package.appxmanifest"
 >   }
 > }
 > ```
@@ -123,7 +123,7 @@ module.exports = {
     {
       name: '@electron-forge/maker-msix',
       config: {
-        appManifest: '.\\appxmanifest.xml',
+        appManifest: '.\\Package.appxmanifest',
         windowsSignOptions: {
           certificateFile: '.\\devcert.pfx',
           certificatePassword: 'password'
@@ -135,9 +135,9 @@ module.exports = {
 };
 ```
 
-#### Update appxmanifest.xml
+#### Update Package.appxmanifest
 
-The Electron Forge MSIX maker uses a different folder layout than the winapp CLI approach. It places your app inside an `app\` folder in the MSIX. This folder is created automatically during packaging — you don't need to create it yourself. Update the `Executable` path in your `appxmanifest.xml` to point to the `app` folder:
+The Electron Forge MSIX maker uses a different folder layout than the winapp CLI approach. It places your app inside an `app\` folder in the MSIX. This folder is created automatically during packaging — you don't need to create it yourself. Update the `Executable` path in your `Package.appxmanifest` to point to the `app` folder:
 
 ```xml
 <Applications>
@@ -152,7 +152,7 @@ The Electron Forge MSIX maker uses a different folder layout than the winapp CLI
 Replace `my-app.exe` with your actual executable name. This is based on the `productName` (or `name`) field in your `package.json`.
 
 > [!NOTE]
-> The Forge MSIX maker looks for Windows SDK tools based on the `MinVersion` in your `appxmanifest.xml`. If you get an error about WindowsKit not being found, ensure the SDK version specified in `MinVersion` is installed on your machine, or update `MinVersion` to match an installed SDK version.
+> The Forge MSIX maker looks for Windows SDK tools based on the `MinVersion` in your `Package.appxmanifest`. If you get an error about WindowsKit not being found, ensure the SDK version specified in `MinVersion` is installed on your machine, or update `MinVersion` to match an installed SDK version.
 
 #### Create the MSIX Package
 
@@ -201,7 +201,7 @@ Host the MSIX package on your website for direct download. Ensure you sign it wi
 Submit your app to the Microsoft Store for the widest distribution and automatic updates. You'll need to:
 1. Create a Microsoft Partner Center account
 2. Reserve your app name
-3. Update `appxmanifest.xml` with your Store identity. No need to sign the msix, the store publishing process will sign it automaticly. 
+3. Update `Package.appxmanifest` with your Store identity. No need to sign the msix, the store publishing process will sign it automaticly. 
 5. Submit for certification
 
 Learn more: [Publish your app to the Microsoft Store](https://learn.microsoft.com/windows/apps/publish/)

--- a/docs/guides/electron/packaging.md
+++ b/docs/guides/electron/packaging.md
@@ -201,7 +201,7 @@ Host the MSIX package on your website for direct download. Ensure you sign it wi
 Submit your app to the Microsoft Store for the widest distribution and automatic updates. You'll need to:
 1. Create a Microsoft Partner Center account
 2. Reserve your app name
-3. Update `Package.appxmanifest` with your Store identity. No need to sign the msix, the store publishing process will sign it automaticly. 
+3. Update `Package.appxmanifest` with your Store identity. No need to sign the msix, the store publishing process will sign it automatically. 
 5. Submit for certification
 
 Learn more: [Publish your app to the Microsoft Store](https://learn.microsoft.com/windows/apps/publish/)

--- a/docs/guides/electron/phi-silica-addon.md
+++ b/docs/guides/electron/phi-silica-addon.md
@@ -156,7 +156,7 @@ When you run the app, the summary will be printed to the console. From here, you
 
 ## Step 5: Add Required Capability
 
-Before you can use the Phi Silica API, you need to declare the required capability in your app manifest. Open `appxmanifest.xml` and add the `systemAIModels` capability inside the `<Capabilities>` section:
+Before you can use the Phi Silica API, you need to declare the required capability in your app manifest. Open `Package.appxmanifest` and add the `systemAIModels` capability inside the `<Capabilities>` section:
 
 ```xml
 <Capabilities>
@@ -170,20 +170,20 @@ Before you can use the Phi Silica API, you need to declare the required capabili
 
 ## Step 6: Update Debug Identity
 
-Whenever you modify `appxmanifest.xml` or change assets referenced in the manifest (like app icons), you need to update your app's debug identity. Run:
+Whenever you modify `Package.appxmanifest` or change assets referenced in the manifest (like app icons), you need to update your app's debug identity. Run:
 
 ```bash
 npx winapp node add-electron-debug-identity
 ```
 
 This command:
-1. Reads your `appxmanifest.xml` to get app details and capabilities
+1. Reads your `Package.appxmanifest` to get app details and capabilities
 2. Registers `electron.exe` in your `node_modules` with a temporary identity
 3. Enables you to test identity-required APIs without full MSIX packaging
 
 > [!NOTE]
 > This command is already part of the `postinstall` script we added in the setup guide, so it runs automatically after `npm install`. However, you need to run it manually whenever you:
-> - Modify `appxmanifest.xml` (change capabilities, identity, or properties)
+> - Modify `Package.appxmanifest` (change capabilities, identity, or properties)
 > - Update app assets (icons, logos, etc.)
 > - Reinstall or update dependencies
 

--- a/docs/guides/electron/setup.md
+++ b/docs/guides/electron/setup.md
@@ -68,7 +68,7 @@ This command sets up everything you need for Windows development:
    - Headers and libraries from the **Windows App SDK**
    - NuGet packages with the required binaries
 
-2. **Generates `appxmanifest.xml`** - The app manifest required for app identity and MSIX packaging
+2. **Generates `Package.appxmanifest`** - The app manifest required for app identity and MSIX packaging
 
 3. **Creates `Assets/` folder** - Contains app icons and visual assets for your app
 
@@ -81,7 +81,7 @@ This command sets up everything you need for Windows development:
 > [!NOTE]
 > The `.winapp/` folder is automatically added to `.gitignore` and should not be checked in to source.
 
-You can open `appxmanifest.xml` to further customize properties like the display name, publisher, and capabilities.
+You can open `Package.appxmanifest` to further customize properties like the display name, publisher, and capabilities.
 
 > [!TIP]
 > **About the Windows SDKs:**
@@ -159,7 +159,7 @@ The `npm install` you ran in Step 4 triggered the `postinstall` script, which ra
 ### What Does Debug Identity Do?
 
 This command:
-1. Reads your `appxmanifest.xml` to get app details and capabilities
+1. Reads your `Package.appxmanifest` to get app details and capabilities
 2. Registers `electron.exe` in your `node_modules` with a temporary identity
 3. Enables you to test identity-required APIs without creating a full MSIX package
 
@@ -167,7 +167,7 @@ The debug identity was applied automatically when you ran `npm install` in Step 
 
 ### When to Manually Update Debug Identity
 
-You need to run this command manually whenever you modify `appxmanifest.xml` (change capabilities, identity, or properties) or any of the linked assets (icons, mcp.json, etc)
+You need to run this command manually whenever you modify `Package.appxmanifest` (change capabilities, identity, or properties) or any of the linked assets (icons, mcp.json, etc)
 
 ```bash
 npx winapp node add-electron-debug-identity

--- a/docs/guides/electron/winml-addon.md
+++ b/docs/guides/electron/winml-addon.md
@@ -343,20 +343,20 @@ When you run the app, you'll see the classification results in the console!
 
 ## Step 7: Update Debug Identity
 
-To ensure the Windows App SDK is loaded and available for usage, we need to ensure we setup debug identity which will ensure the framework is loaded whenever our app runs. Likewise, whenever you modify `appxmanifest.xml` or change assets referenced in the manifest (like app icons), you need to update your app's debug identity. Run:
+To ensure the Windows App SDK is loaded and available for usage, we need to ensure we setup debug identity which will ensure the framework is loaded whenever our app runs. Likewise, whenever you modify `Package.appxmanifest` or change assets referenced in the manifest (like app icons), you need to update your app's debug identity. Run:
 
 ```bash
 npx winapp node add-electron-debug-identity
 ```
 
 This command:
-1. Reads your `appxmanifest.xml` to get app details and capabilities
+1. Reads your `Package.appxmanifest` to get app details and capabilities
 2. Registers `electron.exe` in your `node_modules` with a temporary identity
 3. Enables you to test identity-required APIs without full MSIX packaging
 
 > [!NOTE]
 > This command is already part of the `postinstall` script we added in the setup guide, so it runs automatically after `npm install`. However, you need to run it manually whenever you:
-> - Modify `appxmanifest.xml` (change capabilities, identity, or properties)
+> - Modify `Package.appxmanifest` (change capabilities, identity, or properties)
 > - Update app assets (icons, logos, etc.)
 
 Now run your app:

--- a/docs/guides/flutter.md
+++ b/docs/guides/flutter.md
@@ -207,12 +207,12 @@ When prompted:
 - **Setup SDKs**: Select "Stable SDKs" to download Windows App SDK and generate C++ headers (needed for step 6)
 
 This command will:
-- Create `appxmanifest.xml` — the manifest that defines your app's identity
+- Create `Package.appxmanifest` — the manifest that defines your app's identity
 - Create `Assets` folder — icons required for MSIX packaging and Store submission
 - Create a `.winapp` folder with Windows App SDK headers and libraries
 - Create a `winapp.yaml` configuration file for pinning SDK versions
 
-You can open `appxmanifest.xml` to further customize properties like the display name, publisher, and capabilities.
+You can open `Package.appxmanifest` to further customize properties like the display name, publisher, and capabilities.
 
 ## 5. Debug with Identity
 
@@ -467,7 +467,7 @@ Now you can package and sign:
 winapp pack .\dist --cert .\devcert.pfx
 ```
 
-> Note: The `pack` command automatically uses the `appxmanifest.xml` from your current directory and copies it to the target folder before packaging.
+> Note: The `pack` command automatically uses the `Package.appxmanifest` from your current directory and copies it to the target folder before packaging.
 
 ### Install the Certificate
 
@@ -487,7 +487,7 @@ Install the package by double-clicking the generated `.msix` file, or using Powe
 Add-AppxPackage .\flutterapp.msix
 ```
 
-> **Tip**: The MSIX filename includes the version and architecture (e.g., `flutterapplication1_1.0.0.0_x64.msix`). Check your directory for the exact filename. If you need to repackage after code changes, increment the `Version` in your `appxmanifest.xml` — Windows requires a higher version number to update an installed package.
+> **Tip**: The MSIX filename includes the version and architecture (e.g., `flutterapplication1_1.0.0.0_x64.msix`). Check your directory for the exact filename. If you need to repackage after code changes, increment the `Version` in your `Package.appxmanifest` — Windows requires a higher version number to update an installed package.
 
 ## Tips
 

--- a/docs/guides/packaging-cli.md
+++ b/docs/guides/packaging-cli.md
@@ -29,19 +29,19 @@ Install the winapp CLI via Windows Package Manager, or update to the latest vers
 winget install microsoft.winappcli --source winget
 ```
 
-### 3. Generate the appxmanifest.xml
+### 3. Generate the Package.appxmanifest
 
-Generate a base appxmanifest.xml and required assets for your CLI executable:
+Generate a base Package.appxmanifest and required assets for your CLI executable:
 
 ```powershell
 winapp manifest generate --executable .\yourcli.exe
 ```
 
-This command creates an `appxmanifest.xml` file in the current directory with default values populated from your executable.
+This command creates an `Package.appxmanifest` file in the current directory with default values populated from your executable.
 
 ### 4. Configure the Manifest
 
-Edit the generated `appxmanifest.xml` to customize your package. Each sub-step below explains what to change and why.
+Edit the generated `Package.appxmanifest` to customize your package. Each sub-step below explains what to change and why.
 
 #### 4.1 Add Required Namespace
 

--- a/docs/guides/packaging-cli.md
+++ b/docs/guides/packaging-cli.md
@@ -37,7 +37,7 @@ Generate a base Package.appxmanifest and required assets for your CLI executable
 winapp manifest generate --executable .\yourcli.exe
 ```
 
-This command creates an `Package.appxmanifest` file in the current directory with default values populated from your executable.
+This command creates a `Package.appxmanifest` file in the current directory with default values populated from your executable.
 
 ### 4. Configure the Manifest
 

--- a/docs/guides/rust.md
+++ b/docs/guides/rust.md
@@ -99,10 +99,10 @@ When prompted:
 - **Setup SDKs**: Select "Do not setup SDKs" (Rust uses its own `windows` crate, not the C++ SDK headers)
 
 This command will:
-- Create `appxmanifest.xml` — the manifest that defines your app's identity
+- Create `Package.appxmanifest` — the manifest that defines your app's identity
 - Create `Assets` folder — icons required for MSIX packaging and Store submission
 
-You can open `appxmanifest.xml` to further customize properties like the display name, publisher, and capabilities.
+You can open `Package.appxmanifest` to further customize properties like the display name, publisher, and capabilities.
 
 ### Add Execution Alias (for console apps)
 An execution alias lets users run your app by name from any terminal (like `rust-app`). It also enables `winapp run --with-alias` during development, which keeps console output in the current terminal instead of opening a new window.
@@ -113,7 +113,7 @@ You can add one automatically:
 winapp manifest add-alias
 ```
 
-Or manually: open `appxmanifest.xml` and add the `uap5` namespace to the `<Package>` tag if it's missing, and then add the extension inside `<Applications><Application><Extensions>...`:
+Or manually: open `Package.appxmanifest` and add the `uap5` namespace to the `<Package>` tag if it's missing, and then add the extension inside `<Applications><Application><Extensions>...`:
 
 ```diff
 <Package
@@ -195,7 +195,7 @@ MSIX packages must be signed. For local testing, generate a self-signed developm
 winapp cert generate --if-exists skip
 ```
 
-> **Important**: The certificate's publisher must match the `Publisher` in your `appxmanifest.xml`. The `cert generate` command reads this automatically from your manifest.
+> **Important**: The certificate's publisher must match the `Publisher` in your `Package.appxmanifest`. The `cert generate` command reads this automatically from your manifest.
 
 ### Sign and Pack
 
@@ -205,7 +205,7 @@ Now you can package and sign in one step:
 winapp pack .\dist --cert .\devcert.pfx 
 ```
 
-> Note: The `pack` command automatically uses the appxmanifest.xml from your current directory and copies it to the target folder before packaging. The generated .msix file will be in the current directory.
+> Note: The `pack` command automatically uses the Package.appxmanifest from your current directory and copies it to the target folder before packaging. The generated .msix file will be in the current directory.
 
 ### Install the Certificate
 
@@ -233,7 +233,7 @@ rust-app
 
 You should see the "Package Family Name" output, confirming it's installed and running with identity.
 
-> **Tip**: If you need to repackage your app (e.g., after code changes), increment the `Version` in your `appxmanifest.xml` before running `winapp pack` again. Windows requires a higher version number to update an installed package.
+> **Tip**: If you need to repackage your app (e.g., after code changes), increment the `Version` in your `Package.appxmanifest` before running `winapp pack` again. Windows requires a higher version number to update an installed package.
 
 ## Tips
 1. Once you are ready for distribution, you can sign your MSIX with a code signing certificate from a Certificate Authority so your users don't have to install a self-signed certificate

--- a/docs/guides/tauri.md
+++ b/docs/guides/tauri.md
@@ -154,10 +154,10 @@ When prompted:
 - **Setup SDKs**: Select "Do not setup SDKs" (Tauri uses Rust's `windows` crate, not the C++ SDK headers)
 
 This command will:
-- Create `appxmanifest.xml` — the manifest that defines your app's identity
+- Create `Package.appxmanifest` — the manifest that defines your app's identity
 - Create `Assets` folder — icons required for MSIX packaging and Store submission
 
-You can open `appxmanifest.xml` to further customize properties like the display name, publisher, and capabilities.
+You can open `Package.appxmanifest` to further customize properties like the display name, publisher, and capabilities.
 
 ## 4. Debug with Identity
 
@@ -218,7 +218,7 @@ MSIX packages must be signed. For local testing, generate a self-signed developm
 winapp cert generate --if-exists skip
 ```
 
-> **Tip**: The certificate's publisher must match the `Publisher` in your `appxmanifest.xml`. The `cert generate` command reads this automatically from your manifest.
+> **Tip**: The certificate's publisher must match the `Publisher` in your `Package.appxmanifest`. The `cert generate` command reads this automatically from your manifest.
 
 ### Build, Stage, and Pack
 
@@ -226,7 +226,7 @@ winapp cert generate --if-exists skip
 npm run pack:msix
 ```
 
-> **Tip**: The `pack` command automatically uses the appxmanifest.xml from your current directory and copies it to the target folder before packaging. The generated .msix file will be in the current directory.
+> **Tip**: The `pack` command automatically uses the Package.appxmanifest from your current directory and copies it to the target folder before packaging. The generated .msix file will be in the current directory.
 
 ### Install the Certificate
 
@@ -246,7 +246,7 @@ Install the package by double-clicking the generated `.msix` file, or using Powe
 Add-AppxPackage .\tauri-app.msix
 ```
 
-> **Tip**: The MSIX filename includes the version and architecture (e.g., `tauri-app_1.0.0.0_x64.msix`). Check your directory for the exact filename. If you need to repackage after code changes, increment the `Version` in your `appxmanifest.xml` — Windows requires a higher version number to update an installed package.
+> **Tip**: The MSIX filename includes the version and architecture (e.g., `tauri-app_1.0.0.0_x64.msix`). Check your directory for the exact filename. If you need to repackage after code changes, increment the `Version` in your `Package.appxmanifest` — Windows requires a higher version number to update an installed package.
 
 Once installed, you can launch your app from the Start menu. You should see the app running with identity.
 

--- a/docs/npm-usage.md
+++ b/docs/npm-usage.md
@@ -799,7 +799,7 @@ function execWithBuildTools(command: string, options?: ExecSyncOptions): string 
 
 ### `addMsixIdentityToExe()`
 
-Adds package identity information from an appxmanifest.xml file to an executable's embedded manifest
+Adds package identity information from a Package.appxmanifest file to an executable's embedded manifest
 
 ```typescript
 function addMsixIdentityToExe(exePath: string, appxManifestPath?: string | undefined, options?: MsixIdentityOptions): Promise<MsixIdentityResult>
@@ -810,7 +810,7 @@ function addMsixIdentityToExe(exePath: string, appxManifestPath?: string | undef
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `exePath` | `string` | Yes | Path to the executable file |
-| `appxManifestPath` | `string \| undefined` | No | Path to the appxmanifest.xml file containing package identity data |
+| `appxManifestPath` | `string \| undefined` | No | Path to the Package.appxmanifest file containing package identity data |
 | `options` | `MsixIdentityOptions` | No | Optional configuration |
 
 ---
@@ -905,7 +905,7 @@ npx winapp node create-addon --template cs --name MyCsAddon
 
 ### `node add-electron-debug-identity`
 
-Add package identity to the Electron debug process using sparse packaging.  Creates a backup of `electron.exe`, generates a sparse MSIX manifest, adds identity to the executable, and registers the sparse package.  Requires an `appxmanifest.xml` (create one with `winapp init` or `winapp manifest generate`).
+Add package identity to the Electron debug process using sparse packaging.  Creates a backup of `electron.exe`, generates a sparse MSIX manifest, adds identity to the executable, and registers the sparse package.  Requires an `Package.appxmanifest` (create one with `winapp init` or `winapp manifest generate`).
 
 ```bash
 npx winapp node add-electron-debug-identity [options]
@@ -915,7 +915,7 @@ npx winapp node add-electron-debug-identity [options]
 
 | Flag | Description |
 |------|-------------|
-| `--manifest <path>` | Path to custom `appxmanifest.xml` (default: `appxmanifest.xml` in current directory) |
+| `--manifest <path>` | Path to custom `Package.appxmanifest` (default: `Package.appxmanifest` in current directory) |
 | `--no-install` | Do not install the package after creation |
 | `--keep-identity` | Keep the manifest identity as-is, without appending `.debug` suffix |
 | `--verbose` | Enable verbose output |
@@ -926,7 +926,7 @@ npx winapp node add-electron-debug-identity [options]
 
 ```bash
 npx winapp node add-electron-debug-identity
-npx winapp node add-electron-debug-identity --manifest ./custom/appxmanifest.xml
+npx winapp node add-electron-debug-identity --manifest ./custom/Package.appxmanifest
 ```
 
 ---

--- a/docs/npm-usage.md
+++ b/docs/npm-usage.md
@@ -905,7 +905,7 @@ npx winapp node create-addon --template cs --name MyCsAddon
 
 ### `node add-electron-debug-identity`
 
-Add package identity to the Electron debug process using sparse packaging.  Creates a backup of `electron.exe`, generates a sparse MSIX manifest, adds identity to the executable, and registers the sparse package.  Requires an `Package.appxmanifest` (create one with `winapp init` or `winapp manifest generate`).
+Add package identity to the Electron debug process using sparse packaging.  Creates a backup of `electron.exe`, generates a sparse MSIX manifest, adds identity to the executable, and registers the sparse package.  Requires a `Package.appxmanifest` (create one with `winapp init` or `winapp manifest generate`).
 
 ```bash
 npx winapp node add-electron-debug-identity [options]
@@ -1502,4 +1502,3 @@ type ManifestTemplates = "packaged" | "sparse"
 | `quiet` | `boolean \| undefined` | No | Suppress progress messages. |
 | `verbose` | `boolean \| undefined` | No | Enable verbose output. |
 | `cwd` | `string \| undefined` | No | Working directory for the CLI process (defaults to process.cwd()). |
-

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -146,7 +146,7 @@ winapp update --setup-sdks experimental
 
 ### pack
 
-Create MSIX packages from prepared application directories. Requires Package.appxmanifest file to be present in the target directory, in the current directory, or passed with the `--manifest` option. (run `init` or `manifest generate` to create a manifest)
+Create MSIX packages from prepared application directories. Requires a manifest file (`Package.appxmanifest` preferred, `appxmanifest.xml` also supported) to be present in the target directory, in the current directory, or passed with the `--manifest` option. (run `init` or `manifest generate` to create a manifest)
 
 ```bash
 winapp pack <input-folder> [options]
@@ -160,7 +160,7 @@ winapp pack <input-folder> [options]
 
 - `--output <filename>` - Output MSIX file name (default: `<name>_<version>.msix`)
 - `--name <name>` - Package name (default: from manifest)
-- `--manifest <path>` - Path to Package.appxmanifest (default: auto-detect)
+- `--manifest <path>` - Path to manifest file (`Package.appxmanifest` preferred, `appxmanifest.xml` also supported; default: auto-detect)
 - `--cert <path>` - Path to signing certificate (enables auto-signing)
 - `--cert-password <password>` - Certificate password (default: "password")
 - `--generate-cert` - Generate a new development certificate

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -38,7 +38,7 @@ winapp init [base-directory] [options]
 - Creates `winapp.yaml` configuration file
 - Downloads Windows SDK and Windows App SDK packages
 - Generates C++/WinRT headers and binaries
-- Creates AppxManifest.xml
+- Creates Package.appxmanifest
 - Sets up build tools and enables developer mode
 - Updates .gitignore to exclude generated files
 - Stores sharable files in the global cache directory
@@ -49,7 +49,7 @@ When a `.csproj` file is found in the target directory, `init` uses a streamline
 
 - Validates and updates the `TargetFramework` to a Windows-compatible TFM (e.g., `net10.0-windows10.0.26100.0`)
 - Adds `Microsoft.WindowsAppSDK` and `Microsoft.Windows.SDK.BuildTools` as NuGet `PackageReference` entries directly in the `.csproj`
-- Generates `appxmanifest.xml`, assets, and a development certificate
+- Generates `Package.appxmanifest`, assets, and a development certificate
 - Does **not** create a `winapp.yaml` or download C++ projections (use `dotnet restore` for NuGet packages)
 
 **Examples:**
@@ -146,7 +146,7 @@ winapp update --setup-sdks experimental
 
 ### pack
 
-Create MSIX packages from prepared application directories. Requires appxmanifest.xml file to be present in the target directory, in the current directory, or passed with the `--manifest` option. (run `init` or `manifest generate` to create a manifest)
+Create MSIX packages from prepared application directories. Requires Package.appxmanifest file to be present in the target directory, in the current directory, or passed with the `--manifest` option. (run `init` or `manifest generate` to create a manifest)
 
 ```bash
 winapp pack <input-folder> [options]
@@ -160,7 +160,7 @@ winapp pack <input-folder> [options]
 
 - `--output <filename>` - Output MSIX file name (default: `<name>_<version>.msix`)
 - `--name <name>` - Package name (default: from manifest)
-- `--manifest <path>` - Path to AppxManifest.xml (default: auto-detect)
+- `--manifest <path>` - Path to Package.appxmanifest (default: auto-detect)
 - `--cert <path>` - Path to signing certificate (enables auto-signing)
 - `--cert-password <password>` - Certificate password (default: "password")
 - `--generate-cert` - Generate a new development certificate
@@ -172,7 +172,7 @@ winapp pack <input-folder> [options]
 
 **What it does:**
 
-- Validates and processes AppxManifest.xml files
+- Validates and processes Package.appxmanifest files
 - Resolves `$placeholder$` tokens in the manifest (see [Manifest placeholders](#manifest-placeholders) below)
 - Ensures proper framework dependencies
 - Updates side-by-side manifests with registrations
@@ -184,7 +184,7 @@ winapp pack <input-folder> [options]
 
 When packaging, `winapp pack` automatically scans NuGet packages defined in the `winapp.yaml` or `*.csproj` for third-party WinRT components (e.g., Win2D). It parses `.winmd` files to extract activatable class names and locates their implementation DLLs. The discovered entries are registered as follows:
 
-- **Framework-dependent** (default): Activatable classes are added as `<InProcessServer>` entries in the `AppxManifest.xml`
+- **Framework-dependent** (default): Activatable classes are added as `<InProcessServer>` entries in the `Package.appxmanifest`
 - **Self-contained** (`--self-contained`): Activatable classes are embedded in side-by-side (SxS) manifests within the executable
 
 **Placeholder resolution during packaging:**
@@ -228,7 +228,7 @@ winapp create-debug-identity [entrypoint] [options]
 
 **Options:**
 
-- `--manifest <path>` - Path to AppxManifest.xml (default: `./appxmanifest.xml`)
+- `--manifest <path>` - Path to Package.appxmanifest (default: `./Package.appxmanifest`)
 - `--no-install` - Don't install the package after creation
 - `--keep-identity` - Keep the manifest identity as-is, without appending `.debug` to the package name and application ID
 
@@ -255,11 +255,11 @@ winapp create-debug-identity app.py
 
 ### manifest
 
-Generate and manage AppxManifest.xml files.
+Generate and manage Package.appxmanifest files.
 
 #### manifest generate
 
-Generate AppxManifest.xml from templates.
+Generate Package.appxmanifest from templates.
 
 ```bash
 winapp manifest generate [directory] [options]
@@ -333,7 +333,7 @@ winapp run <input-folder> [options]
 
 **Options:**
 
-- `--manifest <path>` - Path to AppxManifest.xml (default: auto-detect from input folder or current directory)
+- `--manifest <path>` - Path to Package.appxmanifest (default: auto-detect from input folder or current directory)
 - `--output-appx-directory <path>` - Output directory for the loose layout package (default: `AppX` inside the input folder directory)
 - `--args <string>` - Command-line arguments to pass to the application
 - `--no-launch` - Only create the debug identity and register the package without launching the application
@@ -352,7 +352,7 @@ Use `--clean` when you need a fresh start (e.g., to reset corrupted state or tes
 
 **What it does:**
 
-- Locates or generates the AppxManifest.xml
+- Locates or generates the Package.appxmanifest
 - Creates and registers a debug identity using a loose layout package
 - Computes the Application User Model ID (AUMID)
 - Launches the application using the registered identity (unless `--no-launch` is specified)
@@ -365,7 +365,7 @@ Use `--clean` when you need a fresh start (e.g., to reset corrupted state or tes
 winapp run ./bin/Debug
 
 # Launch with custom manifest and arguments
-winapp run ./dist --manifest ./out/AppxManifest.xml --args "--my-flag value"
+winapp run ./dist --manifest ./out/Package.appxmanifest --args "--my-flag value"
 
 # Specify output directory for loose layout package
 winapp run ./bin/Release --output-appx-directory ./AppXDebug
@@ -429,7 +429,7 @@ winapp unregister [options]
 
 **Options:**
 
-- `--manifest <path>` - Path to AppxManifest.xml (default: auto-detect from current directory)
+- `--manifest <path>` - Path to Package.appxmanifest (default: auto-detect from current directory)
 - `--force` - Skip the install-location directory check and unregister even if the package was registered from a different project tree
 - `--json` - Format output as JSON
 
@@ -448,7 +448,7 @@ winapp unregister [options]
 winapp unregister
 
 # Unregister with explicit manifest
-winapp unregister --manifest ./appxmanifest.xml
+winapp unregister --manifest ./Package.appxmanifest
 
 # Force unregister even if registered from a different project tree
 winapp unregister --force
@@ -461,7 +461,7 @@ winapp unregister --json
 
 #### manifest add-alias
 
-Add an execution alias (`uap5:AppExecutionAlias`) to an appxmanifest.xml. This allows launching the packaged app from the command line by typing the alias name.
+Add an execution alias (`uap5:AppExecutionAlias`) to a Package.appxmanifest. This allows launching the packaged app from the command line by typing the alias name.
 
 ```bash
 winapp manifest add-alias [options]
@@ -470,7 +470,7 @@ winapp manifest add-alias [options]
 **Options:**
 
 - `--name <alias>` - Alias name (e.g. `myapp.exe`). Default: inferred from the `Executable` attribute in the manifest.
-- `--manifest <path>` - Path to AppxManifest.xml (default: search current directory)
+- `--manifest <path>` - Path to Package.appxmanifest (default: search current directory)
 - `--app-id <id>` - Application Id to add the alias to (default: first Application element)
 
 **What it does:**
@@ -490,7 +490,7 @@ winapp manifest add-alias
 winapp manifest add-alias --name myapp.exe
 
 # Add alias to specific manifest
-winapp manifest add-alias --manifest ./dist/appxmanifest.xml
+winapp manifest add-alias --manifest ./dist/Package.appxmanifest
 ```
 
 Generate all required MSIX image assets from a single source image.
@@ -505,7 +505,7 @@ winapp manifest update-assets <image-path> [options]
 
 **Options:**
 
-- `--manifest <path>` - Path to AppxManifest.xml file (default: search current directory)
+- `--manifest <path>` - Path to Package.appxmanifest file (default: search current directory)
 - `--light-image <path>` - Path to a separate source image for light theme variants
 
 **Description:**
@@ -540,7 +540,7 @@ winapp manifest update-assets mylogo.png
 winapp manifest update-assets mylogo.svg
 
 # Specify manifest location explicitly
-winapp manifest update-assets mylogo.png --manifest ./dist/appxmanifest.xml
+winapp manifest update-assets mylogo.png --manifest ./dist/Package.appxmanifest
 
 # Generate light theme variants from a separate image
 winapp manifest update-assets mylogo.png --light-image mylogo-light.png
@@ -568,7 +568,7 @@ winapp cert generate [options]
 
 **Options:**
 
-- `--manifest <appxmanifest.xml>` - Extract publisher information from appxmanifest.xml 
+- `--manifest <Package.appxmanifest>` - Extract publisher information from Package.appxmanifest 
 - `--publisher <name>` - Publisher name for certificate
 - `--output <path>` - Output certificate file path (supports absolute and relative paths)
 - `--password <password>` - Certificate password (default: "password")
@@ -832,7 +832,7 @@ npx winapp node create-addon --name myWindowsAddon
 
 ### node add-electron-debug-identity
 
-*(Available in NPM package only)* Add app identity to Electron development process by using sparse packaging. Requires an appxmanifest.xml (create one with `winapp init` or `winapp manifest generate` if you don't have one).
+*(Available in NPM package only)* Add app identity to Electron development process by using sparse packaging. Requires a Package.appxmanifest (create one with `winapp init` or `winapp manifest generate` if you don't have one).
 
 > [!IMPORTANT]  
 > There is a known issue with sparse packaging Electron applications which causes the app to crash on start or not render the web content. The issue has been fixed in Windows but it has not propagated to external Windows devices yet. If you are seeing this issue after calling `add-electron-debug-identity`, you can [disable sandboxing in your Electron app](https://www.electronjs.org/docs/latest/tutorial/sandbox#disabling-chromiums-sandbox-testing-only) for debug purposes with the `--no-sandbox` flag. This issue does not affect full MSIX packaging.
@@ -847,7 +847,7 @@ npx winapp node add-electron-debug-identity [options]
 
 | Option | Description |
 |--------|-------------|
-| `--manifest <path>` | Path to custom appxmanifest.xml (default: appxmanifest.xml in current directory) |
+| `--manifest <path>` | Path to custom Package.appxmanifest (default: Package.appxmanifest in current directory) |
 | `--no-install` | Do not install or modify dependencies; only configure the Electron debug identity |
 | `--keep-identity` | Keep the manifest identity as-is, without appending `.debug` to the package name and application ID |
 | `--verbose` | Enable verbose output |
@@ -856,7 +856,7 @@ npx winapp node add-electron-debug-identity [options]
 
 - Registers debug identity for electron.exe process
 - Enables testing identity-requiring APIs in Electron development
-- Uses existing AppxManifest.xml for identity configuration
+- Uses existing Package.appxmanifest for identity configuration
 
 **Examples:**
 
@@ -865,7 +865,7 @@ npx winapp node add-electron-debug-identity [options]
 npx winapp node add-electron-debug-identity
 
 # Use a custom manifest file
-npx winapp node add-electron-debug-identity --manifest ./custom/appxmanifest.xml
+npx winapp node add-electron-debug-identity --manifest ./custom/Package.appxmanifest
 ```
 
 ---

--- a/src/winapp-CLI/WinApp.Cli/Commands/ManifestUpdateAssetsCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/ManifestUpdateAssetsCommand.cs
@@ -59,7 +59,7 @@ internal class ManifestUpdateAssetsCommand : Command, IShortDescription
                 manifestPath = MsixService.FindProjectManifest(currentDirectoryProvider);
                 if (manifestPath == null)
                 {
-                    logger.LogError("{UISymbol} Could not find Package.appxmanifest in current directory or parent directories", UiSymbols.Error);
+                    logger.LogError("{UISymbol} Could not find Package.appxmanifest or appxmanifest.xml in current directory or parent directories", UiSymbols.Error);
                     return 1;
                 }
 

--- a/src/winapp-CLI/WinApp.Cli/Commands/ManifestUpdateAssetsCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/ManifestUpdateAssetsCommand.cs
@@ -59,7 +59,7 @@ internal class ManifestUpdateAssetsCommand : Command, IShortDescription
                 manifestPath = MsixService.FindProjectManifest(currentDirectoryProvider);
                 if (manifestPath == null)
                 {
-                    logger.LogError("{UISymbol} Could not find AppxManifest.xml/Package.appxmanifest in current directory or parent directories", UiSymbols.Error);
+                    logger.LogError("{UISymbol} Could not find Package.appxmanifest in current directory or parent directories", UiSymbols.Error);
                     return 1;
                 }
 

--- a/src/winapp-CLI/WinApp.Cli/Services/CertificateService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/CertificateService.cs
@@ -472,7 +472,7 @@ internal partial class CertificateService(
     /// Infers the publisher name using the specified hierarchy:
     /// 1. If explicit publisher is provided, use that
     /// 2. If manifest path is provided, extract publisher from that manifest
-    /// 3. If appxmanifest.xml is found in project (.winapp directory), use that
+    /// 3. If Package.appxmanifest is found in project (.winapp directory), use that
     /// 4. Use the system default publisher (from SystemDefaultsService.GetDefaultPublisherCN())
     /// </summary>
     private async Task<string> InferPublisherAsync(
@@ -504,7 +504,7 @@ internal partial class CertificateService(
             }
         }
 
-        // 3. If appxmanifest.xml is found in the current project, use that
+        // 3. If Package.appxmanifest is found in the current project, use that
         var projectManifestPath = MsixService.FindProjectManifest(currentDirectoryProvider);
         if (projectManifestPath != null)
         {

--- a/src/winapp-CLI/WinApp.Cli/Services/CertificateService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/CertificateService.cs
@@ -472,7 +472,7 @@ internal partial class CertificateService(
     /// Infers the publisher name using the specified hierarchy:
     /// 1. If explicit publisher is provided, use that
     /// 2. If manifest path is provided, extract publisher from that manifest
-    /// 3. If Package.appxmanifest is found in project (.winapp directory), use that
+    /// 3. If a project manifest is found by searching the current directory and parent directories (preferring Package.appxmanifest, then appxmanifest.xml), use that
     /// 4. Use the system default publisher (from SystemDefaultsService.GetDefaultPublisherCN())
     /// </summary>
     private async Task<string> InferPublisherAsync(

--- a/src/winapp-CLI/WinApp.Cli/Services/MsixService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/MsixService.cs
@@ -318,7 +318,7 @@ internal partial class MsixService(
             }
             else
             {
-                throw new FileNotFoundException($"Manifest file not found. Searched for Package.appxmanifest in: input folder ({inputFolder.FullName}), current directory ({currentDirectoryProvider.GetCurrentDirectory()})");
+                throw new FileNotFoundException($"Manifest file not found. Searched for Package.appxmanifest, then appxmanifest.xml in: input folder ({inputFolder.FullName}), current directory ({currentDirectoryProvider.GetCurrentDirectory()})");
             }
         }
 
@@ -677,10 +677,10 @@ internal partial class MsixService(
     }
 
     /// <summary>
-    /// Searches for Package.appxmanifest in the project by looking for .winapp directory in parent directories
+    /// Searches for a manifest file in the start directory and parent directories.
     /// </summary>
     /// <param name="startDirectory">The directory to start searching from. If null, uses current directory.</param>
-    /// <returns>Path to the project's Package.appxmanifest file, or null if not found</returns>
+    /// <returns>Path to the first manifest found (preferring Package.appxmanifest over appxmanifest.xml), or null if not found.</returns>
     public static FileInfo? FindProjectManifest(ICurrentDirectoryProvider currentDirectoryProvider, DirectoryInfo? startDirectory = null)
     {
         var directory = startDirectory ?? currentDirectoryProvider.GetCurrentDirectoryInfo();

--- a/src/winapp-CLI/WinApp.Cli/Services/MsixService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/MsixService.cs
@@ -677,7 +677,7 @@ internal partial class MsixService(
     }
 
     /// <summary>
-    /// Searches for a manifest file in the start directory and parent directories.
+    /// Searches for a manifest file in the start directory and walks up parent directories until one is found.
     /// </summary>
     /// <param name="startDirectory">The directory to start searching from. If null, uses current directory.</param>
     /// <returns>Path to the first manifest found (preferring Package.appxmanifest over appxmanifest.xml), or null if not found.</returns>

--- a/src/winapp-CLI/WinApp.Cli/Services/MsixService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/MsixService.cs
@@ -298,8 +298,8 @@ internal partial class MsixService(
 
         // Determine manifest path based on priority:
         // 1. Use provided manifestPath parameter
-        // 2. Check for appxmanifest.xml or package.appxmanifest in input folder
-        // 3. Check for appxmanifest.xml or package.appxmanifest in current directory
+        // 2. Check for Package.appxmanifest or appxmanifest.xml in input folder
+        // 3. Check for Package.appxmanifest or appxmanifest.xml in current directory
         FileInfo resolvedManifestPath;
         if (manifestPath != null)
         {
@@ -318,7 +318,7 @@ internal partial class MsixService(
             }
             else
             {
-                throw new FileNotFoundException($"Manifest file not found. Searched for appxmanifest.xml and package.appxmanifest in: input folder ({inputFolder.FullName}), current directory ({currentDirectoryProvider.GetCurrentDirectory()})");
+                throw new FileNotFoundException($"Manifest file not found. Searched for Package.appxmanifest in: input folder ({inputFolder.FullName}), current directory ({currentDirectoryProvider.GetCurrentDirectory()})");
             }
         }
 
@@ -677,10 +677,10 @@ internal partial class MsixService(
     }
 
     /// <summary>
-    /// Searches for appxmanifest.xml in the project by looking for .winapp directory in parent directories
+    /// Searches for Package.appxmanifest in the project by looking for .winapp directory in parent directories
     /// </summary>
     /// <param name="startDirectory">The directory to start searching from. If null, uses current directory.</param>
-    /// <returns>Path to the project's appxmanifest.xml file, or null if not found</returns>
+    /// <returns>Path to the project's Package.appxmanifest file, or null if not found</returns>
     public static FileInfo? FindProjectManifest(ICurrentDirectoryProvider currentDirectoryProvider, DirectoryInfo? startDirectory = null)
     {
         var directory = startDirectory ?? currentDirectoryProvider.GetCurrentDirectoryInfo();


### PR DESCRIPTION
## Description
Updates documentation and CLI error messages to prefer Package.appxmanifest over appxmanifest.xml, aligning docs with the naming convention already established in the CLI code.

## Related Issue
Fixes: #471 

## Type of Change
- 📝 Documentation

## Checklist
<!-- Delete the ones that do not apply to your changes -->
- [x] Tested locally on Windows
- [x] Main [README.md](../README.md) updated (if applicable)
- [x] Agent skill templates updated in `docs/fragments/skills/` (if CLI commands/workflows changed)
