### PR TITLE
fix(nuget): add compliant Copyright element for Microsoft NuGet policy

### DIFF
--- a/src/winapp-NuGet/Microsoft.Windows.SDK.BuildTools.WinApp.csproj
+++ b/src/winapp-NuGet/Microsoft.Windows.SDK.BuildTools.WinApp.csproj
@@ -13,6 +13,7 @@
     <Company>Microsoft Corporation</Company>
     <Product>Windows SDK Build Tools MSIX Extras</Product>
     <Description>Enables 'dotnet run' for packaged Windows applications. This package provides MSBuild targets that integrate with the .NET CLI to build, register, and launch packaged applications seamlessly.</Description>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>winui;msix;packaged;dotnet-run;msbuild;build-tools</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/microsoft/WinAppCli</PackageProjectUrl>


### PR DESCRIPTION
Adds the required `<Copyright>` element to `Microsoft.Windows.SDK.BuildTools.WinApp.csproj` so the NuGet package satisfies Microsoft's nuget.org compliance policy (https://aka.ms/Microsoft-NuGet-Compliance). Without this element, `nuget push` fails with HTTP 400: `The package metadata contains a non-compliant copyright element.`

Sets:

```xml
<Copyright>(c) Microsoft Corporation. All rights reserved.</Copyright>
```

(uses the © character in the actual file — exact string required by policy).

This was already cherry-picked to `rel/v0.3.0` as `f3db417` so the in-flight 0.3.0 NuGet republish can succeed. Merging here ensures future releases ship compliant metadata by default.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>