### PR TITLE
Update READMEs for VSC + Config for Pre-launch Build Task

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,15 @@ This repository includes samples demonstrating how to use the CLI with various f
 | [Tauri App](/samples/tauri-app/README.md) | Tauri cross-platform app with Rust backend |
 | [Flutter App](/samples/flutter-app/README.md) | Flutter desktop app with package identity and Windows App SDK |
 
+## 🧩 VS Code Extension
+
+The **WinApp VS Code Extension** brings WinApp CLI into Visual Studio Code. It can initialize projects, debug with package identity, package, sign, and more without leaving the editor. Press **F5** to launch your app with identity and automatically attach a debugger.
+
+> [!IMPORTANT]
+> The extension is not yet available in the VS Code Marketplace. Download the latest prerelease: [**VS Code Extension**](https://nightly.link/microsoft/WinAppCli/workflows/build-package/main/vscode-extension.zip)
+
+For setup, configuration, and troubleshooting details, see the [VS Code Extension README](./src/winapp-VSC/README.md).
+
 ## 🤖 Using with AI Coding Agents
 
 AI coding agents (GitHub Copilot, Claude Code, etc.) auto-discover skill files in your project.

--- a/src/winapp-VSC/README.md
+++ b/src/winapp-VSC/README.md
@@ -1,6 +1,6 @@
 # WinApp — VS Code Extension
 
-The **WinApp** extension brings the [Windows App Development CLI (WinApp CLI)](https://github.com/microsoft/WinAppCli) into Visual Studio Code so you can initialize, build, debug, package, and sign Windows applications without leaving the editor.
+The **WinApp** extension brings the [Windows App Development CLI (WinApp CLI)](https://github.com/microsoft/WinAppCli) into Visual Studio Code so you can initialize, debug, package, and sign Windows applications without leaving the editor.
 
 > **Status: Public Preview** — The WinApp CLI and this extension are experimental and in active development. We'd love your feedback! [File an issue](https://github.com/microsoft/WinAppCli/issues).
 

--- a/src/winapp-VSC/README.md
+++ b/src/winapp-VSC/README.md
@@ -162,7 +162,7 @@ For debugging, install the debugger extension that matches your app's language (
 
 | Problem | Cause | Solution |
 |---------|-------|----------|
-| **"No build output folder found"** when pressing F5 | The project hasn't been built yet, or the build output is in an unexpected location. | Build your project first (e.g., `dotnet build`), or set `inputFolder` in `launch.json` to point to the folder containing your `.exe`. |
+| **"No folders containing .exe files found in the workspace..."** or **"No build output folder selected..."** when pressing F5 | The project hasn't been built yet, or the build output is in an unexpected location. | Build your project first (e.g., `dotnet build`), or set `inputFolder` in `launch.json` to point to the folder containing your `.exe`. |
 | **Debugger doesn't attach** | The required debugger extension isn't installed. | Install the matching extension for your language — see [Supported debuggers](#integrated-debugging). |
 | **App launches but changes aren't visible** | The `winapp` debug type does not build the project automatically. | Rebuild your project before pressing F5, or add a `preLaunchTask` to automate it (see the tip in [Integrated Debugging](#integrated-debugging)). |
 | **Certificate trust error when running** | The development certificate isn't installed or has expired. | Run **WinApp: Generate Certificate** and choose to install it, or run **WinApp: Install Certificate** with your existing `.pfx` file. (requires Admin elevation) |

--- a/src/winapp-VSC/README.md
+++ b/src/winapp-VSC/README.md
@@ -1,8 +1,17 @@
 # WinApp — VS Code Extension
 
-The **WinApp** extension brings the [Windows App Development CLI (winapp CLI)](https://github.com/microsoft/WinAppCli) into Visual Studio Code so you can initialize, build, debug, package, and sign Windows applications without leaving the editor.
+The **WinApp** extension brings the [Windows App Development CLI (WinApp CLI)](https://github.com/microsoft/WinAppCli) into Visual Studio Code so you can initialize, build, debug, package, and sign Windows applications without leaving the editor.
 
-> **Status: Public Preview** — The winapp CLI and this extension are experimental and in active development. We'd love your feedback! [File an issue](https://github.com/microsoft/WinAppCli/issues).
+> **Status: Public Preview** — The WinApp CLI and this extension are experimental and in active development. We'd love your feedback! [File an issue](https://github.com/microsoft/WinAppCli/issues).
+
+## Get Started
+
+> [!IMPORTANT]
+> The WinApp VS Code Extension is not yet available in the VS Code Marketplace. We plan to publish the extension publicly soon. 
+
+Try the WinApp extension today by downloading our latest prerelease: [**VS Code Extension**](https://nightly.link/microsoft/WinAppCli/workflows/build-package/main/vscode-extension.zip)
+
+Simply navigate to the 'Extensions' tab in VS Code, and select the option to 'Install via VSIX...'. You may need to restart VS Code for the extension to begin working. 
 
 ## Features
 
@@ -18,10 +27,10 @@ All commands are accessible from the Command Palette (`Ctrl+Shift+P`). Type **Wi
 | **WinApp: Run Application** | Run your app as a loose-layout packaged application with full package identity — great for testing APIs that require identity. |
 | **WinApp: Create Debug Identity** | Add sparse package identity to an existing executable so you can launch and debug it directly from VS Code with identity. |
 | **WinApp: Create MSIX Package** | Package your application into an MSIX, with options to generate a certificate and bundle the runtime self-contained. |
-| **WinApp: Generate Manifest** | Generate an `AppxManifest.xml` from a template (packaged or sparse). |
+| **WinApp: Generate Manifest** | Generate an `Package.appxmanifest` from a template (packaged or sparse). |
 | **WinApp: Update Manifest Assets** | Auto-generate all required app icon assets from a single source image (PNG, JPG, GIF, or BMP). |
 | **WinApp: Generate Certificate** | Create a development certificate for signing, with an option to install it immediately. |
-| **WinApp: Install Certificate** | Install an existing `.pfx` or `.cer` certificate. |
+| **WinApp: Install Certificate** | Install an existing `.pfx` or `.cer` certificate. (requires Admin elevation) |
 | **WinApp: Sign Package** | Sign an MSIX package or executable with a certificate. |
 | **WinApp: Run SDK Tool** | Run Windows SDK tools (`makeappx`, `signtool`, `mt`, `makepri`) with custom arguments. |
 | **WinApp: Get WinApp Path** | Show paths to installed SDK components. |
@@ -37,6 +46,37 @@ The extension provides a **custom `winapp` debug type** that launches your app w
 3. You'll then have the option to select the build directory you'd like to run.
 4. It launches your app via `winapp run` to give it package identity.
 5. A child debug session attaches to the running process using the debugger you specified.
+
+> [!IMPORTANT]
+> The `winapp` debug type assumes your project has already been built and that a build output folder containing an `.exe` exists in your project. It **does not** build your project automatically — so after making code changes, you must rebuild your project before launching to see those changes reflected in the running app.
+
+> [!TIP]
+> You can automate the build step by adding a `preLaunchTask` to your `launch.json` configuration. This tells VS Code to run a build task before every debug session, so your changes are always compiled before launch.
+>
+> 1. Define a build task in `.vscode/tasks.json` (example for .NET):
+>    ```jsonc
+>    {
+>        "version": "2.0.0",
+>        "tasks": [
+>            {
+>                "label": "build",
+>                "command": "dotnet",
+>                "type": "process",
+>                "args": ["build", "${workspaceFolder}"],
+>                "problemMatcher": "$msCompile"
+>            }
+>        ]
+>    }
+>    ```
+> 2. Reference it in your `launch.json`:
+>    ```jsonc
+>    {
+>        "type": "winapp",
+>        "request": "launch",
+>        "name": "WinApp: Launch and Attach",
+>        "preLaunchTask": "build"
+>    }
+>    ```
 
 **Supported debuggers:**
 
@@ -88,7 +128,7 @@ See the full [Debugging Guide](https://github.com/microsoft/WinAppCli/blob/main/
 
 ### Generate manifests and assets
 
-Use **WinApp: Generate Manifest** to create an `AppxManifest.xml` from a template, then **WinApp: Update Manifest Assets** to auto-generate all required app icons from a single source image.
+Use **WinApp: Generate Manifest** to create an `Package.appxmanifest` from a template, then **WinApp: Update Manifest Assets** to auto-generate all required app icons from a single source image.
 
 ### Package and sign
 
@@ -117,6 +157,16 @@ The winapp CLI (and this extension) works with any Windows app framework:
 The winapp CLI is bundled with the extension — no separate installation required.
 
 For debugging, install the debugger extension that matches your app's language (see [Supported debuggers](#integrated-debugging) above).
+
+## Troubleshooting
+
+| Problem | Cause | Solution |
+|---------|-------|----------|
+| **"No build output folder found"** when pressing F5 | The project hasn't been built yet, or the build output is in an unexpected location. | Build your project first (e.g., `dotnet build`), or set `inputFolder` in `launch.json` to point to the folder containing your `.exe`. |
+| **Debugger doesn't attach** | The required debugger extension isn't installed. | Install the matching extension for your language — see [Supported debuggers](#integrated-debugging). |
+| **App launches but changes aren't visible** | The `winapp` debug type does not build the project automatically. | Rebuild your project before pressing F5, or add a `preLaunchTask` to automate it (see the tip in [Integrated Debugging](#integrated-debugging)). |
+| **Certificate trust error when running** | The development certificate isn't installed or has expired. | Run **WinApp: Generate Certificate** and choose to install it, or run **WinApp: Install Certificate** with your existing `.pfx` file. (requires Admin elevation) |
+| **"Access denied" or permission errors** | Some operations (certificate install, package registration) require elevation. | Run VS Code as Administrator, or use an elevated terminal for the failing command. |
 
 ## Feedback and Support
 

--- a/src/winapp-VSC/README.md
+++ b/src/winapp-VSC/README.md
@@ -27,7 +27,7 @@ All commands are accessible from the Command Palette (`Ctrl+Shift+P`). Type **Wi
 | **WinApp: Run Application** | Run your app as a loose-layout packaged application with full package identity — great for testing APIs that require identity. |
 | **WinApp: Create Debug Identity** | Add sparse package identity to an existing executable so you can launch and debug it directly from VS Code with identity. |
 | **WinApp: Create MSIX Package** | Package your application into an MSIX, with options to generate a certificate and bundle the runtime self-contained. |
-| **WinApp: Generate Manifest** | Generate an `Package.appxmanifest` from a template (packaged or sparse). |
+| **WinApp: Generate Manifest** | Generate a `Package.appxmanifest` from a template (packaged or sparse). |
 | **WinApp: Update Manifest Assets** | Auto-generate all required app icon assets from a single source image (PNG, JPG, GIF, or BMP). |
 | **WinApp: Generate Certificate** | Create a development certificate for signing, with an option to install it immediately. |
 | **WinApp: Install Certificate** | Install an existing `.pfx` or `.cer` certificate. (requires Admin elevation) |


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does and why -->
Update READMEs for VSC. Added VSC section to README at root. Updated VSC README to callout that VSC extension does not rebuild app project, it only launches.

Added instructions to README for how users can configure VS Code to rebuild their application before launching. 

## Related Issue
Fixes #490
Fixes #372 

## Type of Change

<!-- Keep the applicable line(s), delete the rest -->
- 📝 Documentation
- 
## Checklist
<!-- Delete the ones that do not apply to your changes -->

- [x] Tested locally on Windows
- [x] Main [README.md](../README.md) updated (if applicable)

## AI Description

<!-- ai-description-start -->
This update enhances the documentation for the WinApp VS Code Extension. A new section has been added to the root README to introduce the extension and outline its capabilities. The VSC-specific README now clarifies that the extension does not rebuild projects automatically and provides instructions for users to configure their VS Code settings to enable project rebuilding before launching the app.
<!-- ai-description-end -->
