### PR TITLE
Fix Redundant Labelling for WinApp Commands in VSCE

### DIFF
--- a/src/winapp-VSC/package.json
+++ b/src/winapp-VSC/package.json
@@ -38,82 +38,82 @@
     "commands": [
       {
         "command": "winapp.init",
-        "title": "WinApp: Initialize Project",
+        "title": "Initialize Project",
         "category": "WinApp"
       },
       {
         "command": "winapp.restore",
-        "title": "WinApp: Restore Packages",
+        "title": "Restore Packages",
         "category": "WinApp"
       },
       {
         "command": "winapp.update",
-        "title": "WinApp: Update Packages",
+        "title": "Update Packages",
         "category": "WinApp"
       },
       {
         "command": "winapp.pack",
-        "title": "WinApp: Create MSIX Package",
+        "title": "Create MSIX Package",
         "category": "WinApp"
       },
       {
         "command": "winapp.run",
-        "title": "WinApp: Run Application",
+        "title": "Run Application",
         "category": "WinApp"
       },
       {
         "command": "winapp.createDebugIdentity",
-        "title": "WinApp: Create Debug Identity",
+        "title": "Create Debug Identity",
         "category": "WinApp"
       },
       {
         "command": "winapp.manifestGenerate",
-        "title": "WinApp: Generate Manifest",
+        "title": "Generate Manifest",
         "category": "WinApp"
       },
       {
         "command": "winapp.manifestUpdateAssets",
-        "title": "WinApp: Update Manifest Assets",
+        "title": "Update Manifest Assets",
         "category": "WinApp"
       },
       {
         "command": "winapp.certGenerate",
-        "title": "WinApp: Generate Certificate",
+        "title": "Generate Certificate",
         "category": "WinApp"
       },
       {
         "command": "winapp.certInstall",
-        "title": "WinApp: Install Certificate",
+        "title": "Install Certificate",
         "category": "WinApp"
       },
       {
         "command": "winapp.sign",
-        "title": "WinApp: Sign Package",
+        "title": "Sign Package",
         "category": "WinApp"
       },
       {
         "command": "winapp.tool",
-        "title": "WinApp: Run SDK Tool",
+        "title": "Run SDK Tool",
         "category": "WinApp"
       },
       {
         "command": "winapp.getWinappPath",
-        "title": "WinApp: Get WinApp Path",
+        "title": "Get WinApp Path",
         "category": "WinApp"
       },
       {
         "command": "winapp.manifestAddAlias",
-        "title": "WinApp: Add Manifest Execution Alias",
+        "title": "Add Manifest Execution Alias",
         "category": "WinApp"
       },
       {
         "command": "winapp.unregister",
-        "title": "WinApp: Unregister Package",
+        "title": "Unregister Package",
         "category": "WinApp"
       },
       {
         "command": "winapp.certInfo",
-        "title": "WinApp: Certificate Info",
+        "title": "Certificate Info",
         "category": "WinApp"
       }
     ],


### PR DESCRIPTION
## Description

Fix Redundant Labelling for WinApp Commands in VSCE. All commands in command palette had "WinApp: WinApp: ..."

## Related Issue

<!-- Link to any related issues: Fixes #123, Closes #456, Related to #789 -->
Fixes #501

## Type of Change

<!-- Keep the applicable line(s), delete the rest -->

- 🐛 Bug fix

## Checklist
<!-- Delete the ones that do not apply to your changes -->
- [x] Tested locally on Windows

## Screenshots / Demo

<!-- If applicable, add screenshots or GIFs demonstrating the changes -->
<img width="1340" height="849" alt="image" src="https://github.com/user-attachments/assets/41ab82e3-92fe-4fb1-a813-5aff2728ccf9" />

## Additional Notes

<!-- Any additional information that reviewers should know -->

## AI Description

<!-- ai-description-start -->
This update removes the redundant "WinApp: " prefix from the titles of various WinApp commands in the Visual Studio Code extension, streamlining the command palette entries for a cleaner display. The commands affected include 'Initialize Project', 'Restore Packages', 'Update Packages', and several others, enhancing usability.

```json
{
  "command": "winapp.init",
  "title": "Initialize Project",
}
```
```json
{
  "command": "winapp.restore",
  "title": "Restore Packages",
}
```
<!-- ai-description-end -->
