### PR TITLE
Improve winapp ui --json output: stable envelopes, no leaks, no cycles

### DIFF
--- a/docs/ui-automation.md
+++ b/docs/ui-automation.md
@@ -456,14 +456,24 @@ winapp ui wait-for "Dialog Title" -a $pid --gone -t 5000
 
 ### Assert with JSON output
 Use `--json` with PowerShell or jq for more complex assertions:
+
+> **Exit-code contract for `search` and `wait-for` in `--json` mode:** when no element matches
+> (`search`) or the wait times out (`wait-for`), the command writes a fully parseable result envelope
+> to **stdout** (`{ "matchCount": 0, ... }` or `{ "found": false, "timedOut": true, ... }`) and
+> returns **exit code 1**. Stderr is empty in `--json` mode (logger output is suppressed).
+> Branch on the envelope fields, or on `$LASTEXITCODE`, depending on which is more ergonomic.
+
 ```powershell
 # Assert: search found exactly one match
 $result = winapp ui search "Submit" -a $pid --json | ConvertFrom-Json
 if ($result.matchCount -ne 1) { throw "Expected 1 Submit button, found $($result.matchCount)" }
 
 # Assert: element has expected properties
+# inspect --json returns { windows: [{ hwnd, title, elements: [...] }] };
+# each window's elements[] is the nested tree (children rendered via .children).
 $tree = winapp ui inspect "Counter Display" -a $pid --json | ConvertFrom-Json
-if ($tree.elements[0].name -ne "Count: 3") { throw "Counter value wrong: $($tree.elements[0].name)" }
+$counter = $tree.windows[0].elements[0]
+if ($counter.name -ne "Count: 3") { throw "Counter value wrong: $($counter.name)" }
 ```
 
 ### Full smoke test example

--- a/scripts/test-e2e-winui-ui.ps1
+++ b/scripts/test-e2e-winui-ui.ps1
@@ -285,7 +285,7 @@ Assert-WinappJsonField "list-windows" -WinappArgs @("ui", "list-windows", "-a", 
 Assert-WinappJsonField "status" -WinappArgs @("ui", "status", "-a", "$appPid", "--json") -Field "processName" -Expected "winui-app"
 
 # --- inspect (JSON) ---
-Assert-WinappJsonField "inspect --json" -WinappArgs @("ui", "inspect", "-a", "$appPid", "--json", "-d", "8") -Field "elements.0.type" -Expected "Window"
+Assert-WinappJsonField "inspect --json" -WinappArgs @("ui", "inspect", "-a", "$appPid", "--json", "-d", "8") -Field "windows.0.elements.0.type" -Expected "Window"
 
 # --- inspect interactive (exit code) ---
 Assert-WinappSuccess "inspect --interactive" -WinappArgs @("ui", "inspect", "-a", "$appPid", "-i")
@@ -363,10 +363,12 @@ $jsonResult = Invoke-Winapp @("ui", "inspect", "-a", "$appPid", "--json", "-d", 
 if ($jsonResult.ExitCode -eq 0) {
     try {
         $parsed = $jsonResult.Output | ConvertFrom-Json
-        if ($parsed.elements.Count -gt 0) {
-            Write-TestPass "inspect --json structure" "$($parsed.elements.Count) elements"
+        $totalElements = 0
+        foreach ($w in $parsed.windows) { $totalElements += $w.elementCount }
+        if ($parsed.windows.Count -gt 0 -and $totalElements -gt 0) {
+            Write-TestPass "inspect --json structure" "$($parsed.windows.Count) window(s), $totalElements element(s)"
         } else {
-            Write-TestFail "inspect --json structure" "No elements in JSON"
+            Write-TestFail "inspect --json structure" "No windows/elements in JSON"
         }
     } catch {
         Write-TestFail "inspect --json structure" "Invalid JSON: $_"

--- a/src/winapp-CLI/WinApp.Cli.Tests/FakeUiServices.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/FakeUiServices.cs
@@ -57,7 +57,6 @@ internal class FakeUiAutomationService : IUiAutomationService
         => Task.CompletedTask;
 
     public UiElement? FocusedResult { get; set; } = new UiElement { Id = "e0", Type = "Edit", Name = "FocusedElement" };
-    public bool FocusedResultSet { get; set; }
 
     public Task<UiElement?> GetFocusedElementAsync(UiSessionInfo session, CancellationToken ct)
         => Task.FromResult(FocusedResult);

--- a/src/winapp-CLI/WinApp.Cli.Tests/FakeUiServices.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/FakeUiServices.cs
@@ -56,8 +56,11 @@ internal class FakeUiAutomationService : IUiAutomationService
     public Task ScrollContainerAsync(UiSessionInfo session, UiElement element, string? direction, string? to, CancellationToken ct)
         => Task.CompletedTask;
 
+    public UiElement? FocusedResult { get; set; } = new UiElement { Id = "e0", Type = "Edit", Name = "FocusedElement" };
+    public bool FocusedResultSet { get; set; }
+
     public Task<UiElement?> GetFocusedElementAsync(UiSessionInfo session, CancellationToken ct)
-        => Task.FromResult<UiElement?>(new UiElement { Id = "e0", Type = "Edit", Name = "FocusedElement" });
+        => Task.FromResult(FocusedResult);
 
     public Task<string?> GetTextAsync(UiSessionInfo session, UiElement element, CancellationToken ct)
         => Task.FromResult<string?>("fake text content");

--- a/src/winapp-CLI/WinApp.Cli.Tests/UiCommandTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/UiCommandTests.cs
@@ -43,16 +43,89 @@ public class UiCommandTests : BaseCommandTests
     [TestMethod]
     public async Task Inspect_ReturnsElements()
     {
+        // Inspect returns a DFS-ordered flat list with depth values; the JSON path nests them
+        // into windows[].elements[].children[]. Setting Depth lets the depth-stack reconstruct
+        // the tree (Window contains Button as a child).
         _fakeUia.InspectResult = [
-            new UiElement { Id = "e0", Type = "Window", Name = "Test", IsEnabled = true, Width = 800, Height = 600 },
-            new UiElement { Id = "e1", Type = "Button", Name = "OK", IsEnabled = true, Width = 100, Height = 30 }
+            new UiElement { Id = "e0", Type = "Window", Name = "Test", Depth = 0, IsEnabled = true, Width = 800, Height = 600 },
+            new UiElement { Id = "e1", Type = "Button", Name = "OK", Depth = 1, IsEnabled = true, Width = 100, Height = 30 }
         ];
 
         var command = GetRequiredService<UiInspectCommand>();
         var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["-a", "TestApp", "--json"]);
         Assert.AreEqual(0, exitCode);
-        StringAssert.Contains(TestAnsiConsole.Output, "\"id\": \"e0\"");
+        // New nested-tree shape: top-level "windows" array, each with nested "elements" -> "children".
+        StringAssert.Contains(TestAnsiConsole.Output, "\"windows\":");
+        StringAssert.Contains(TestAnsiConsole.Output, "\"elements\":");
+        StringAssert.Contains(TestAnsiConsole.Output, "\"children\":");
         StringAssert.Contains(TestAnsiConsole.Output, "\"type\": \"Window\"");
+        StringAssert.Contains(TestAnsiConsole.Output, "\"type\": \"Button\"");
+    }
+
+    [TestMethod]
+    public async Task Inspect_Json_OmitsRedundantFields()
+    {
+        // The internal element id (e0/e1) is implementation detail — selectors are the public handle.
+        // Element-level depth/parentSelector/windowHandle are also redundant in nested form
+        // (implied by tree position). Note the request-level "depth" option is still emitted at
+        // the top of the envelope; we're asserting on per-element fields only.
+        _fakeUia.InspectResult = [
+            new UiElement { Id = "e0", Type = "Window", Name = "Test", Depth = 0, ParentSelector = "p", WindowHandle = 42 }
+        ];
+
+        var command = GetRequiredService<UiInspectCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["-a", "TestApp", "--json"]);
+        Assert.AreEqual(0, exitCode);
+        var output = TestAnsiConsole.Output;
+        // No "id" property anywhere (top-level envelope has no id either).
+        StringAssert.DoesNotMatch(output, new System.Text.RegularExpressions.Regex("\"id\"\\s*:"));
+        // Element-level redundant fields stripped.
+        StringAssert.DoesNotMatch(output, new System.Text.RegularExpressions.Regex("\"parentSelector\"\\s*:"));
+        // windowHandle moved up to the window envelope ("hwnd"); element's windowHandle: 42 must be gone.
+        Assert.IsFalse(output.Contains("\"windowHandle\""), "windowHandle should be stripped from elements");
+    }
+
+    [TestMethod]
+    public async Task Inspect_Interactive_AddsAncestorPath()
+    {
+        // --interactive collapses non-interactive ancestors (Window/Pane/Group) out of the tree
+        // and surfaces them as ancestorPath on the surviving interactive descendants (e.g., Button).
+        _fakeUia.InspectResult = [
+            new UiElement { Id = "e0", Type = "Window", Name = "App",  Depth = 0 },
+            new UiElement { Id = "e1", Type = "Pane",   Name = "Root", Depth = 1 },
+            new UiElement { Id = "e2", Type = "Group",  Name = "Bar",  Depth = 2 },
+            new UiElement { Id = "e3", Type = "Button", Name = "OK",   Depth = 3, IsEnabled = true }
+        ];
+
+        var command = GetRequiredService<UiInspectCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["-a", "TestApp", "--interactive", "--json"]);
+        Assert.AreEqual(0, exitCode);
+        var output = TestAnsiConsole.Output;
+        StringAssert.Contains(output, "\"type\": \"Button\"");
+        // Window/Pane/Group are non-interactive — they should be dropped from the tree...
+        StringAssert.DoesNotMatch(output, new System.Text.RegularExpressions.Regex("\"type\"\\s*:\\s*\"Window\""));
+        StringAssert.DoesNotMatch(output, new System.Text.RegularExpressions.Regex("\"type\"\\s*:\\s*\"Pane\""));
+        StringAssert.DoesNotMatch(output, new System.Text.RegularExpressions.Regex("\"type\"\\s*:\\s*\"Group\""));
+        // ...but their types should appear in ancestorPath on Button.
+        StringAssert.Contains(output, "\"ancestorPath\":");
+        StringAssert.Contains(output, "\"Window\"");
+        StringAssert.Contains(output, "\"Pane\"");
+        StringAssert.Contains(output, "\"Group\"");
+    }
+
+    [TestMethod]
+    public async Task Inspect_Json_HasMoreChildrenHint()
+    {
+        // When WalkTree hits the depth limit but more children exist, it sets HasMoreChildren=true.
+        // The JSON output should preserve this hint so consumers can prompt for a deeper inspect.
+        _fakeUia.InspectResult = [
+            new UiElement { Id = "e0", Type = "Window", Depth = 0, HasMoreChildren = true }
+        ];
+
+        var command = GetRequiredService<UiInspectCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["-a", "TestApp", "--json"]);
+        Assert.AreEqual(0, exitCode);
+        StringAssert.Contains(TestAnsiConsole.Output, "\"hasMoreChildren\": true");
     }
 
     [TestMethod]
@@ -67,6 +140,21 @@ public class UiCommandTests : BaseCommandTests
         var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["Button", "-a", "TestApp", "--json"]);
         Assert.AreEqual(0, exitCode);
         StringAssert.Contains(TestAnsiConsole.Output, "\"matchCount\": 2");
+    }
+
+    [TestMethod]
+    public async Task Search_Json_OmitsInternalId()
+    {
+        // Selectors are the stable public handle; the internal "e0/e1" counter is implementation detail.
+        _fakeUia.SearchResult = [
+            new UiElement { Id = "e0", Type = "Button", Name = "OK", Selector = "btn-ok-a1b2" }
+        ];
+
+        var command = GetRequiredService<UiSearchCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["Button", "-a", "TestApp", "--json"]);
+        Assert.AreEqual(0, exitCode);
+        StringAssert.DoesNotMatch(TestAnsiConsole.Output, new System.Text.RegularExpressions.Regex("\"id\"\\s*:"));
+        StringAssert.Contains(TestAnsiConsole.Output, "\"selector\": \"btn-ok-a1b2\"");
     }
 
     [TestMethod]
@@ -192,6 +280,51 @@ public class UiCommandTests : BaseCommandTests
     }
 
     [TestMethod]
+    public async Task WaitFor_Json_OmitsInternalId()
+    {
+        _fakeUia.FindSingleResult = new UiElement { Id = "e0", Type = "Button", Name = "Submit", Selector = "btn-submit-a1b2" };
+
+        var command = GetRequiredService<UiWaitForCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["Button", "-a", "TestApp", "--timeout", "1000", "--json"]);
+        Assert.AreEqual(0, exitCode);
+        var output = TestAnsiConsole.Output;
+        StringAssert.Contains(output, "\"found\": true");
+        StringAssert.DoesNotMatch(output, new System.Text.RegularExpressions.Regex("\"id\"\\s*:"));
+        StringAssert.Contains(output, "\"selector\": \"btn-submit-a1b2\"");
+    }
+
+    [TestMethod]
+    public async Task GetFocused_Json_NoFocus_EmitsEnvelope()
+    {
+        // When no element has keyboard focus the JSON output must still be a parsable object,
+        // not a bare "null" — consumers need a stable schema with hasFocus to detect the case.
+        _fakeUia.FocusedResult = null;
+
+        var command = GetRequiredService<UiGetFocusedCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["-a", "TestApp", "--json"]);
+        Assert.AreEqual(0, exitCode);
+        var output = TestAnsiConsole.Output.Trim();
+        Assert.AreNotEqual("null", output, "Bare null is unhelpful — should be an envelope object.");
+        StringAssert.Contains(output, "\"hasFocus\": false");
+    }
+
+    [TestMethod]
+    public async Task GetFocused_Json_WithFocus_EmitsEnvelope()
+    {
+        _fakeUia.FocusedResult = new UiElement { Id = "e0", Type = "Edit", Name = "TextBox", Selector = "edit-textbox-a1b2" };
+
+        var command = GetRequiredService<UiGetFocusedCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["-a", "TestApp", "--json"]);
+        Assert.AreEqual(0, exitCode);
+        var output = TestAnsiConsole.Output;
+        StringAssert.Contains(output, "\"hasFocus\": true");
+        StringAssert.Contains(output, "\"element\":");
+        StringAssert.Contains(output, "\"selector\": \"edit-textbox-a1b2\"");
+        // Internal id should not leak into the focused envelope either.
+        StringAssert.DoesNotMatch(output, new System.Text.RegularExpressions.Regex("\"id\"\\s*:"));
+    }
+
+    [TestMethod]
     public async Task WaitFor_NonExistent_TimesOut()
     {
         _fakeUia.SearchResult = [];
@@ -213,5 +346,203 @@ public class UiCommandTests : BaseCommandTests
         var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["-a", "TestApp", "--json"]);
         Assert.AreEqual(0, exitCode);
         StringAssert.Contains(TestAnsiConsole.Output, "\"hwnd\": 1001");
+    }
+
+    // ---------------------------------------------------------------------
+    // Tree-shape edge cases (M9): ensure BuildWindows/NestElements parse
+    // unusual but realistic flat lists into the right window/root layout.
+    // ---------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task Inspect_Json_MultipleWindows_GroupsBySeparator()
+    {
+        // Two windows separated by a "---" entry. JSON output must be two windows[] entries,
+        // each with its own elements[] tree. (Separators come from MsixService walk; the Name
+        // field carries the HWND/title metadata parsed by SeparatorRegex.)
+        _fakeUia.InspectResult = [
+            new UiElement { Type = "---", Name = "HWND 100: \"Window A\" (App, Win32Class)", WindowHandle = 100 },
+            new UiElement { Id = "e0", Type = "Window", Name = "A", Depth = 0, IsEnabled = true },
+            new UiElement { Id = "e1", Type = "Button", Name = "OK", Depth = 1, IsEnabled = true },
+            new UiElement { Type = "---", Name = "HWND 200: \"Window B\" (App, Win32Class)", WindowHandle = 200 },
+            new UiElement { Id = "e2", Type = "Window", Name = "B", Depth = 0, IsEnabled = true },
+        ];
+
+        var command = GetRequiredService<UiInspectCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["-a", "TestApp", "--json"]);
+        Assert.AreEqual(0, exitCode);
+        var output = TestAnsiConsole.Output;
+        StringAssert.Contains(output, "\"hwnd\": 100");
+        StringAssert.Contains(output, "\"hwnd\": 200");
+        StringAssert.Contains(output, "\"title\": \"Window A\"");
+        StringAssert.Contains(output, "\"title\": \"Window B\"");
+    }
+
+    [TestMethod]
+    public async Task Inspect_Json_DepthJump_KeepsSiblings()
+    {
+        // Depth 0 -> 2 (skipping 1). The depth-stack should still nest the Button under the
+        // Window (any node with depth > root depth becomes a descendant), not as a root sibling.
+        _fakeUia.InspectResult = [
+            new UiElement { Id = "e0", Type = "Window", Name = "Root", Depth = 0, IsEnabled = true },
+            new UiElement { Id = "e1", Type = "Button", Name = "Deep", Depth = 2, IsEnabled = true }
+        ];
+
+        var command = GetRequiredService<UiInspectCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["-a", "TestApp", "--json"]);
+        Assert.AreEqual(0, exitCode);
+        var output = TestAnsiConsole.Output;
+        StringAssert.Contains(output, "\"type\": \"Window\"");
+        StringAssert.Contains(output, "\"type\": \"Button\"");
+        StringAssert.Contains(output, "\"children\":");
+    }
+
+    [TestMethod]
+    public async Task Inspect_Interactive_Json_FlattensInvokableAncestor_NoCycle()
+    {
+        // Regression for the InvokableAncestor reference cycle:
+        // - Group is non-interactive but invokable (both surface in --interactive).
+        // - Button is invokable; AttachInvokableAncestors links Button.InvokableAncestor = Group.
+        // - In the resulting JSON tree Group also has Button as a child.
+        // Without flattening, System.Text.Json (no ReferenceHandler) throws on the
+        // Group -> children -> Button -> invokableAncestor -> Group cycle.
+        _fakeUia.InspectResult = [
+            new UiElement { Id = "e0", Type = "Window", Name = "App",  Depth = 0 },
+            new UiElement { Id = "e1", Type = "Group",  Name = "Bar",  Depth = 1, IsInvokable = true, Selector = "grp-bar-aaaa" },
+            new UiElement { Id = "e2", Type = "Button", Name = "OK",   Depth = 2, IsEnabled = true, IsInvokable = false, Selector = "btn-ok-bbbb", ParentSelector = "grp-bar-aaaa" }
+        ];
+
+        var command = GetRequiredService<UiInspectCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["-a", "TestApp", "--interactive", "--json"]);
+        Assert.AreEqual(0, exitCode);
+        var output = TestAnsiConsole.Output;
+        // Did not throw on serialization. InvokableAncestor still present as a hint…
+        StringAssert.Contains(output, "\"invokableAncestor\":");
+        StringAssert.Contains(output, "\"selector\": \"grp-bar-aaaa\"");
+        // …but flattened — no nested children/invokableAncestor inside it.
+        // (Children still appears in the outer Button node, but the ancestor hint object should not contain a "children" key.)
+        // We assert a structural property that proves the projection: the hint copy has no AutomationId on this fixture.
+        StringAssert.Contains(output, "\"isInvokable\": true");
+    }
+
+    [TestMethod]
+    public async Task Search_Json_FlattensInvokableAncestor_Scrubs()
+    {
+        // Search results with an InvokableAncestor must (a) not leak the ancestor's internal id /
+        // parentSelector / windowHandle, and (b) flatten its Children/InvokableAncestor chain.
+        var ancestor = new UiElement
+        {
+            Id = "e9", Type = "Group", Selector = "grp-toolbar-1234",
+            ParentSelector = "wnd-app-0000", WindowHandle = 99,
+            IsInvokable = true,
+            Children = [new UiElement { Id = "e10", Type = "Button" }]
+        };
+        _fakeUia.SearchResult = [
+            new UiElement
+            {
+                Id = "e0", Type = "MenuItem", Name = "Open", Selector = "mi-open-abcd",
+                ParentSelector = "grp-toolbar-1234", WindowHandle = 99,
+                InvokableAncestor = ancestor
+            }
+        ];
+
+        var command = GetRequiredService<UiSearchCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["Open", "-a", "TestApp", "--json"]);
+        Assert.AreEqual(0, exitCode);
+        var output = TestAnsiConsole.Output;
+        StringAssert.Contains(output, "\"selector\": \"mi-open-abcd\"");
+        StringAssert.Contains(output, "\"invokableAncestor\":");
+        StringAssert.Contains(output, "\"selector\": \"grp-toolbar-1234\"");
+        // Internal/redundant fields stripped at every level (top-level + nested ancestor).
+        StringAssert.DoesNotMatch(output, new System.Text.RegularExpressions.Regex("\"id\"\\s*:"));
+        StringAssert.DoesNotMatch(output, new System.Text.RegularExpressions.Regex("\"parentSelector\"\\s*:"));
+        StringAssert.DoesNotMatch(output, new System.Text.RegularExpressions.Regex("\"windowHandle\"\\s*:"));
+    }
+
+    [TestMethod]
+    public async Task Inspect_Ancestors_Json_NestsChain()
+    {
+        // M3 regression: InspectAncestorsAsync returns root..target with no Depth assigned.
+        // The command must assign Depth = i so BuildWindows nests them as a single chain
+        // instead of flattening them into N sibling roots.
+        // Fake's InspectAncestorsAsync mirrors InspectResult, so populate that.
+        _fakeUia.InspectResult = [
+            new UiElement { Id = "e0", Type = "Window", Name = "App",  IsEnabled = true, Selector = "wnd-app-aaaa" },
+            new UiElement { Id = "e1", Type = "Pane",   Name = "Root", IsEnabled = true, Selector = "pn-root-bbbb" },
+            new UiElement { Id = "e2", Type = "Group",  Name = "Bar",  IsEnabled = true, Selector = "grp-bar-cccc" },
+            new UiElement { Id = "e3", Type = "Button", Name = "OK",   IsEnabled = true, Selector = "btn-ok-dddd" }
+        ];
+
+        var command = GetRequiredService<UiInspectCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["btn-ok-dddd", "-a", "TestApp", "--ancestors", "--json"]);
+        Assert.AreEqual(0, exitCode);
+        var output = TestAnsiConsole.Output;
+        // All four types present...
+        StringAssert.Contains(output, "\"selector\": \"wnd-app-aaaa\"");
+        StringAssert.Contains(output, "\"selector\": \"btn-ok-dddd\"");
+        // ...and the chain is nested (the Window has at least one child layer of nesting).
+        StringAssert.Contains(output, "\"children\":");
+        // elementCount should reflect all 4 elements when properly nested.
+        StringAssert.Contains(output, "\"elementCount\": 4");
+    }
+
+    // ---------------------------------------------------------------------
+    // NativeAOT smoke tests (M10): exercise each result-type registration in
+    // UiJsonContext at least once via --json so a missing/incorrect registration
+    // fails Debug too instead of only blowing up in the published trim build.
+    // ---------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task Click_Json_EmitsEnvelope()
+    {
+        _fakeUia.FindSingleResult = new UiElement { Id = "e0", Type = "Button", Selector = "btn-go-1234", X = 10, Y = 20, Width = 100, Height = 30 };
+
+        var command = GetRequiredService<UiClickCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["btn-go-1234", "-a", "TestApp", "--json"]);
+        Assert.AreEqual(0, exitCode);
+        StringAssert.Contains(TestAnsiConsole.Output, "\"clickType\":");
+    }
+
+    [TestMethod]
+    public async Task Focus_Json_EmitsEnvelope()
+    {
+        _fakeUia.FindSingleResult = new UiElement { Id = "e0", Type = "Edit", Selector = "edit-name-1234" };
+
+        var command = GetRequiredService<UiFocusCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["edit-name-1234", "-a", "TestApp", "--json"]);
+        Assert.AreEqual(0, exitCode);
+        StringAssert.Contains(TestAnsiConsole.Output, "\"elementId\":");
+    }
+
+    [TestMethod]
+    public async Task SetValue_Json_EmitsEnvelope()
+    {
+        _fakeUia.FindSingleResult = new UiElement { Id = "e1", Type = "Edit", Selector = "edit-name-1234" };
+
+        var command = GetRequiredService<UiSetValueCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["edit-name-1234", "Hello", "-a", "TestApp", "--json"]);
+        Assert.AreEqual(0, exitCode);
+        StringAssert.Contains(TestAnsiConsole.Output, "\"elementId\":");
+    }
+
+    [TestMethod]
+    public async Task Scroll_Json_EmitsEnvelope()
+    {
+        _fakeUia.FindSingleResult = new UiElement { Id = "e0", Type = "List", Selector = "lst-items-1234" };
+
+        var command = GetRequiredService<UiScrollCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["lst-items-1234", "--direction", "down", "-a", "TestApp", "--json"]);
+        Assert.AreEqual(0, exitCode);
+        StringAssert.Contains(TestAnsiConsole.Output, "\"direction\":");
+    }
+
+    [TestMethod]
+    public async Task ScrollIntoView_Json_EmitsEnvelope()
+    {
+        _fakeUia.FindSingleResult = new UiElement { Id = "e0", Type = "ListItem", Selector = "li-row42-1234" };
+
+        var command = GetRequiredService<UiScrollIntoViewCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["li-row42-1234", "-a", "TestApp", "--json"]);
+        Assert.AreEqual(0, exitCode);
+        StringAssert.Contains(TestAnsiConsole.Output, "\"elementId\":");
     }
 }

--- a/src/winapp-CLI/WinApp.Cli.Tests/WinApp.Cli.Tests.csproj
+++ b/src/winapp-CLI/WinApp.Cli.Tests/WinApp.Cli.Tests.csproj
@@ -10,7 +10,10 @@
     <AnalysisMode>Recommended</AnalysisMode>
     
     <!-- Suppress specific warnings -->
-    <NoWarn>CA1852;CA1707;IDE1006</NoWarn>
+    <!-- SYSLIB1045: inline Regex constructions in test assertions are throwaway literals
+         (used by StringAssert.DoesNotMatch); compile-time GeneratedRegex source-gen would
+         add zero value here and only bloat the test file. -->
+    <NoWarn>CA1852;CA1707;IDE1006;SYSLIB1045</NoWarn>
     
     <!-- Test discovery and execution -->
     <IsPackable>false</IsPackable>

--- a/src/winapp-CLI/WinApp.Cli/Commands/UiClickCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/UiClickCommand.cs
@@ -49,23 +49,23 @@ internal class UiClickCommand : Command, IShortDescription
     {
         public override async Task<int> InvokeAsync(ParseResult parseResult, CancellationToken cancellationToken = default)
         {
+            var json = parseResult.GetValue(WinAppRootCommand.JsonOption);
             var selectorStr = parseResult.GetValue(SharedUiOptions.SelectorArgument);
             var app = parseResult.GetValue(SharedUiOptions.AppOption);
             var window = parseResult.GetValue(SharedUiOptions.WindowOption);
 
             if (string.IsNullOrWhiteSpace(app) && window is null)
             {
-                UiErrors.MissingApp(logger);
+                UiErrors.MissingApp(logger, json);
                 return 1;
             }
 
             if (string.IsNullOrWhiteSpace(selectorStr))
             {
-                UiErrors.MissingSelector(logger, "click");
+                UiErrors.MissingSelector(logger, "click", json);
                 return 1;
             }
 
-            var json = parseResult.GetValue(WinAppRootCommand.JsonOption);
             var doubleClick = parseResult.GetValue(DoubleClickOption);
             var rightClick = parseResult.GetValue(RightClickOption);
 
@@ -77,7 +77,7 @@ internal class UiClickCommand : Command, IShortDescription
 
                 if (element is null)
                 {
-                    UiErrors.ElementNotFound(logger, selectorStr);
+                    UiErrors.ElementNotFound(logger, selectorStr, json);
                     return 1;
                 }
 
@@ -90,6 +90,7 @@ internal class UiClickCommand : Command, IShortDescription
                 if (element.Width == 0 || element.Height == 0)
                 {
                     logger.LogError("{Symbol} Element has zero size — cannot click.", UiSymbols.Error);
+                    UiJsonError.Emit(json, UiJsonError.CodeZeroSize, "Element has zero size — cannot click.", selectorStr);
                     return 1;
                 }
 
@@ -104,7 +105,7 @@ internal class UiClickCommand : Command, IShortDescription
                 // Perform the click via SendInput
                 MouseInput.Click(centerX, centerY, doubleClick, rightClick);
 
-                var elementId = element.Selector ?? element.Id;
+                var elementId = (element.Selector ?? element.Id ?? "");
 
                 if (json)
                 {
@@ -130,12 +131,12 @@ internal class UiClickCommand : Command, IShortDescription
             catch (System.Runtime.InteropServices.COMException comEx)
             {
                 logger.LogDebug("COM error: {HResult} {StackTrace}", comEx.HResult, comEx.StackTrace);
-                UiErrors.StaleElement(logger);
+                UiErrors.StaleElement(logger, json);
                 return 1;
             }
             catch (Exception ex)
             {
-                UiErrors.GenericError(logger, ex);
+                UiErrors.GenericError(logger, ex, json);
                 return 1;
             }
         }

--- a/src/winapp-CLI/WinApp.Cli/Commands/UiFocusCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/UiFocusCommand.cs
@@ -36,20 +36,20 @@ internal class UiFocusCommand : Command, IShortDescription
     {
         public override async Task<int> InvokeAsync(ParseResult parseResult, CancellationToken cancellationToken = default)
         {
+            var json = parseResult.GetValue(WinAppRootCommand.JsonOption);
             var selectorStr = parseResult.GetValue(SharedUiOptions.SelectorArgument);
             var app = parseResult.GetValue(SharedUiOptions.AppOption);
             var window = parseResult.GetValue(SharedUiOptions.WindowOption);
 
             if (string.IsNullOrWhiteSpace(app) && window is null)
             {
-                UiErrors.MissingApp(logger);
+                UiErrors.MissingApp(logger, json);
                 return 1;
             }
-            var json = parseResult.GetValue(WinAppRootCommand.JsonOption);
 
             if (string.IsNullOrWhiteSpace(selectorStr))
             {
-                UiErrors.MissingSelector(logger, "focus");
+                UiErrors.MissingSelector(logger, "focus", json);
                 return 1;
             }
 
@@ -61,32 +61,32 @@ internal class UiFocusCommand : Command, IShortDescription
 
                 if (element is null)
                 {
-                    UiErrors.ElementNotFound(logger, selectorStr);
+                    UiErrors.ElementNotFound(logger, selectorStr, json);
                     return 1;
                 }
 
                 await uiAutomation.FocusAsync(session, element, cancellationToken);
                 if (json)
                 {
-                    var result = new UiFocusResult { ElementId = element.Selector ?? element.Id, Hwnd = session.WindowHandle };
+                    var result = new UiFocusResult { ElementId = (element.Selector ?? element.Id ?? ""), Hwnd = session.WindowHandle };
                     ansiConsole.Profile.Out.Writer.WriteLine(
                         JsonSerializer.Serialize(result, UiJsonContext.Default.UiFocusResult));
                 }
                 else
                 {
-                    logger.LogInformation("Focused {ElementId}", element.Selector ?? element.Id);
+                    logger.LogInformation("Focused {ElementId}", (element.Selector ?? element.Id ?? ""));
                 }
                 return 0;
             }
             catch (System.Runtime.InteropServices.COMException comEx)
             {
                 logger.LogDebug("COM error: {HResult} {StackTrace}", comEx.HResult, comEx.StackTrace);
-                UiErrors.StaleElement(logger);
+                UiErrors.StaleElement(logger, json);
                 return 1;
             }
             catch (Exception ex)
             {
-                UiErrors.GenericError(logger, ex);
+                UiErrors.GenericError(logger, ex, json);
                 return 1;
             }
         }

--- a/src/winapp-CLI/WinApp.Cli/Commands/UiGetFocusedCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/UiGetFocusedCommand.cs
@@ -32,62 +32,57 @@ internal class UiGetFocusedCommand : Command, IShortDescription
     {
         public override async Task<int> InvokeAsync(ParseResult parseResult, CancellationToken cancellationToken = default)
         {
+            var json = parseResult.GetValue(WinAppRootCommand.JsonOption);
             var app = parseResult.GetValue(SharedUiOptions.AppOption);
             var window = parseResult.GetValue(SharedUiOptions.WindowOption);
 
             if (string.IsNullOrWhiteSpace(app) && window is null)
             {
-                UiErrors.MissingApp(logger);
+                UiErrors.MissingApp(logger, json);
                 return 1;
             }
-            var json = parseResult.GetValue(WinAppRootCommand.JsonOption);
 
             try
             {
                 var session = await sessionService.ResolveSessionAsync(app, window, cancellationToken);
                 var element = await uiAutomation.GetFocusedElementAsync(session, cancellationToken);
 
-                if (element is null)
+                if (json)
                 {
-                    if (!json)
-                    {
-                        logger.LogInformation("No element has keyboard focus in this app");
-                    }
+                    UiElementScrubber.Scrub(element);
+                    var result = new UiFocusedResult { HasFocus = element is not null, Element = element };
+                    ansiConsole.Profile.Out.Writer.WriteLine(
+                        JsonSerializer.Serialize(result, UiJsonContext.Default.UiFocusedResult));
                     return 0;
                 }
 
-                if (json)
+                if (element is null)
                 {
-                    ansiConsole.Profile.Out.Writer.WriteLine(
-                        JsonSerializer.Serialize(element, UiJsonContext.Default.UiElement));
-                }
-                else
-                {
-                    var sel = element.Selector ?? element.Id;
-                    var displayName = element.Name ?? element.AutomationId;
-                    var name = displayName is not null && displayName != sel
-                        ? $" [green]\"{Markup.Escape(displayName)}\"[/]" : "";
-                    var value = element.Value is not null && element.Value != element.Name
-                        ? $" [yellow]value=\"{Markup.Escape(element.Value)}\"[/]" : "";
-                    var bounds = element.Width > 0 ? $" [grey]({element.X},{element.Y} {element.Width}x{element.Height})[/]" : "";
-                    ansiConsole.MarkupLine($"[bold cyan]{Markup.Escape(sel)}[/] {element.Type}{name}{value}{bounds}");
+                    logger.LogInformation("No element has keyboard focus in this app");
+                    return 0;
                 }
 
-                if (!json)
-                {
-                    logger.LogInformation("Focused: {Type} {Name}", element.Type, element.Name ?? "(unnamed)");
-                }
+                var sel = element.Selector ?? element.Id ?? "";
+                var displayName = element.Name ?? element.AutomationId;
+                var name = displayName is not null && displayName != sel
+                    ? $" [green]\"{Markup.Escape(displayName)}\"[/]" : "";
+                var value = element.Value is not null && element.Value != element.Name
+                    ? $" [yellow]value=\"{Markup.Escape(element.Value)}\"[/]" : "";
+                var bounds = element.Width > 0 ? $" [grey]({element.X},{element.Y} {element.Width}x{element.Height})[/]" : "";
+                ansiConsole.MarkupLine($"[bold cyan]{Markup.Escape(sel)}[/] {element.Type}{name}{value}{bounds}");
+
+                logger.LogInformation("Focused: {Type} {Name}", element.Type, element.Name ?? "(unnamed)");
                 return 0;
             }
             catch (System.Runtime.InteropServices.COMException comEx)
             {
                 logger.LogDebug("COM error: {HResult} {StackTrace}", comEx.HResult, comEx.StackTrace);
-                UiErrors.StaleElement(logger);
+                UiErrors.StaleElement(logger, json);
                 return 1;
             }
             catch (Exception ex)
             {
-                UiErrors.GenericError(logger, ex);
+                UiErrors.GenericError(logger, ex, json);
                 return 1;
             }
         }

--- a/src/winapp-CLI/WinApp.Cli/Commands/UiGetPropertyCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/UiGetPropertyCommand.cs
@@ -37,20 +37,20 @@ internal class UiGetPropertyCommand : Command, IShortDescription
     {
         public override async Task<int> InvokeAsync(ParseResult parseResult, CancellationToken cancellationToken = default)
         {
+            var json = parseResult.GetValue(WinAppRootCommand.JsonOption);
             var selectorStr = parseResult.GetValue(SharedUiOptions.SelectorArgument);
             var app = parseResult.GetValue(SharedUiOptions.AppOption);
             var window = parseResult.GetValue(SharedUiOptions.WindowOption);
 
             if (string.IsNullOrWhiteSpace(app) && window is null)
             {
-                UiErrors.MissingApp(logger);
+                UiErrors.MissingApp(logger, json);
                 return 1;
             }
-            var json = parseResult.GetValue(WinAppRootCommand.JsonOption);
 
             if (string.IsNullOrWhiteSpace(selectorStr))
             {
-                UiErrors.MissingSelector(logger, "get-property");
+                UiErrors.MissingSelector(logger, "get-property", json);
                 return 1;
             }
 
@@ -64,7 +64,7 @@ internal class UiGetPropertyCommand : Command, IShortDescription
 
                 if (element is null)
                 {
-                    UiErrors.ElementNotFound(logger, selectorStr);
+                    UiErrors.ElementNotFound(logger, selectorStr, json);
                     return 1;
                 }
 
@@ -78,7 +78,7 @@ internal class UiGetPropertyCommand : Command, IShortDescription
                     {
                         stringProps[kvp.Key] = kvp.Value?.ToString();
                     }
-                    var result = new UiPropertyResult { ElementId = element.Selector ?? element.Id, Properties = stringProps };
+                    var result = new UiPropertyResult { ElementId = (element.Selector ?? element.Id ?? ""), Properties = stringProps };
                     ansiConsole.Profile.Out.Writer.WriteLine(
                         JsonSerializer.Serialize(result, UiJsonContext.Default.UiPropertyResult));
                 }
@@ -95,19 +95,19 @@ internal class UiGetPropertyCommand : Command, IShortDescription
 
                 if (!json)
                 {
-                    logger.LogInformation("{ElementId}: {Count} properties", element.Selector ?? element.Id, props.Count);
+                    logger.LogInformation("{ElementId}: {Count} properties", (element.Selector ?? element.Id ?? ""), props.Count);
                 }
                 return 0;
             }
             catch (System.Runtime.InteropServices.COMException comEx)
             {
                 logger.LogDebug("COM error: {HResult} {StackTrace}", comEx.HResult, comEx.StackTrace);
-                UiErrors.StaleElement(logger);
+                UiErrors.StaleElement(logger, json);
                 return 1;
             }
             catch (Exception ex)
             {
-                UiErrors.GenericError(logger, ex);
+                UiErrors.GenericError(logger, ex, json);
                 return 1;
             }
         }

--- a/src/winapp-CLI/WinApp.Cli/Commands/UiGetValueCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/UiGetValueCommand.cs
@@ -37,20 +37,20 @@ internal class UiGetValueCommand : Command, IShortDescription
     {
         public override async Task<int> InvokeAsync(ParseResult parseResult, CancellationToken cancellationToken = default)
         {
+            var json = parseResult.GetValue(WinAppRootCommand.JsonOption);
             var selectorStr = parseResult.GetValue(SharedUiOptions.SelectorArgument);
             var app = parseResult.GetValue(SharedUiOptions.AppOption);
             var window = parseResult.GetValue(SharedUiOptions.WindowOption);
 
             if (string.IsNullOrWhiteSpace(app) && window is null)
             {
-                UiErrors.MissingApp(logger);
+                UiErrors.MissingApp(logger, json);
                 return 1;
             }
-            var json = parseResult.GetValue(WinAppRootCommand.JsonOption);
 
             if (string.IsNullOrWhiteSpace(selectorStr))
             {
-                UiErrors.MissingSelector(logger, "get-value");
+                UiErrors.MissingSelector(logger, "get-value", json);
                 return 1;
             }
 
@@ -62,7 +62,7 @@ internal class UiGetValueCommand : Command, IShortDescription
 
                 if (element is null)
                 {
-                    UiErrors.ElementNotFound(logger, selectorStr);
+                    UiErrors.ElementNotFound(logger, selectorStr, json);
                     return 1;
                 }
 
@@ -72,7 +72,7 @@ internal class UiGetValueCommand : Command, IShortDescription
                 {
                     var result = new UiGetValueResult
                     {
-                        ElementId = element.Selector ?? element.Id,
+                        ElementId = (element.Selector ?? element.Id ?? ""),
                         Text = text
                     };
                     ansiConsole.Profile.Out.Writer.WriteLine(
@@ -82,7 +82,7 @@ internal class UiGetValueCommand : Command, IShortDescription
 
                 if (text is null)
                 {
-                    logger.LogInformation("No value found on {ElementId}", element.Selector ?? element.Id);
+                    logger.LogInformation("No value found on {ElementId}", (element.Selector ?? element.Id ?? ""));
                 }
                 else
                 {
@@ -95,12 +95,12 @@ internal class UiGetValueCommand : Command, IShortDescription
             catch (System.Runtime.InteropServices.COMException comEx)
             {
                 logger.LogDebug("COM error: {HResult} {StackTrace}", comEx.HResult, comEx.StackTrace);
-                UiErrors.StaleElement(logger);
+                UiErrors.StaleElement(logger, json);
                 return 1;
             }
             catch (Exception ex)
             {
-                UiErrors.GenericError(logger, ex);
+                UiErrors.GenericError(logger, ex, json);
                 return 1;
             }
         }

--- a/src/winapp-CLI/WinApp.Cli/Commands/UiInspectCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/UiInspectCommand.cs
@@ -13,7 +13,7 @@ using WinApp.Cli.Services;
 
 namespace WinApp.Cli.Commands;
 
-internal class UiInspectCommand : Command, IShortDescription
+internal partial class UiInspectCommand : Command, IShortDescription
 {
     public string ShortDescription => "View the element tree of a running app";
 
@@ -42,7 +42,7 @@ internal class UiInspectCommand : Command, IShortDescription
         Options.Add(SharedUiOptions.HideOffscreenOption);
     }
 
-    public class Handler(
+    public partial class Handler(
         IUiSessionService sessionService,
         IUiAutomationService uiAutomation,
         IAnsiConsole ansiConsole,
@@ -50,24 +50,28 @@ internal class UiInspectCommand : Command, IShortDescription
     {
         public override async Task<int> InvokeAsync(ParseResult parseResult, CancellationToken cancellationToken = default)
         {
+            var json = parseResult.GetValue(WinAppRootCommand.JsonOption);
+
             var selector = parseResult.GetValue(SharedUiOptions.SelectorArgument);
             var app = parseResult.GetValue(SharedUiOptions.AppOption);
             var window = parseResult.GetValue(SharedUiOptions.WindowOption);
 
             if (string.IsNullOrWhiteSpace(app) && window is null)
             {
-                UiErrors.MissingApp(logger);
+                UiErrors.MissingApp(logger, json);
                 return 1;
             }
             var depth = parseResult.GetRequiredValue(SharedUiOptions.DepthOption);
+            var depthExplicit = parseResult.GetResult(SharedUiOptions.DepthOption)?.Implicit == false;
             var ancestors = parseResult.GetValue(AncestorsOption);
-            var json = parseResult.GetValue(WinAppRootCommand.JsonOption);
             var interactive = parseResult.GetValue(SharedUiOptions.InteractiveOption);
             var hideDisabled = parseResult.GetValue(SharedUiOptions.HideDisabledOption);
             var hideOffscreen = parseResult.GetValue(SharedUiOptions.HideOffscreenOption);
 
-            // --interactive bumps default depth to 8 (sparse tree after filtering)
-            if (interactive && depth == 4)
+            // --interactive bumps the default depth to 8 (sparse tree after filtering).
+            // Only override when the user did NOT explicitly pass --depth, so an explicit
+            // `--depth 4` is honored.
+            if (interactive && !depthExplicit)
             {
                 depth = 8;
             }
@@ -80,6 +84,10 @@ internal class UiInspectCommand : Command, IShortDescription
                 if (ancestors && selector is not null)
                 {
                     elements = await uiAutomation.InspectAncestorsAsync(session, selector, cancellationToken);
+                    // The ancestor walk returns root-first..target-last but does not assign Depth.
+                    // BuildWindows/NestElements use a depth-stack to nest children, so without an
+                    // ascending depth assignment all ancestors collapse into sibling roots in JSON.
+                    for (int i = 0; i < elements.Length; i++) { elements[i].Depth = i; }
                 }
                 else
                 {
@@ -97,17 +105,37 @@ internal class UiInspectCommand : Command, IShortDescription
                 }
 
                 // For --interactive, filter to interactive elements but keep the full
-                // list for breadcrumb context rendering (non-JSON path)
+                // list for breadcrumb context rendering (non-JSON path).
                 var allElements = elements;
-                if (interactive && json)
+                if (interactive)
                 {
-                    elements = elements.Where(e => e.Type == "---" || IsInteractiveType(e)).ToArray();
+                    elements = elements.Where(e => e.Type == "---" || IsInteractive(e)).ToArray();
                 }
 
                 if (json)
                 {
-                    var jsonElements = elements.Where(e => e.Type != "---").ToArray();
-                    var result = new UiInspectResult { Elements = jsonElements };
+                    // For --interactive, attach an InvokableAncestor hint for elements that don't
+                    // themselves support an actionable pattern (e.g. some MenuItems / TabItems).
+                    if (interactive)
+                    {
+                        AttachInvokableAncestors(elements, allElements);
+                    }
+
+                    // Build a nested tree grouped by window. The flat element list is in DFS walk
+                    // order with separators marking window boundaries. For --interactive we pass
+                    // the unfiltered tree so BuildWindows can collapse non-interactive ancestors
+                    // and surface them as ancestorPath breadcrumbs on the surviving descendants.
+                    var jsonElements = interactive ? allElements : elements;
+                    var windows = BuildWindows(jsonElements, session, interactive);
+
+                    var result = new UiInspectResult
+                    {
+                        Depth = depth,
+                        Interactive = interactive,
+                        HideDisabled = hideDisabled,
+                        HideOffscreen = hideOffscreen,
+                        Windows = windows,
+                    };
                     ansiConsole.Profile.Out.Writer.WriteLine(
                         JsonSerializer.Serialize(result, UiJsonContext.Default.UiInspectResult));
                 }
@@ -129,18 +157,38 @@ internal class UiInspectCommand : Command, IShortDescription
                             continue;
                         }
 
-                        if (interactive && !IsInteractiveType(el))
+                        if (interactive && !IsInteractive(el))
                         {
                             // Track as ancestor context for upcoming interactive elements
-                            ancestorTypes[el.Depth] = el.Type;
+                            ancestorTypes[el.Depth ?? 0] = el.Type;
+
+                            // Even though this non-interactive ancestor is itself hidden, if its
+                            // subtree was truncated (HasMoreChildren), there may be hidden
+                            // interactive descendants — emit a breadcrumb + +more hint.
+                            if (el.HasMoreChildren == true)
+                            {
+                                var parts = new List<string>();
+                                for (int d = 0; d <= (el.Depth ?? 0); d++)
+                                {
+                                    if (ancestorTypes[d] is not null) { parts.Add(ancestorTypes[d]!); }
+                                }
+                                var breadcrumb = string.Join(" > ", parts);
+                                if (breadcrumb.Length > 0 && breadcrumb != lastBreadcrumb)
+                                {
+                                    ansiConsole.MarkupLine($"[grey]{EscapeMarkup(breadcrumb)}[/]");
+                                    lastBreadcrumb = breadcrumb;
+                                }
+                                var moreIndent = new string(' ', ((el.Depth ?? 0) + 1) * 2);
+                                ansiConsole.MarkupLine($"{moreIndent}[grey]+more[/]");
+                            }
                             continue;
                         }
 
                         // In --interactive mode, emit a breadcrumb when ancestor path changed
-                        if (interactive && el.Depth > 0)
+                        if (interactive && (el.Depth ?? 0) > 0)
                         {
                             var parts = new List<string>();
-                            for (int d = 0; d < el.Depth; d++)
+                            for (int d = 0; d < (el.Depth ?? 0); d++)
                             {
                                 if (ancestorTypes[d] is not null) { parts.Add(ancestorTypes[d]!); }
                             }
@@ -152,8 +200,8 @@ internal class UiInspectCommand : Command, IShortDescription
                             }
                         }
 
-                        var indent = new string(' ', el.Depth * 2);
-                        var elSelector = el.Selector ?? el.Id;
+                        var indent = new string(' ', (el.Depth ?? 0) * 2);
+                        var elSelector = el.Selector ?? el.Id ?? "";
                         var displayName = el.Name ?? el.AutomationId;
                         var name = displayName is not null && displayName != elSelector
                             ? $" [green]\"{EscapeMarkup(Truncate(displayName, 80))}\"[/]" : "";
@@ -166,24 +214,40 @@ internal class UiInspectCommand : Command, IShortDescription
                         var disabled = el.IsEnabled ? "" : " [grey][[disabled]][/]";
                         var offscreen = el.IsOffscreen ? " [grey][[offscreen]][/]" : "";
                         ansiConsole.MarkupLine($"{indent}[bold cyan]{EscapeMarkup(elSelector)}[/] {el.Type}{name}{value}{toggle}{expand}{scroll}{bounds}{disabled}{offscreen}");
+
+                        // Render truncated descendants as a single short child line for readability.
+                        if (el.HasMoreChildren == true)
+                        {
+                            var childIndent = new string(' ', ((el.Depth ?? 0) + 1) * 2);
+                            ansiConsole.MarkupLine($"{childIndent}[grey]+more[/]");
+                        }
                     }
 
                     // Footer with example using first interactive element or first element
                     var realElements = (interactive ? allElements : elements).Where(e => e.Type != "---").ToArray();
                     var displayedElements = interactive
-                        ? realElements.Where(IsInteractiveType).ToArray()
+                        ? realElements.Where(IsInteractive).ToArray()
                         : realElements;
                     var separators = (interactive ? allElements : elements).Where(e => e.Type == "---").ToArray();
-                    var example = realElements.FirstOrDefault(IsInteractiveType) ?? realElements.FirstOrDefault();
+                    var truncated = realElements.Count(e => e.HasMoreChildren == true);
+                    var example = realElements.FirstOrDefault(IsInteractive) ?? realElements.FirstOrDefault();
                     var exampleSelector = example?.Selector ?? example?.Id;
                     var exampleHint = exampleSelector is not null
                         ? $" Use the [bold cyan]first token[/] as selector, e.g.: [grey]winapp ui invoke {EscapeMarkup(exampleSelector)} -a <app>[/]"
                         : "";
                     ansiConsole.WriteLine();
                     ansiConsole.MarkupLine($"[grey]Found {displayedElements.Length} elements (--depth {depth}).{exampleHint}[/]");
+                    if (truncated > 0)
+                    {
+                        ansiConsole.MarkupLine($"[grey]{truncated} element(s) have hidden children ([yellow]+more[/]) - re-run with [bold]--depth {depth + 4}[/] to expand.[/]");
+                    }
                     if (separators.Length > 1)
                     {
                         ansiConsole.MarkupLine("[grey]Use -w <HWND> to target a specific window.[/]");
+                    }
+                    if (!interactive)
+                    {
+                        ansiConsole.MarkupLine("[grey]Use -i to only show interactive elements.[/]");
                     }
                 }
 
@@ -193,12 +257,12 @@ internal class UiInspectCommand : Command, IShortDescription
             catch (System.Runtime.InteropServices.COMException comEx)
             {
                 logger.LogDebug("COM error: {HResult} {StackTrace}", comEx.HResult, comEx.StackTrace);
-                UiErrors.StaleElement(logger);
+                UiErrors.StaleElement(logger, json);
                 return 1;
             }
             catch (Exception ex)
             {
-                UiErrors.GenericError(logger, ex);
+                UiErrors.GenericError(logger, ex, json);
                 return 1;
             }
         }
@@ -221,6 +285,8 @@ internal class UiInspectCommand : Command, IShortDescription
             return text.Replace("\r\n", "↵").Replace("\r", "↵").Replace("\n", "↵").Replace("\t", "→");
         }
 
+        // ControlType allowlist for back-compat: even if pattern detection misses something,
+        // these types are conventionally interactive.
         private static readonly HashSet<string> InteractiveTypes = new(StringComparer.OrdinalIgnoreCase)
         {
             "Button", "CheckBox", "ComboBox", "Edit", "TextBox", "Hyperlink",
@@ -228,6 +294,204 @@ internal class UiInspectCommand : Command, IShortDescription
             "TreeItem", "DataItem", "Slider"
         };
 
-        private static bool IsInteractiveType(Models.UiElement el) => InteractiveTypes.Contains(el.Type);
+        /// <summary>An element is interactive if it supports an actionable UIA pattern OR matches a conventional control type.</summary>
+        private static bool IsInteractive(Models.UiElement el)
+            => el.IsInvokable || InteractiveTypes.Contains(el.Type);
+
+        /// <summary>For each interactive element without its own actionable pattern, find the nearest
+        /// invokable ancestor in the unfiltered element list and attach it as a fallback hint.</summary>
+        private static void AttachInvokableAncestors(Models.UiElement[] filtered, Models.UiElement[] all)
+        {
+            // Index 'all' by selector for fast lookup.
+            var bySelector = new Dictionary<string, Models.UiElement>(StringComparer.Ordinal);
+            foreach (var el in all)
+            {
+                var key = el.Selector ?? el.Id;
+                if (!string.IsNullOrEmpty(key)) { bySelector[key] = el; }
+            }
+
+            foreach (var el in filtered)
+            {
+                if (el.Type == "---" || el.IsInvokable) { continue; }
+
+                var parentKey = el.ParentSelector;
+                while (!string.IsNullOrEmpty(parentKey) && bySelector.TryGetValue(parentKey, out var parent))
+                {
+                    if (parent.IsInvokable)
+                    {
+                        el.InvokableAncestor = parent;
+                        break;
+                    }
+                    parentKey = parent.ParentSelector;
+                }
+            }
+        }
+
+        // Pattern: HWND <hwnd>: "<title>" (<label>, <className>[, owner: HWND <ownerHwnd>])
+        [System.Text.RegularExpressions.GeneratedRegex(
+            @"^HWND\s+\d+:\s+""(?<title>.*)""\s+\((?<label>[^,]+),\s*(?<class>[^,)]+)(,\s*owner:.*)?\)$")]
+        private static partial System.Text.RegularExpressions.Regex SeparatorRegex();
+
+        /// <summary>Group the flat element walk into per-window nested trees. The flat list is in
+        /// DFS order; separators (Type=="---") delimit independent windows. For --interactive,
+        /// keeps the full structural tree but prunes subtrees with no interactive descendants.
+        /// Clears redundant per-element fields (depth/parentSelector/ancestorPath/windowHandle)
+        /// since they're implied by the tree structure.</summary>
+        private static UiInspectWindowInfo[] BuildWindows(Models.UiElement[] elements, UiSessionInfo session, bool interactive)
+        {
+            var windows = new List<UiInspectWindowInfo>();
+            UiInspectWindowInfo? current = null;
+            var bucket = new List<Models.UiElement>();
+
+            void Flush()
+            {
+                if (current is null) { return; }
+                var roots = NestElements(bucket, interactive, out var totalCount);
+                current.Elements = roots;
+                current.ElementCount = totalCount;
+                if (roots.Length > 0 || current.Hwnd != 0) { windows.Add(current); }
+                bucket.Clear();
+            }
+
+            foreach (var el in elements)
+            {
+                if (el.Type == "---")
+                {
+                    Flush();
+                    var match = el.Name is not null ? SeparatorRegex().Match(el.Name) : null;
+                    current = new UiInspectWindowInfo
+                    {
+                        Hwnd = el.WindowHandle ?? 0,
+                        Title = match?.Success == true ? match.Groups["title"].Value : el.Name,
+                        ClassName = match?.Success == true ? match.Groups["class"].Value.Trim() : null,
+                    };
+                }
+                else
+                {
+                    // No separator yet — implicit single window. Initialize from session info.
+                    if (current is null)
+                    {
+                        current = new UiInspectWindowInfo
+                        {
+                            Hwnd = el.WindowHandle ?? session.WindowHandle,
+                            Title = session.WindowTitle,
+                        };
+                    }
+                    bucket.Add(el);
+                }
+            }
+            Flush();
+
+            return windows.ToArray();
+        }
+
+        /// <summary>Build a nested tree from a DFS-ordered flat list using a depth-stack.
+        /// Clears redundant fields and (for --interactive) prunes branches with no interactive descendants.</summary>
+        private static Models.UiElement[] NestElements(List<Models.UiElement> flat, bool interactive, out int totalCount)
+        {
+            var roots = new List<Models.UiElement>();
+            var stack = new Stack<(Models.UiElement el, List<Models.UiElement> kids)>();
+
+            foreach (var el in flat)
+            {
+                var d = el.Depth ?? 0;
+                while (stack.Count > 0 && (stack.Peek().el.Depth ?? 0) >= d) { Finalize(stack.Pop()); }
+
+                var kids = new List<Models.UiElement>();
+                if (stack.Count == 0) { roots.Add(el); }
+                else { stack.Peek().kids.Add(el); }
+                stack.Push((el, kids));
+            }
+            while (stack.Count > 0) { Finalize(stack.Pop()); }
+
+            // Prune for --interactive: drop subtrees with no interactive descendants,
+            // then collapse non-interactive intermediate nodes — surviving nodes are
+            // interactive elements (or +more sentinels), each with an ancestorPath
+            // showing the collapsed chain of non-interactive types above it.
+            if (interactive)
+            {
+                roots = roots.Where(r => PruneInteractive(r)).ToList();
+                roots = CollapseNonInteractive(roots, droppedAbove: []);
+            }
+
+            // Strip redundant tree-rebuild metadata (implied by nesting)
+            totalCount = 0;
+            foreach (var r in roots) { StripRedundant(r, ref totalCount, interactive); }
+            return roots.ToArray();
+
+            static void Finalize((Models.UiElement el, List<Models.UiElement> kids) frame)
+            {
+                frame.el.Children = frame.kids.Count > 0 ? frame.kids.ToArray() : null;
+            }
+
+            static bool PruneInteractive(Models.UiElement el)
+            {
+                if (el.Children is { Length: > 0 } kids)
+                {
+                    var keptKids = kids.Where(PruneInteractive).ToArray();
+                    el.Children = keptKids.Length > 0 ? keptKids : null;
+                }
+                return IsInteractive(el) || el.HasMoreChildren == true || (el.Children?.Length ?? 0) > 0;
+            }
+
+            // Collapse non-interactive intermediate nodes. A node "survives" if it's interactive
+            // or carries the +more truncation hint. Non-survivors are stripped from the tree;
+            // their type is appended to droppedAbove and propagated to their (recursively collapsed)
+            // children, which are spliced up to take their place. Each surviving node gets the
+            // accumulated droppedAbove chain attached as ancestorPath.
+            static List<Models.UiElement> CollapseNonInteractive(List<Models.UiElement> nodes, List<string> droppedAbove)
+            {
+                var output = new List<Models.UiElement>();
+                foreach (var el in nodes)
+                {
+                    var selfSurvives = IsInteractive(el) || el.HasMoreChildren == true;
+                    var childrenInput = el.Children?.ToList() ?? [];
+
+                    if (selfSurvives)
+                    {
+                        var collapsedKids = CollapseNonInteractive(childrenInput, droppedAbove: []);
+                        el.Children = collapsedKids.Count > 0 ? collapsedKids.ToArray() : null;
+                        el.AncestorPath = droppedAbove.Count > 0 ? droppedAbove.ToArray() : null;
+                        output.Add(el);
+                    }
+                    else
+                    {
+                        var nextDropped = new List<string>(droppedAbove) { el.Type };
+                        output.AddRange(CollapseNonInteractive(childrenInput, nextDropped));
+                    }
+                }
+                return output;
+            }
+
+            static void StripRedundant(Models.UiElement el, ref int count, bool interactive)
+            {
+                count++;
+                el.Id = null;
+                el.Depth = null;
+                el.ParentSelector = null;
+                el.WindowHandle = null;
+                // Flatten InvokableAncestor to a hint (no nested Children / no nested ancestor)
+                // — without this System.Text.Json can hit a reference cycle when the surviving
+                // descendant points back to one of its own ancestors that's also in the tree.
+                if (el.InvokableAncestor is { } anc)
+                {
+                    el.InvokableAncestor = new Models.UiElement
+                    {
+                        Type = anc.Type,
+                        Name = anc.Name,
+                        AutomationId = anc.AutomationId,
+                        Selector = anc.Selector,
+                        IsInvokable = anc.IsInvokable,
+                    };
+                }
+                // In non-interactive mode the tree is complete, so ancestorPath is redundant.
+                // In interactive mode it's populated only with the collapsed non-interactive chain.
+                if (!interactive) { el.AncestorPath = null; }
+                if (el.Children is { } kids)
+                {
+                    foreach (var c in kids) { StripRedundant(c, ref count, interactive); }
+                }
+            }
+        }
     }
 }

--- a/src/winapp-CLI/WinApp.Cli/Commands/UiInvokeCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/UiInvokeCommand.cs
@@ -37,20 +37,20 @@ internal class UiInvokeCommand : Command, IShortDescription
     {
         public override async Task<int> InvokeAsync(ParseResult parseResult, CancellationToken cancellationToken = default)
         {
+            var json = parseResult.GetValue(WinAppRootCommand.JsonOption);
             var selectorStr = parseResult.GetValue(SharedUiOptions.SelectorArgument);
             var app = parseResult.GetValue(SharedUiOptions.AppOption);
             var window = parseResult.GetValue(SharedUiOptions.WindowOption);
 
             if (string.IsNullOrWhiteSpace(app) && window is null)
             {
-                UiErrors.MissingApp(logger);
+                UiErrors.MissingApp(logger, json);
                 return 1;
             }
-            var json = parseResult.GetValue(WinAppRootCommand.JsonOption);
 
             if (string.IsNullOrWhiteSpace(selectorStr))
             {
-                UiErrors.MissingSelector(logger, "invoke");
+                UiErrors.MissingSelector(logger, "invoke", json);
                 return 1;
             }
 
@@ -62,7 +62,7 @@ internal class UiInvokeCommand : Command, IShortDescription
 
                 if (element is null)
                 {
-                    UiErrors.ElementNotFound(logger, selectorStr);
+                    UiErrors.ElementNotFound(logger, selectorStr, json);
                     return 1;
                 }
 
@@ -77,7 +77,7 @@ internal class UiInvokeCommand : Command, IShortDescription
                     pattern = await uiAutomation.InvokeAsync(session, ancestor, cancellationToken);
                     if (json)
                     {
-                        var result = new UiInvokeResult { ElementId = ancestor.Selector ?? ancestor.Id, Pattern = pattern, Hwnd = session.WindowHandle };
+                        var result = new UiInvokeResult { ElementId = ancestor.Selector ?? ancestor.Id ?? "", Pattern = pattern, Hwnd = session.WindowHandle };
                         ansiConsole.Profile.Out.Writer.WriteLine(
                             JsonSerializer.Serialize(result, UiJsonContext.Default.UiInvokeResult));
                     }
@@ -91,13 +91,13 @@ internal class UiInvokeCommand : Command, IShortDescription
 
                 if (json)
                 {
-                    var result = new UiInvokeResult { ElementId = element.Selector ?? element.Id, Pattern = pattern, Hwnd = session.WindowHandle };
+                    var result = new UiInvokeResult { ElementId = (element.Selector ?? element.Id ?? ""), Pattern = pattern, Hwnd = session.WindowHandle };
                     ansiConsole.Profile.Out.Writer.WriteLine(
                         JsonSerializer.Serialize(result, UiJsonContext.Default.UiInvokeResult));
                 }
                 else
                 {
-                    logger.LogInformation("Invoked {ElementId} via {Pattern}", element.Selector ?? element.Id, pattern);
+                    logger.LogInformation("Invoked {ElementId} via {Pattern}", (element.Selector ?? element.Id ?? ""), pattern);
                 }
 
                 return 0;
@@ -105,12 +105,12 @@ internal class UiInvokeCommand : Command, IShortDescription
             catch (System.Runtime.InteropServices.COMException comEx)
             {
                 logger.LogDebug("COM error: {HResult} {StackTrace}", comEx.HResult, comEx.StackTrace);
-                UiErrors.StaleElement(logger);
+                UiErrors.StaleElement(logger, json);
                 return 1;
             }
             catch (Exception ex)
             {
-                UiErrors.GenericError(logger, ex);
+                UiErrors.GenericError(logger, ex, json);
                 return 1;
             }
         }

--- a/src/winapp-CLI/WinApp.Cli/Commands/UiListWindowsCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/UiListWindowsCommand.cs
@@ -32,8 +32,8 @@ internal class UiListWindowsCommand : Command, IShortDescription
     {
         public override async Task<int> InvokeAsync(ParseResult parseResult, CancellationToken cancellationToken = default)
         {
-            var app = parseResult.GetValue(SharedUiOptions.AppOption);
             var json = parseResult.GetValue(WinAppRootCommand.JsonOption);
+            var app = parseResult.GetValue(SharedUiOptions.AppOption);
 
             try
             {
@@ -135,7 +135,7 @@ internal class UiListWindowsCommand : Command, IShortDescription
             }
             catch (Exception ex)
             {
-                UiErrors.GenericError(logger, ex);
+                UiErrors.GenericError(logger, ex, json);
                 return 1;
             }
         }

--- a/src/winapp-CLI/WinApp.Cli/Commands/UiScreenshotCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/UiScreenshotCommand.cs
@@ -40,17 +40,17 @@ internal class UiScreenshotCommand : Command, IShortDescription
     {
         public override async Task<int> InvokeAsync(ParseResult parseResult, CancellationToken cancellationToken = default)
         {
+            var json = parseResult.GetValue(WinAppRootCommand.JsonOption);
             var selector = parseResult.GetValue(SharedUiOptions.SelectorArgument);
             var app = parseResult.GetValue(SharedUiOptions.AppOption);
             var window = parseResult.GetValue(SharedUiOptions.WindowOption);
 
             if (string.IsNullOrWhiteSpace(app) && window is null)
             {
-                UiErrors.MissingApp(logger);
+                UiErrors.MissingApp(logger, json);
                 return 1;
             }
             var output = parseResult.GetValue(SharedUiOptions.OutputOption);
-            var json = parseResult.GetValue(WinAppRootCommand.JsonOption);
             var captureScreen = parseResult.GetValue(SharedUiOptions.CaptureScreenOption);
 
             try
@@ -121,12 +121,12 @@ internal class UiScreenshotCommand : Command, IShortDescription
             catch (System.Runtime.InteropServices.COMException comEx)
             {
                 logger.LogDebug("COM error: {HResult} {StackTrace}", comEx.HResult, comEx.StackTrace);
-                UiErrors.StaleElement(logger);
+                UiErrors.StaleElement(logger, json);
                 return 1;
             }
             catch (Exception ex)
             {
-                UiErrors.GenericError(logger, ex);
+                UiErrors.GenericError(logger, ex, json);
                 return 1;
             }
         }
@@ -155,6 +155,7 @@ internal class UiScreenshotCommand : Command, IShortDescription
 
             // Capture each window
             var captures = new List<(byte[] Pixels, int Width, int Height, nint Hwnd, string Title, string Label)>();
+            var windowDetails = new List<UiScreenshotWindowInfo>();
             foreach (var w in sorted)
             {
                 var info = UiSessionService.GetWindowInfo(w.Hwnd);
@@ -170,6 +171,15 @@ internal class UiScreenshotCommand : Command, IShortDescription
                     };
                     var (pixels, width, height) = await uiAutomation.ScreenshotAsync(windowSession, null, captureScreen, ct);
                     captures.Add((pixels, width, height, w.Hwnd, title, info.Label));
+                    windowDetails.Add(new UiScreenshotWindowInfo
+                    {
+                        Hwnd = w.Hwnd,
+                        Title = string.IsNullOrEmpty(w.Title) ? null : w.Title,
+                        Label = info.Label,
+                        Width = width,
+                        Height = height,
+                        Captured = true,
+                    });
 
                     if (!json)
                     {
@@ -180,6 +190,14 @@ internal class UiScreenshotCommand : Command, IShortDescription
                 catch (Exception ex)
                 {
                     logger.LogDebug("Failed to capture HWND {Hwnd}: {Error}", w.Hwnd, ex.Message);
+                    windowDetails.Add(new UiScreenshotWindowInfo
+                    {
+                        Hwnd = w.Hwnd,
+                        Title = string.IsNullOrEmpty(w.Title) ? null : w.Title,
+                        Label = info.Label,
+                        Captured = false,
+                        Error = ex.Message,
+                    });
                     if (!json)
                     {
                         ansiConsole.MarkupLine($"  [red]✗[/] HWND {w.Hwnd}: \"{Markup.Escape(title)}\" — {Markup.Escape(ex.Message)}");
@@ -190,6 +208,7 @@ internal class UiScreenshotCommand : Command, IShortDescription
             if (captures.Count == 0)
             {
                 logger.LogError("No windows could be captured.");
+                UiJsonError.Emit(json, UiJsonError.CodeInternalError, "No windows could be captured.");
                 return 1;
             }
 
@@ -216,7 +235,8 @@ internal class UiScreenshotCommand : Command, IShortDescription
                     Height = compositeHeight,
                     ProcessId = session.ProcessId,
                     WindowTitle = session.WindowTitle,
-                    Hwnd = session.WindowHandle
+                    Hwnd = session.WindowHandle,
+                    Windows = windowDetails.ToArray(),
                 };
                 ansiConsole.Profile.Out.Writer.WriteLine(
                     JsonSerializer.Serialize(result, UiJsonContext.Default.UiScreenshotResult));

--- a/src/winapp-CLI/WinApp.Cli/Commands/UiScrollCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/UiScrollCommand.cs
@@ -53,29 +53,31 @@ internal class UiScrollCommand : Command, IShortDescription
     {
         public override async Task<int> InvokeAsync(ParseResult parseResult, CancellationToken cancellationToken = default)
         {
+            var json = parseResult.GetValue(WinAppRootCommand.JsonOption);
             var selectorStr = parseResult.GetValue(SharedUiOptions.SelectorArgument);
             var app = parseResult.GetValue(SharedUiOptions.AppOption);
             var window = parseResult.GetValue(SharedUiOptions.WindowOption);
 
             if (string.IsNullOrWhiteSpace(app) && window is null)
             {
-                UiErrors.MissingApp(logger);
+                UiErrors.MissingApp(logger, json);
                 return 1;
             }
 
             var direction = parseResult.GetValue(DirectionOption);
             var to = parseResult.GetValue(ToOption);
-            var json = parseResult.GetValue(WinAppRootCommand.JsonOption);
 
             if (string.IsNullOrWhiteSpace(selectorStr))
             {
-                UiErrors.MissingSelector(logger, "scroll");
+                UiErrors.MissingSelector(logger, "scroll", json);
                 return 1;
             }
 
             if (direction is null && to is null)
             {
                 logger.LogError("Specify --direction (up/down/left/right) or --to (top/bottom).");
+                UiJsonError.Emit(json, UiJsonError.CodeInvalidArguments,
+                    "Specify --direction (up/down/left/right) or --to (top/bottom).");
                 return 1;
             }
 
@@ -87,7 +89,7 @@ internal class UiScrollCommand : Command, IShortDescription
 
                 if (element is null)
                 {
-                    UiErrors.ElementNotFound(logger, selectorStr);
+                    UiErrors.ElementNotFound(logger, selectorStr, json);
                     return 1;
                 }
 
@@ -97,7 +99,7 @@ internal class UiScrollCommand : Command, IShortDescription
                 {
                     var result = new UiScrollResult
                     {
-                        ElementId = element.Selector ?? element.Id,
+                        ElementId = (element.Selector ?? element.Id ?? ""),
                         Direction = direction,
                         To = to,
                         Hwnd = session.WindowHandle
@@ -115,12 +117,12 @@ internal class UiScrollCommand : Command, IShortDescription
             catch (System.Runtime.InteropServices.COMException comEx)
             {
                 logger.LogDebug("COM error: {HResult} {StackTrace}", comEx.HResult, comEx.StackTrace);
-                UiErrors.StaleElement(logger);
+                UiErrors.StaleElement(logger, json);
                 return 1;
             }
             catch (Exception ex)
             {
-                UiErrors.GenericError(logger, ex);
+                UiErrors.GenericError(logger, ex, json);
                 return 1;
             }
         }

--- a/src/winapp-CLI/WinApp.Cli/Commands/UiScrollIntoViewCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/UiScrollIntoViewCommand.cs
@@ -36,20 +36,20 @@ internal class UiScrollIntoViewCommand : Command, IShortDescription
     {
         public override async Task<int> InvokeAsync(ParseResult parseResult, CancellationToken cancellationToken = default)
         {
+            var json = parseResult.GetValue(WinAppRootCommand.JsonOption);
             var selectorStr = parseResult.GetValue(SharedUiOptions.SelectorArgument);
             var app = parseResult.GetValue(SharedUiOptions.AppOption);
             var window = parseResult.GetValue(SharedUiOptions.WindowOption);
 
             if (string.IsNullOrWhiteSpace(app) && window is null)
             {
-                UiErrors.MissingApp(logger);
+                UiErrors.MissingApp(logger, json);
                 return 1;
             }
-            var json = parseResult.GetValue(WinAppRootCommand.JsonOption);
 
             if (string.IsNullOrWhiteSpace(selectorStr))
             {
-                UiErrors.MissingSelector(logger, "scroll-into-view");
+                UiErrors.MissingSelector(logger, "scroll-into-view", json);
                 return 1;
             }
 
@@ -61,32 +61,32 @@ internal class UiScrollIntoViewCommand : Command, IShortDescription
 
                 if (element is null)
                 {
-                    UiErrors.ElementNotFound(logger, selectorStr);
+                    UiErrors.ElementNotFound(logger, selectorStr, json);
                     return 1;
                 }
 
                 await uiAutomation.ScrollIntoViewAsync(session, element, cancellationToken);
                 if (json)
                 {
-                    var result = new UiScrollIntoViewResult { ElementId = element.Selector ?? element.Id, Hwnd = session.WindowHandle };
+                    var result = new UiScrollIntoViewResult { ElementId = (element.Selector ?? element.Id ?? ""), Hwnd = session.WindowHandle };
                     ansiConsole.Profile.Out.Writer.WriteLine(
                         JsonSerializer.Serialize(result, UiJsonContext.Default.UiScrollIntoViewResult));
                 }
                 else
                 {
-                    logger.LogInformation("Scrolled {ElementId} into view", element.Selector ?? element.Id);
+                    logger.LogInformation("Scrolled {ElementId} into view", (element.Selector ?? element.Id ?? ""));
                 }
                 return 0;
             }
             catch (System.Runtime.InteropServices.COMException comEx)
             {
                 logger.LogDebug("COM error: {HResult} {StackTrace}", comEx.HResult, comEx.StackTrace);
-                UiErrors.StaleElement(logger);
+                UiErrors.StaleElement(logger, json);
                 return 1;
             }
             catch (Exception ex)
             {
-                UiErrors.GenericError(logger, ex);
+                UiErrors.GenericError(logger, ex, json);
                 return 1;
             }
         }

--- a/src/winapp-CLI/WinApp.Cli/Commands/UiSearchCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/UiSearchCommand.cs
@@ -37,21 +37,21 @@ internal class UiSearchCommand : Command, IShortDescription
     {
         public override async Task<int> InvokeAsync(ParseResult parseResult, CancellationToken cancellationToken = default)
         {
+            var json = parseResult.GetValue(WinAppRootCommand.JsonOption);
             var selectorStr = parseResult.GetValue(SharedUiOptions.SelectorArgument);
             var app = parseResult.GetValue(SharedUiOptions.AppOption);
             var window = parseResult.GetValue(SharedUiOptions.WindowOption);
 
             if (string.IsNullOrWhiteSpace(app) && window is null)
             {
-                UiErrors.MissingApp(logger);
+                UiErrors.MissingApp(logger, json);
                 return 1;
             }
             var maxResults = parseResult.GetRequiredValue(SharedUiOptions.MaxResultsOption);
-            var json = parseResult.GetValue(WinAppRootCommand.JsonOption);
 
             if (string.IsNullOrWhiteSpace(selectorStr))
             {
-                UiErrors.MissingSelector(logger, "search");
+                UiErrors.MissingSelector(logger, "search", json);
                 return 1;
             }
 
@@ -69,6 +69,9 @@ internal class UiSearchCommand : Command, IShortDescription
 
                 if (json)
                 {
+                    // Strip internal/redundant fields — selectors are the stable handle for consumers.
+                    // Also flattens InvokableAncestor to a hint (no cycle, no nested children).
+                    UiElementScrubber.ScrubAll(matches);
                     var result = new UiSearchResult
                     {
                         MatchCount = matches.Length,
@@ -82,7 +85,7 @@ internal class UiSearchCommand : Command, IShortDescription
                 {
                     foreach (var el in matches)
                     {
-                        var elSelector = el.Selector ?? el.Id;
+                        var elSelector = el.Selector ?? el.Id ?? "";
                         var displayName = el.Name ?? el.AutomationId;
                         var name = displayName is not null && displayName != elSelector
                             ? $" [green]\"{EscapeMarkup(Truncate(displayName, 80))}\"[/]" : "";
@@ -96,7 +99,7 @@ internal class UiSearchCommand : Command, IShortDescription
 
                         if (el.InvokableAncestor is { } ancestor)
                         {
-                            var ancestorSel = ancestor.Selector ?? ancestor.Id;
+                            var ancestorSel = ancestor.Selector ?? ancestor.Id ?? "";
                             var aName = ancestor.Name is not null ? $" \"{ancestor.Name}\"" : "";
                             ansiConsole.MarkupLine($"        ^ invoke via: [bold cyan]{EscapeMarkup(ancestorSel)}[/]{aName}");
                         }
@@ -113,12 +116,12 @@ internal class UiSearchCommand : Command, IShortDescription
             catch (System.Runtime.InteropServices.COMException comEx)
             {
                 logger.LogDebug("COM error: {HResult} {StackTrace}", comEx.HResult, comEx.StackTrace);
-                UiErrors.StaleElement(logger);
+                UiErrors.StaleElement(logger, json);
                 return 1;
             }
             catch (Exception ex)
             {
-                UiErrors.GenericError(logger, ex);
+                UiErrors.GenericError(logger, ex, json);
                 return 1;
             }
         }

--- a/src/winapp-CLI/WinApp.Cli/Commands/UiSetValueCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/UiSetValueCommand.cs
@@ -38,26 +38,28 @@ internal class UiSetValueCommand : Command, IShortDescription
     {
         public override async Task<int> InvokeAsync(ParseResult parseResult, CancellationToken cancellationToken = default)
         {
+            var json = parseResult.GetValue(WinAppRootCommand.JsonOption);
             var selectorStr = parseResult.GetValue(SharedUiOptions.SelectorArgument);
             var app = parseResult.GetValue(SharedUiOptions.AppOption);
             var window = parseResult.GetValue(SharedUiOptions.WindowOption);
 
             if (string.IsNullOrWhiteSpace(app) && window is null)
             {
-                UiErrors.MissingApp(logger);
+                UiErrors.MissingApp(logger, json);
                 return 1;
             }
             var value = parseResult.GetValue(SharedUiOptions.ValueArgument);
-            var json = parseResult.GetValue(WinAppRootCommand.JsonOption);
 
             if (string.IsNullOrWhiteSpace(selectorStr))
             {
-                UiErrors.MissingSelector(logger, "set-value");
+                UiErrors.MissingSelector(logger, "set-value", json);
                 return 1;
             }
             if (value is null)
             {
                 logger.LogError("{Symbol} A value is required. Usage: winapp ui set-value <selector> <value> -a <app>", UiSymbols.Error);
+                UiJsonError.Emit(json, UiJsonError.CodeInvalidArguments,
+                    "A value is required. Usage: winapp ui set-value <selector> <value> -a <app>");
                 return 1;
             }
 
@@ -69,32 +71,32 @@ internal class UiSetValueCommand : Command, IShortDescription
 
                 if (element is null)
                 {
-                    UiErrors.ElementNotFound(logger, selectorStr);
+                    UiErrors.ElementNotFound(logger, selectorStr, json);
                     return 1;
                 }
 
                 await uiAutomation.SetValueAsync(session, element, value, cancellationToken);
                 if (json)
                 {
-                    var result = new UiSetValueResult { ElementId = element.Selector ?? element.Id, Hwnd = session.WindowHandle };
+                    var result = new UiSetValueResult { ElementId = (element.Selector ?? element.Id ?? ""), Hwnd = session.WindowHandle };
                     ansiConsole.Profile.Out.Writer.WriteLine(
                         JsonSerializer.Serialize(result, UiJsonContext.Default.UiSetValueResult));
                 }
                 else
                 {
-                    logger.LogInformation("Set value on {ElementId}", element.Selector ?? element.Id);
+                    logger.LogInformation("Set value on {ElementId}", (element.Selector ?? element.Id ?? ""));
                 }
                 return 0;
             }
             catch (System.Runtime.InteropServices.COMException comEx)
             {
                 logger.LogDebug("COM error: {HResult} {StackTrace}", comEx.HResult, comEx.StackTrace);
-                UiErrors.StaleElement(logger);
+                UiErrors.StaleElement(logger, json);
                 return 1;
             }
             catch (Exception ex)
             {
-                UiErrors.GenericError(logger, ex);
+                UiErrors.GenericError(logger, ex, json);
                 return 1;
             }
         }

--- a/src/winapp-CLI/WinApp.Cli/Commands/UiStatusCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/UiStatusCommand.cs
@@ -33,15 +33,15 @@ internal class UiStatusCommand : Command, IShortDescription
     {
         public override async Task<int> InvokeAsync(ParseResult parseResult, CancellationToken cancellationToken = default)
         {
+            var json = parseResult.GetValue(WinAppRootCommand.JsonOption);
             var app = parseResult.GetValue(SharedUiOptions.AppOption);
             var window = parseResult.GetValue(SharedUiOptions.WindowOption);
 
             if (string.IsNullOrWhiteSpace(app) && window is null)
             {
-                UiErrors.MissingApp(logger);
+                UiErrors.MissingApp(logger, json);
                 return 1;
             }
-            var json = parseResult.GetValue(WinAppRootCommand.JsonOption);
 
             try
             {
@@ -78,7 +78,7 @@ internal class UiStatusCommand : Command, IShortDescription
             }
             catch (Exception ex)
             {
-                UiErrors.GenericError(logger, ex);
+                UiErrors.GenericError(logger, ex, json);
                 return 1;
             }
         }

--- a/src/winapp-CLI/WinApp.Cli/Commands/UiWaitForCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/UiWaitForCommand.cs
@@ -65,13 +65,14 @@ internal class UiWaitForCommand : Command, IShortDescription
     {
         public override async Task<int> InvokeAsync(ParseResult parseResult, CancellationToken cancellationToken = default)
         {
+            var json = parseResult.GetValue(WinAppRootCommand.JsonOption);
             var selectorStr = parseResult.GetValue(SharedUiOptions.SelectorArgument);
             var app = parseResult.GetValue(SharedUiOptions.AppOption);
             var window = parseResult.GetValue(SharedUiOptions.WindowOption);
 
             if (string.IsNullOrWhiteSpace(app) && window is null)
             {
-                UiErrors.MissingApp(logger);
+                UiErrors.MissingApp(logger, json);
                 return 1;
             }
             var timeout = parseResult.GetRequiredValue(SharedUiOptions.TimeoutOption);
@@ -79,11 +80,10 @@ internal class UiWaitForCommand : Command, IShortDescription
             var property = parseResult.GetValue(SharedUiOptions.PropertyOption);
             var value = parseResult.GetValue(ValueOption);
             var contains = parseResult.GetValue(ContainsOption);
-            var json = parseResult.GetValue(WinAppRootCommand.JsonOption);
 
             if (string.IsNullOrWhiteSpace(selectorStr))
             {
-                UiErrors.MissingSelector(logger, "wait-for");
+                UiErrors.MissingSelector(logger, "wait-for", json);
                 return 1;
             }
 
@@ -160,6 +160,7 @@ internal class UiWaitForCommand : Command, IShortDescription
                             {
                                 if (json)
                                 {
+                                    UiElementScrubber.Scrub(element);
                                     var result = new UiWaitForResult
                                     {
                                         Found = true,
@@ -182,6 +183,7 @@ internal class UiWaitForCommand : Command, IShortDescription
                         {
                             if (json)
                             {
+                                UiElementScrubber.Scrub(element);
                                 var result = new UiWaitForResult
                                 {
                                     Found = true,
@@ -202,23 +204,39 @@ internal class UiWaitForCommand : Command, IShortDescription
                     await Task.Delay(100, cancellationToken);
                 }
 
-                logger.LogError("'{Selector}' not found after {Timeout}ms", selectorStr, timeout);
+                // Timeout exhausted without satisfying the condition.
+                if (json)
+                {
+                    var result = new UiWaitForResult
+                    {
+                        Found = false,
+                        TimedOut = true,
+                        WaitedMs = (int)sw.ElapsedMilliseconds,
+                    };
+                    ansiConsole.Profile.Out.Writer.WriteLine(
+                        JsonSerializer.Serialize(result, UiJsonContext.Default.UiWaitForResult));
+                }
+                else
+                {
+                    logger.LogError("'{Selector}' not found after {Timeout}ms", selectorStr, timeout);
+                }
                 return 1;
             }
             catch (OperationCanceledException)
             {
                 logger.LogError("Wait cancelled");
+                UiJsonError.Emit(json, UiJsonError.CodeInternalError, "Wait cancelled");
                 return 1;
             }
             catch (System.Runtime.InteropServices.COMException comEx)
             {
                 logger.LogDebug("COM error: {HResult} {StackTrace}", comEx.HResult, comEx.StackTrace);
-                UiErrors.StaleElement(logger);
+                UiErrors.StaleElement(logger, json);
                 return 1;
             }
             catch (Exception ex)
             {
-                UiErrors.GenericError(logger, ex);
+                UiErrors.GenericError(logger, ex, json);
                 return 1;
             }
         }

--- a/src/winapp-CLI/WinApp.Cli/Helpers/UiElementScrubber.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/UiElementScrubber.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using WinApp.Cli.Models;
+
+namespace WinApp.Cli.Helpers;
+
+/// <summary>
+/// Strips internal/redundant fields from <see cref="UiElement"/> trees before JSON serialization.
+/// </summary>
+/// <remarks>
+/// JSON consumers address elements via the public <c>selector</c> slug; the synthetic walk-order
+/// <c>id</c>, <c>parentSelector</c>, <c>windowHandle</c>, and <c>depth</c> are implementation
+/// detail that leaks if not scrubbed. This helper also flattens <c>InvokableAncestor</c> down
+/// to a hint (selector/name/type/isInvokable only) so it can never form a reference cycle with
+/// its parent's children — System.Text.Json (without ReferenceHandler) would otherwise throw.
+/// </remarks>
+internal static class UiElementScrubber
+{
+    /// <summary>Recursively clear internal fields on <paramref name="element"/>, its
+    /// <see cref="UiElement.Children"/>, and (in flattened form) its
+    /// <see cref="UiElement.InvokableAncestor"/>.</summary>
+    public static void Scrub(UiElement? element)
+    {
+        if (element is null) { return; }
+        Strip(element);
+        FlattenInvokableAncestor(element);
+        if (element.Children is { } kids)
+        {
+            foreach (var c in kids) { Scrub(c); }
+        }
+    }
+
+    /// <summary>Scrub each element of a flat list (e.g., search/wait-for matches).</summary>
+    public static void ScrubAll(IEnumerable<UiElement>? elements)
+    {
+        if (elements is null) { return; }
+        foreach (var el in elements) { Scrub(el); }
+    }
+
+    private static void Strip(UiElement el)
+    {
+        el.Id = null;
+        el.ParentSelector = null;
+        el.WindowHandle = null;
+    }
+
+    private static void FlattenInvokableAncestor(UiElement el)
+    {
+        if (el.InvokableAncestor is not { } anc) { return; }
+        // Project to a hint with no Children / nested InvokableAncestor — breaks any cycle and
+        // keeps the payload small. Consumers only need a slug+label to invoke the fallback.
+        el.InvokableAncestor = new UiElement
+        {
+            Type = anc.Type,
+            Name = anc.Name,
+            AutomationId = anc.AutomationId,
+            Selector = anc.Selector,
+            IsInvokable = anc.IsInvokable,
+        };
+    }
+}

--- a/src/winapp-CLI/WinApp.Cli/Helpers/UiElementScrubber.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/UiElementScrubber.cs
@@ -10,10 +10,11 @@ namespace WinApp.Cli.Helpers;
 /// </summary>
 /// <remarks>
 /// JSON consumers address elements via the public <c>selector</c> slug; the synthetic walk-order
-/// <c>id</c>, <c>parentSelector</c>, <c>windowHandle</c>, and <c>depth</c> are implementation
-/// detail that leaks if not scrubbed. This helper also flattens <c>InvokableAncestor</c> down
-/// to a hint (selector/name/type/isInvokable only) so it can never form a reference cycle with
-/// its parent's children — System.Text.Json (without ReferenceHandler) would otherwise throw.
+/// <c>id</c>, <c>parentSelector</c>, and <c>windowHandle</c> are implementation detail that leak
+/// if not scrubbed. This helper also flattens <c>InvokableAncestor</c> down to a non-recursive
+/// hint (<c>type</c>, <c>name</c>, <c>automationId</c>, <c>selector</c>, <c>isInvokable</c>) so
+/// it can never form a reference cycle with its parent's children — System.Text.Json (without
+/// ReferenceHandler) would otherwise throw.
 /// </remarks>
 internal static class UiElementScrubber
 {

--- a/src/winapp-CLI/WinApp.Cli/Helpers/UiErrors.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/UiErrors.cs
@@ -7,32 +7,44 @@ namespace WinApp.Cli.Helpers;
 
 /// <summary>
 /// Consistent error messages across all winapp ui commands.
+/// In --json mode the logger is silenced; these helpers also emit a structured
+/// JSON error envelope to stderr via <see cref="UiJsonError"/> so JSON consumers
+/// always get something parseable on failure.
 /// </summary>
 internal static class UiErrors
 {
-    public static void MissingApp(ILogger logger)
+    public static void MissingApp(ILogger logger, bool json = false)
     {
-        logger.LogError("{Symbol} Target app required. Use --app <name|title|PID> or --window <HWND>. Run 'winapp ui list-windows' to find running apps.", UiSymbols.Error);
+        const string msg = "Target app required. Use --app <name|title|PID> or --window <HWND>. Run 'winapp ui list-windows' to find running apps.";
+        logger.LogError("{Symbol} {Message}", UiSymbols.Error, msg);
+        UiJsonError.Emit(json, UiJsonError.CodeMissingApp, msg);
     }
 
-    public static void MissingSelector(ILogger logger, string commandName)
+    public static void MissingSelector(ILogger logger, string commandName, bool json = false)
     {
-        logger.LogError("{Symbol} A selector is required. Usage: winapp ui {Command} <selector> -a <app>. Use 'winapp ui search <text> -a <app>' to find elements.", UiSymbols.Error, commandName);
+        var msg = $"A selector is required. Usage: winapp ui {commandName} <selector> -a <app>. Use 'winapp ui search <text> -a <app>' to find elements.";
+        logger.LogError("{Symbol} {Message}", UiSymbols.Error, msg);
+        UiJsonError.Emit(json, UiJsonError.CodeMissingSelector, msg);
     }
 
-    public static void ElementNotFound(ILogger logger, string selector)
+    public static void ElementNotFound(ILogger logger, string selector, bool json = false)
     {
-        logger.LogError("{Symbol} No element found matching '{Selector}'. The UI may have changed — re-run 'winapp ui inspect' or 'winapp ui search' to find current elements. Prefer targeting by AutomationId (set via AutomationProperties.AutomationId in XAML) — these survive layout changes.", UiSymbols.Error, selector);
+        var msg = $"No element found matching '{selector}'. The UI may have changed — re-run 'winapp ui inspect' or 'winapp ui search' to find current elements. Prefer targeting by AutomationId (set via AutomationProperties.AutomationId in XAML) — these survive layout changes.";
+        logger.LogError("{Symbol} {Message}", UiSymbols.Error, msg);
+        UiJsonError.Emit(json, UiJsonError.CodeElementNotFound, $"No element found matching '{selector}'", selector);
     }
 
-    public static void StaleElement(ILogger logger)
+    public static void StaleElement(ILogger logger, bool json = false)
     {
-        logger.LogError("{Symbol} Element is no longer accessible — the app may have navigated or the element was removed. Re-run 'winapp ui inspect' to refresh the element tree. Prefer targeting by AutomationId — these are stable across layout changes.", UiSymbols.Error);
+        const string msg = "Element is no longer accessible — the app may have navigated or the element was removed. Re-run 'winapp ui inspect' to refresh the element tree. Prefer targeting by AutomationId — these are stable across layout changes.";
+        logger.LogError("{Symbol} {Message}", UiSymbols.Error, msg);
+        UiJsonError.Emit(json, UiJsonError.CodeStaleElement, "Element is no longer accessible");
     }
 
-    public static void GenericError(ILogger logger, Exception ex)
+    public static void GenericError(ILogger logger, Exception ex, bool json = false)
     {
         logger.LogDebug("Stack trace: {StackTrace}", ex.StackTrace);
         logger.LogError("{Symbol} {Message}", UiSymbols.Error, ex.Message);
+        UiJsonError.Emit(json, UiJsonError.CodeInternalError, ex.Message, details: ex.GetType().Name);
     }
 }

--- a/src/winapp-CLI/WinApp.Cli/Helpers/UiJsonContext.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/UiJsonContext.cs
@@ -15,6 +15,8 @@ namespace WinApp.Cli.Helpers;
 [JsonSerializable(typeof(UiSessionInfo))]
 [JsonSerializable(typeof(UiStatusResult))]
 [JsonSerializable(typeof(UiInspectResult))]
+[JsonSerializable(typeof(UiInspectWindowInfo))]
+[JsonSerializable(typeof(UiInspectWindowInfo[]))]
 [JsonSerializable(typeof(UiSearchResult))]
 [JsonSerializable(typeof(UiPropertyResult))]
 [JsonSerializable(typeof(Dictionary<string, string?>))]
@@ -28,11 +30,16 @@ namespace WinApp.Cli.Helpers;
 [JsonSerializable(typeof(UiSetValueResult))]
 [JsonSerializable(typeof(UiFocusResult))]
 [JsonSerializable(typeof(UiScrollIntoViewResult))]
+[JsonSerializable(typeof(UiErrorResult))]
+[JsonSerializable(typeof(UiErrorInfo))]
+[JsonSerializable(typeof(UiFocusedResult))]
+[JsonSerializable(typeof(UiScreenshotWindowInfo))]
 [JsonSerializable(typeof(WindowInfo))]
 [JsonSerializable(typeof(WindowInfo[]))]
 [JsonSourceGenerationOptions(
     WriteIndented = true,
     NewLine = "\n",
+    MaxDepth = 256,
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
 internal partial class UiJsonContext : JsonSerializerContext;
@@ -49,6 +56,30 @@ internal sealed class UiStatusResult
 
 internal sealed class UiInspectResult
 {
+    /// <summary>Depth used for the tree walk (after any --interactive bump).</summary>
+    public int Depth { get; set; }
+
+    /// <summary>Whether the --interactive filter was applied.</summary>
+    public bool Interactive { get; set; }
+
+    /// <summary>Whether the --hide-disabled filter was applied.</summary>
+    public bool HideDisabled { get; set; }
+
+    /// <summary>Whether the --hide-offscreen filter was applied.</summary>
+    public bool HideOffscreen { get; set; }
+
+    /// <summary>One entry per inspected window, each containing its nested element tree.</summary>
+    public UiInspectWindowInfo[] Windows { get; set; } = [];
+}
+
+internal sealed class UiInspectWindowInfo
+{
+    public long Hwnd { get; set; }
+    public string? Title { get; set; }
+    public string? ClassName { get; set; }
+    /// <summary>Total real elements (counting nested children) belonging to this window.</summary>
+    public int ElementCount { get; set; }
+    /// <summary>Root elements for this window. Children are nested via <c>UiElement.Children</c>.</summary>
     public UiElement[] Elements { get; set; } = [];
 }
 
@@ -90,6 +121,20 @@ internal sealed class UiScreenshotResult
     public int ProcessId { get; set; }
     public string? WindowTitle { get; set; }
     public long Hwnd { get; set; }
+
+    /// <summary>For composite multi-window screenshots, details of each captured window. Null for single-window captures.</summary>
+    public UiScreenshotWindowInfo[]? Windows { get; set; }
+}
+
+internal sealed class UiScreenshotWindowInfo
+{
+    public long Hwnd { get; set; }
+    public string? Title { get; set; }
+    public string? Label { get; set; }
+    public int Width { get; set; }
+    public int Height { get; set; }
+    public bool Captured { get; set; }
+    public string? Error { get; set; }
 }
 
 internal sealed class UiWaitForResult
@@ -97,6 +142,30 @@ internal sealed class UiWaitForResult
     public bool Found { get; set; }
     public int WaitedMs { get; set; }
     public UiElement? Element { get; set; }
+
+    /// <summary>True if the wait exhausted the --timeout without satisfying the condition.</summary>
+    public bool TimedOut { get; set; }
+}
+
+/// <summary>Envelope for <c>ui get-focused --json</c>. Always emitted (even when no element has focus)
+/// so consumers can deterministically detect the no-focus case.</summary>
+internal sealed class UiFocusedResult
+{
+    public bool HasFocus { get; set; }
+    public UiElement? Element { get; set; }
+}
+
+internal sealed class UiErrorResult
+{
+    public UiErrorInfo Error { get; set; } = new();
+}
+
+internal sealed class UiErrorInfo
+{
+    public string Code { get; set; } = "";
+    public string Message { get; set; } = "";
+    public string? Selector { get; set; }
+    public string? Details { get; set; }
 }
 
 internal sealed class WindowInfo

--- a/src/winapp-CLI/WinApp.Cli/Helpers/UiJsonError.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/UiJsonError.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using WinApp.Cli.Models;
+
+namespace WinApp.Cli.Helpers;
+
+/// <summary>
+/// Emits structured JSON error responses for `winapp ui` commands when --json is set.
+/// In --json mode the logger is silenced (LogLevel.None), so error paths must call
+/// <see cref="Emit"/> explicitly to give consumers something to parse.
+/// </summary>
+internal static class UiJsonError
+{
+    public const string CodeMissingApp = "missing_app";
+    public const string CodeMissingSelector = "missing_selector";
+    public const string CodeElementNotFound = "element_not_found";
+    public const string CodeStaleElement = "stale_element";
+    public const string CodeInvalidArguments = "invalid_arguments";
+    public const string CodeInternalError = "internal_error";
+    public const string CodeZeroSize = "zero_size_element";
+
+    /// <summary>Write a JSON error envelope to stderr. No-op when <paramref name="json"/> is false.</summary>
+    public static void Emit(bool json, string code, string message,
+                            string? selector = null, string? details = null)
+    {
+        if (!json) { return; }
+
+        var result = new UiErrorResult
+        {
+            Error = new UiErrorInfo
+            {
+                Code = code,
+                Message = message,
+                Selector = selector,
+                Details = details,
+            },
+        };
+        var payload = JsonSerializer.Serialize(result, UiJsonContext.Default.UiErrorResult);
+        // Errors go to stderr so consumers can separate them from successful stdout payloads.
+        Console.Error.WriteLine(payload);
+    }
+}

--- a/src/winapp-CLI/WinApp.Cli/Models/UiElement.cs
+++ b/src/winapp-CLI/WinApp.Cli/Models/UiElement.cs
@@ -37,13 +37,18 @@ internal sealed class UiElement
     /// <summary>Scroll capability: "v" (vertical), "h" (horizontal), "vh" (both). Null if not scrollable.</summary>
     public string? ScrollDir { get; set; }
 
-    /// <summary>Depth in the tree (0 = root). Set on flat result lists (search) so consumers can reconstruct hierarchy. Null on nested inspect output where children are nested directly.</summary>
+    /// <summary>Depth in the tree (0 = root). Set on flat result lists from inspect (so the
+    /// command can rebuild a nested tree via the depth-stack); not populated by search /
+    /// wait-for / get-focused, and null on already-nested inspect output.</summary>
     public int? Depth { get; set; }
 
-    /// <summary>Selector of the parent element, when known. Set on flat result lists; null on nested output.</summary>
+    /// <summary>Selector of the parent element. Set during the inspect tree walk; not populated
+    /// by search / wait-for / get-focused, and null on already-nested inspect output.</summary>
     public string? ParentSelector { get; set; }
 
-    /// <summary>Ancestor element types from root to direct parent (e.g. ["Window","Pane","MenuBar"]). Set on flat result lists; null on nested output.</summary>
+    /// <summary>Ancestor element types from root to direct parent (e.g. ["Window","Pane","MenuBar"]).
+    /// Set on <c>inspect --interactive --json</c> output to surface the collapsed non-interactive
+    /// chain above each surviving element; not populated by search / wait-for / get-focused.</summary>
     public string[]? AncestorPath { get; set; }
 
     /// <summary>True when this element supports a directly invokable UIA pattern (Invoke/Toggle/SelectionItem/ExpandCollapse). Used by --interactive filtering.</summary>

--- a/src/winapp-CLI/WinApp.Cli/Models/UiElement.cs
+++ b/src/winapp-CLI/WinApp.Cli/Models/UiElement.cs
@@ -8,7 +8,8 @@ namespace WinApp.Cli.Models;
 /// </summary>
 internal sealed class UiElement
 {
-    public string Id { get; set; } = "";
+    /// <summary>Synthetic walk-order id (e0, e1, ...). Useful in flat result lists; null on nested inspect output where elements are addressed via tree position + selector.</summary>
+    public string? Id { get; set; }
     public string Type { get; set; } = "";
     public string? Name { get; set; }
     public string? AutomationId { get; set; }
@@ -36,12 +37,24 @@ internal sealed class UiElement
     /// <summary>Scroll capability: "v" (vertical), "h" (horizontal), "vh" (both). Null if not scrollable.</summary>
     public string? ScrollDir { get; set; }
 
-    /// <summary>Depth in the tree (0 = root). Used for display indentation.</summary>
-    [System.Text.Json.Serialization.JsonIgnore]
-    public int Depth { get; set; }
+    /// <summary>Depth in the tree (0 = root). Set on flat result lists (search) so consumers can reconstruct hierarchy. Null on nested inspect output where children are nested directly.</summary>
+    public int? Depth { get; set; }
 
-    /// <summary>HWND of the window this element belongs to. Used for cross-window element resolution.</summary>
-    public long WindowHandle { get; set; }
+    /// <summary>Selector of the parent element, when known. Set on flat result lists; null on nested output.</summary>
+    public string? ParentSelector { get; set; }
+
+    /// <summary>Ancestor element types from root to direct parent (e.g. ["Window","Pane","MenuBar"]). Set on flat result lists; null on nested output.</summary>
+    public string[]? AncestorPath { get; set; }
+
+    /// <summary>True when this element supports a directly invokable UIA pattern (Invoke/Toggle/SelectionItem/ExpandCollapse). Used by --interactive filtering.</summary>
+    public bool IsInvokable { get; set; }
+
+    /// <summary>True when the element has additional descendants that were not included
+    /// because the inspect depth limit was reached. Hint to re-run with a deeper --depth.</summary>
+    public bool? HasMoreChildren { get; set; }
+
+    /// <summary>HWND of the window this element belongs to. Set on flat result lists; null on nested output (window context is the parent in the tree).</summary>
+    public long? WindowHandle { get; set; }
 
     /// <summary>
     /// Nearest ancestor that supports an invoke pattern (InvokePattern, TogglePattern, etc.).

--- a/src/winapp-CLI/WinApp.Cli/Services/UiAutomationService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/UiAutomationService.cs
@@ -1278,10 +1278,10 @@ return Task.FromResult<UiElement?>(null);
     {
         // Use the element's source HWND if it came from a different window (popup/dialog)
         IUIAutomationElement? root;
-        if (element.WindowHandle != 0 && element.WindowHandle != session.WindowHandle)
+        if (element.WindowHandle is { } elHwnd && elHwnd != 0 && elHwnd != session.WindowHandle)
         {
-            root = GetRootElementForHwnd((nint)element.WindowHandle);
-            _logger.LogDebug("Resolving element on source HWND {Hwnd}", element.WindowHandle);
+            root = GetRootElementForHwnd((nint)elHwnd);
+            _logger.LogDebug("Resolving element on source HWND {Hwnd}", elHwnd);
         }
         else
         {
@@ -1753,31 +1753,46 @@ return Task.FromResult<UiElement?>(null);
         return null;
     }
 
-    private void WalkTree(IUIAutomationElement element, int maxDepth, int currentDepth, string path, List<UiElement> results, ref int nextElementId)
+    private void WalkTree(IUIAutomationElement element, int maxDepth, int currentDepth, string path, List<UiElement> results, ref int nextElementId,
+                          string? parentSelector = null, List<string>? ancestorTypes = null)
     {
         var uiElement = ToUiElement(element, path, ref nextElementId);
         uiElement.Depth = currentDepth;
+        uiElement.ParentSelector = parentSelector;
+        if (ancestorTypes is { Count: > 0 })
+        {
+            uiElement.AncestorPath = ancestorTypes.ToArray();
+        }
         results.Add(uiElement);
 
         if (currentDepth >= maxDepth)
-
-
         {
-
-
+            // Peek for children so we can hint that the tree was truncated.
+            try
+            {
+                var peekWalker = _automation.get_ControlViewWalker();
+                if (peekWalker.GetFirstChildElement(element) is not null)
+                {
+                    uiElement.HasMoreChildren = true;
+                }
+            }
+            catch { /* COM errors here are non-fatal — leave HasMoreChildren null */ }
             return;
-
-
         }
 
         var walker = _automation.get_ControlViewWalker();
         var child = walker.GetFirstChildElement(element);
         var childIndex = 0;
 
+        // Build ancestor list for children: parent's ancestors + this element's type.
+        var childAncestors = ancestorTypes is null ? new List<string>(currentDepth + 1) : new List<string>(ancestorTypes);
+        childAncestors.Add(uiElement.Type);
+        var childParentSelector = uiElement.Selector ?? uiElement.Id;
+
         while (child is not null)
         {
             var childPath = string.IsNullOrEmpty(path) ? $"/{childIndex}" : $"{path}/{childIndex}";
-            WalkTree(child, maxDepth, currentDepth + 1, childPath, results, ref nextElementId);
+            WalkTree(child, maxDepth, currentDepth + 1, childPath, results, ref nextElementId, childParentSelector, childAncestors);
 
             IUIAutomationElement? next;
             try
@@ -1788,10 +1803,10 @@ return Task.FromResult<UiElement?>(null);
             {
                 next = null;
             }
-child = next;
+            child = next;
             childIndex++;
         }
-}
+    }
 
     private static UiElement ToUiElement(IUIAutomationElement element, string path, ref int nextElementId)
     {
@@ -1873,6 +1888,14 @@ child = next;
         }
         catch { }
 
+        // Detect any actionable UIA pattern; used by inspect --interactive to surface
+        // truly clickable elements (including framework-Custom controls) instead of relying
+        // on a hard-coded ControlType allowlist.
+        var isInvokable = toggleState is not null
+                       || expandState is not null
+                       || HasPattern(element, UIA_PATTERN_ID.UIA_InvokePatternId)
+                       || HasPattern(element, UIA_PATTERN_ID.UIA_SelectionItemPatternId);
+
         return new UiElement
         {
             Id = id,
@@ -1891,7 +1914,20 @@ child = next;
             ExpandState = expandState,
             ScrollDir = scrollDir,
             Selector = selector,
+            IsInvokable = isInvokable,
         };
+    }
+
+    private static bool HasPattern(IUIAutomationElement element, UIA_PATTERN_ID patternId)
+    {
+        try
+        {
+            return element.GetCurrentPattern(patternId) is not null;
+        }
+        catch
+        {
+            return false;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
> [!WARNING]
> **Breaking change** — `winapp ui` JSON output shapes have changed. See "Breaking changes" below.

Polishes the JSON output of every `winapp ui` subcommand so consumers get a predictable, parseable shape and exit-code contract.

## Breaking changes

The following `--json` envelopes are not backward compatible. Update any scripts/tools parsing these outputs:

| Command | Before | After |
|---|---|---|
| `ui inspect --json` | `{ elements: [...] }` (flat list) | `{ depth, interactive, hideDisabled, hideOffscreen, windows: [{ hwnd, title, className, elementCount, elements: [{ ..., children: [...] }] }] }` (nested per window) |
| `ui inspect --json` (per element) | included `id`, `depth`, `parentSelector`, `windowHandle` | those fields removed — `selector` is the public handle |
| `ui inspect --ancestors --json` | ancestors emitted as sibling roots | ancestors now nested via `Depth=i` chain (parent → child) |
| `ui get-focused --json` | bare `null` when nothing focused | `{ hasFocus: false }` (or `{ hasFocus: true, element: {...} }`) |
| `ui search --json` / `ui wait-for --json` | element results included `id`, `parentSelector`, `windowHandle` (top-level + nested `invokableAncestor`) | those internal fields scrubbed |

## Envelope/shape fixes

- **`ui inspect --json`**: nest elements under `windows[].elements[].children[]` (was a flat list); strip per-element `id`/`depth`/`parentSelector`/`windowHandle` (selectors are the public handle); preserve `hasMoreChildren` truncation hint with a `+more` marker rendered in text mode.
- **`ui inspect --interactive`**: collapse non-interactive ancestors and surface them as `ancestorPath` on surviving descendants; `+more` rendered for truncated non-interactive subtrees in both text and JSON modes.
- **`ui inspect --ancestors --json`**: assign `Depth=i` to the ancestor chain so `BuildWindows` nests it correctly. Previously every ancestor became a sibling root because `Depth` was unset.
- **`ui get-focused --json`**: emit `{ hasFocus, element? }` envelope (was a bare `null` when nothing focused — unparseable as a typed result).
- **`ui search` / `ui wait-for`**: scrub internal `id`, `parentSelector`, `windowHandle` from results (top-level + nested `invokableAncestor`).

## Cycle prevention

New `UiElementScrubber` flattens `InvokableAncestor` to a hint (selector/name/type only). `System.Text.Json` (no `ReferenceHandler`) would otherwise throw on `inspect --interactive --json` when a surviving descendant's `invokableAncestor` pointed back to one of its own tree ancestors.

## Tests

35/35 `UiCommandTests` pass (was 25). New coverage:
- Multi-window separator grouping.
- Depth-jump nesting (`0` -> `2`).
- `--ancestors --json` nesting regression.
- `InvokableAncestor` cycle (interactive + search paths).
- `--json` happy-path smoke for `click` / `focus` / `set-value` / `scroll` / `scroll-into-view` so NativeAOT JSON registrations are exercised under Debug too (would otherwise only fail in published trim build).
- Updated `scripts/test-e2e-winui-ui.ps1` to navigate the new `windows[].elements[]` envelope.

## Docs

- Updated `docs/ui-automation.md` JSON examples to the new envelope shape (`.windows[0].elements[0]`).
- Documented the `search` / `wait-for` exit-code + envelope contract for `--json` mode (envelope on stdout, exit 1, stderr empty when nothing matches / times out).

## Validation

- `scripts/build-cli.ps1 -SkipTests -SkipMsix -SkipNpm` succeeds (regenerates docs + skills + VSC + NuGet).
- Verified end-to-end against Notepad for inspect/search/wait-for/get-focused in both text and JSON modes.