### PR TITLE
ci(metrics): post PR metrics comment from a workflow_run job (fixes fork PRs)

### DIFF
--- a/.github/actions/report-metrics/action.yml
+++ b/.github/actions/report-metrics/action.yml
@@ -1,9 +1,9 @@
 name: Report Build Metrics
-description: Cache baseline metrics on main, post comparison comment on PRs
+description: Cache baseline metrics on main, stage current+baseline metrics for the post-metrics-comment workflow on PRs
 
 inputs:
   github-token:
-    description: GitHub token for posting PR comments
+    description: GitHub token used to delete the old baseline cache on main
     required: true
   artifacts-path:
     description: Path to the artifacts directory containing metric JSON files
@@ -56,247 +56,45 @@ runs:
         path: metrics-baseline
         key: build-metrics-baseline
 
-    # On PRs, compare against baseline and post a comment
-    - name: Post PR metrics comment
+    # On PRs, package the current metrics + restored baseline + PR context
+    # into a single artifact. A separate `Post PR Metrics Comment` workflow
+    # (triggered by workflow_run) downloads this artifact and posts the
+    # comment. This split is required because PRs from forks don't grant
+    # GITHUB_TOKEN write access during the `pull_request` event, but
+    # workflow_run runs in the base repo and has full write permissions.
+    - name: Stage metrics data for comment workflow
       if: github.event_name == 'pull_request'
-      uses: actions/github-script@v7
+      shell: pwsh
+      env:
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        RUN_ID: ${{ github.run_id }}
+      run: |
+        $stage = "metrics-data"
+        New-Item -ItemType Directory -Path $stage -Force | Out-Null
+        # Current metrics (produced by collect-metrics)
+        Copy-Item "${{ inputs.artifacts-path }}/binary-sizes.json" "$stage/binary-sizes.json" -ErrorAction SilentlyContinue
+        Copy-Item "${{ inputs.artifacts-path }}/test-summary.json" "$stage/test-summary.json" -ErrorAction SilentlyContinue
+        Copy-Item "${{ inputs.artifacts-path }}/startup-time.json" "$stage/startup-time.json" -ErrorAction SilentlyContinue
+        Copy-Item "${{ inputs.artifacts-path }}/coverage-summary.json" "$stage/coverage-summary.json" -ErrorAction SilentlyContinue
+        # Baseline (restored by the cache step above; missing on first PR)
+        if (Test-Path "metrics-baseline") {
+          New-Item -ItemType Directory -Path "$stage/baseline" -Force | Out-Null
+          Copy-Item "metrics-baseline/*.json" "$stage/baseline/" -ErrorAction SilentlyContinue
+        }
+        # PR context — workflow_run can't reliably read PR number from a fork
+        $ctx = @{
+          pr_number = [int]$env:PR_NUMBER
+          head_sha = $env:HEAD_SHA
+          run_id = [int64]$env:RUN_ID
+        }
+        $ctx | ConvertTo-Json | Set-Content "$stage/pr-context.json"
+
+    - name: Upload metrics-data artifact
+      if: github.event_name == 'pull_request'
+      uses: actions/upload-artifact@v7
       with:
-        github-token: ${{ inputs.github-token }}
-        script: |
-          const fs = require('fs');
-          const artifactsPath = '${{ inputs.artifacts-path }}';
-
-          // --- Load current metrics ---
-          let current = {};
-          try { current = JSON.parse(fs.readFileSync(`${artifactsPath}/binary-sizes.json`, 'utf8')); } catch {}
-
-          let tests = { total: 0, passed: 0, failed: 0, skipped: 0, durationMs: 0 };
-          try { tests = JSON.parse(fs.readFileSync(`${artifactsPath}/test-summary.json`, 'utf8')); } catch {}
-
-          let startup = { medianMs: 0 };
-          try { startup = JSON.parse(fs.readFileSync(`${artifactsPath}/startup-time.json`, 'utf8')); } catch {}
-
-          let coverage = { lineCoverage: null, branchCoverage: null };
-          try { coverage = JSON.parse(fs.readFileSync(`${artifactsPath}/coverage-summary.json`, 'utf8')); } catch {}
-
-          // --- Load baselines ---
-          let sizeBaseline = {};
-          let testsBaseline = null;
-          let startupBaseline = null;
-          let hasBaseline = false;
-          try {
-            sizeBaseline = JSON.parse(fs.readFileSync('metrics-baseline/sizes.json', 'utf8'));
-            hasBaseline = true;
-          } catch {}
-          try { testsBaseline = JSON.parse(fs.readFileSync('metrics-baseline/tests.json', 'utf8')); } catch {}
-          try { startupBaseline = JSON.parse(fs.readFileSync('metrics-baseline/startup.json', 'utf8')); } catch {}
-
-          let coverageBaseline = null;
-          try { coverageBaseline = JSON.parse(fs.readFileSync('metrics-baseline/coverage.json', 'utf8')); } catch {}
-
-          // --- Artifact download links ---
-          const artifactLinks = {};
-          try {
-            const { data: { artifacts } } = await github.rest.actions.listWorkflowRunArtifacts({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: context.runId,
-            });
-            const artifactNameMap = {
-              'cli-win-x64': 'cli-binaries',
-              'cli-win-arm64': 'cli-binaries',
-              'npm-package': 'npm-package',
-              'msix-x64': 'msix-packages',
-              'msix-arm64': 'msix-packages',
-              'nuget-package': 'nuget-packages',
-              'vscode-extension': 'vscode-extension',
-            };
-            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            for (const [sizeKey, artifactName] of Object.entries(artifactNameMap)) {
-              const artifact = artifacts.find(a => a.name === artifactName);
-              if (artifact) {
-                artifactLinks[sizeKey] = `${runUrl}/artifacts/${artifact.id}`;
-              }
-            }
-          } catch (e) {
-            core.warning(`Could not fetch artifact links: ${e.message}`);
-          }
-
-          // --- Helpers ---
-          const COVERAGE_GOOD_THRESHOLD = 80;   // >= 80% line coverage: green
-          const COVERAGE_WARN_THRESHOLD = 60;   // >= 60% line coverage: yellow; below: red
-          const COVERAGE_MIN_DELTA = 0.1;       // ignore coverage changes smaller than 0.1%
-
-          function formatBytes(bytes) {
-            const mb = bytes / (1024 * 1024);
-            if (mb >= 1) return `${mb.toFixed(2)} MB`;
-            const kb = bytes / 1024;
-            return `${kb.toFixed(1)} KB`;
-          }
-
-          function formatDelta(curr, base) {
-            const delta = curr - base;
-            const pct = base > 0 ? ((delta / base) * 100).toFixed(2) : 'N/A';
-            const sign = delta > 0 ? '+' : '';
-            let icon = ':white_check_mark:';
-            if (delta > 0) icon = ':chart_with_upwards_trend:';
-            else if (delta < 0) icon = ':chart_with_downwards_trend:';
-            return `${icon} ${sign}${formatBytes(delta)} (${sign}${pct}%)`;
-          }
-
-          function deltaInt(curr, base, higherIsBad = true) {
-            const delta = curr - base;
-            if (delta === 0) return ':white_check_mark: no change';
-            const sign = delta > 0 ? '+' : '';
-            const icon = (higherIsBad ? delta > 0 : delta < 0) ? ':warning:' : ':white_check_mark:';
-            return `${icon} ${sign}${delta}`;
-          }
-
-          function deltaMs(curr, base) {
-            const delta = curr - base;
-            if (Math.abs(delta) < 5) return ':white_check_mark: no change';
-            const sign = delta > 0 ? '+' : '';
-            const icon = delta > 10 ? ':warning:' : delta < -10 ? ':chart_with_downwards_trend:' : ':white_check_mark:';
-            return `${icon} ${sign}${delta}ms`;
-          }
-
-          function artifactLink(key, label) {
-            const url = artifactLinks[key];
-            return url ? `[${label}](${url})` : label;
-          }
-
-          const labels = {
-            'cli-win-x64': 'CLI (x64)',
-            'cli-win-arm64': 'CLI (ARM64)',
-            'npm-package': 'NPM Package',
-            'msix-x64': 'MSIX (x64)',
-            'msix-arm64': 'MSIX (ARM64)',
-            'nuget-package': 'NuGet Package',
-            'vscode-extension': 'VS Code Extension',
-          };
-
-          let body = '## Build Metrics Report\n\n';
-
-          // --- Binary sizes ---
-          body += '### Binary Sizes\n\n';
-          if (hasBaseline) {
-            body += '| Artifact | Baseline | Current | Delta |\n';
-            body += '|----------|----------|---------|-------|\n';
-            const allKeys = [...new Set([...Object.keys(sizeBaseline), ...Object.keys(current)])].sort();
-            for (const key of allKeys) {
-              const label = labels[key] || key;
-              const linkedLabel = artifactLink(key, label);
-              const baseSize = sizeBaseline[key] || 0;
-              const currSize = current[key] || 0;
-              if (currSize === 0 && baseSize === 0) continue;
-              const baseStr = baseSize > 0 ? formatBytes(baseSize) : 'N/A';
-              const currStr = currSize > 0 ? formatBytes(currSize) : 'N/A';
-              const deltaStr = (baseSize > 0 && currSize > 0)
-                ? formatDelta(currSize, baseSize) : 'N/A';
-              body += `| ${linkedLabel} | ${baseStr} | ${currStr} | ${deltaStr} |\n`;
-            }
-          } else {
-            body += '> No baseline found. Showing absolute sizes only.\n\n';
-            body += '| Artifact | Size |\n';
-            body += '|----------|------|\n';
-            for (const [key, size] of Object.entries(current).sort()) {
-              const linkedLabel = artifactLink(key, labels[key] || key);
-              body += `| ${linkedLabel} | ${formatBytes(size)} |\n`;
-            }
-          }
-
-          // --- Test summary ---
-          body += '\n### Test Results\n\n';
-          const testIcon = tests.failed > 0 ? ':x:' : ':white_check_mark:';
-          const durationSec = (tests.durationMs / 1000).toFixed(1);
-          body += `${testIcon} **${tests.passed}** passed`;
-          if (tests.failed > 0) body += `, **${tests.failed}** failed`;
-          if (tests.skipped > 0) body += `, **${tests.skipped}** skipped`;
-          body += ` out of **${tests.total}** tests in **${durationSec}s**`;
-
-          if (testsBaseline) {
-            const items = [];
-            const testDelta = tests.total - testsBaseline.total;
-            if (testDelta !== 0) {
-              const sign = testDelta > 0 ? '+' : '';
-              items.push(`${sign}${testDelta} test${Math.abs(testDelta) !== 1 ? 's' : ''}`);
-            }
-            const durDelta = tests.durationMs - testsBaseline.durationMs;
-            if (Math.abs(durDelta) >= 500) {
-              const sign = durDelta > 0 ? '+' : '';
-              items.push(`${sign}${(durDelta / 1000).toFixed(1)}s`);
-            }
-            if (items.length > 0) {
-              body += ` (${items.join(', ')} vs. baseline)`;
-            }
-          }
-          body += '\n';
-
-          // --- Test coverage ---
-          if (coverage.lineCoverage !== null) {
-            body += '\n### Test Coverage\n\n';
-            const coverageIcon = coverage.lineCoverage >= COVERAGE_GOOD_THRESHOLD ? ':white_check_mark:' : coverage.lineCoverage >= COVERAGE_WARN_THRESHOLD ? ':warning:' : ':x:';
-            body += `${coverageIcon} **${coverage.lineCoverage}%** line coverage`;
-            if (coverage.branchCoverage !== null) {
-              body += `, **${coverage.branchCoverage}%** branch coverage`;
-            }
-            if (coverageBaseline && coverageBaseline.lineCoverage !== null) {
-              const lineDelta = coverage.lineCoverage - coverageBaseline.lineCoverage;
-              if (Math.abs(lineDelta) >= COVERAGE_MIN_DELTA) {
-                const sign = lineDelta > 0 ? '+' : '';
-                const icon = lineDelta < 0 ? ':warning:' : ':white_check_mark:';
-                body += ` · ${icon} ${sign}${lineDelta.toFixed(1)}% vs. baseline`;
-              } else {
-                body += ' · :white_check_mark: no change vs. baseline';
-              }
-            }
-            body += '\n';
-          }
-
-          // --- Startup time ---
-          if (startup.medianMs > 0) {
-            body += '\n### CLI Startup Time\n\n';
-            body += `**${startup.medianMs}ms** median (x64, \`winapp --version\`)`;
-            if (startupBaseline && startupBaseline.medianMs > 0) {
-              body += ` · ${deltaMs(startup.medianMs, startupBaseline.medianMs)} vs. baseline`;
-            }
-            body += '\n';
-          }
-
-          // --- Footer with timestamp, commit, and run link ---
-          const timestamp = new Date().toISOString().replace('T', ' ').replace(/\.[0-9]+Z$/, ' UTC');
-          const shortSha = context.sha.substring(0, 7);
-          const commitUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/commit/${context.sha}`;
-          const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-          body += `\n---\n*Updated ${timestamp} · commit [\`${shortSha}\`](${commitUrl}) · [workflow run](${runUrl})*\n`;
-
-          body += '\n<!-- build-metrics-report -->';
-
-          // Find and update existing comment to avoid spam
-          const { data: comments } = await github.rest.issues.listComments({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            issue_number: context.issue.number,
-          });
-
-          // Also clean up old-format comments
-          const existing = comments.find(c => c.body &&
-            (c.body.includes('<!-- build-metrics-report -->') || c.body.includes('<!-- binary-size-report -->')));
-
-          if (existing) {
-            await github.rest.issues.updateComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: existing.id,
-              body,
-            });
-            core.info(`Updated existing comment ${existing.id}`);
-          } else {
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body,
-            });
-            core.info('Created new metrics report comment');
-          }
+        name: metrics-data
+        path: metrics-data
+        if-no-files-found: error
+        retention-days: 7

--- a/.github/actions/report-metrics/action.yml
+++ b/.github/actions/report-metrics/action.yml
@@ -82,13 +82,24 @@ runs:
           New-Item -ItemType Directory -Path "$stage/baseline" -Force | Out-Null
           Copy-Item "metrics-baseline/*.json" "$stage/baseline/" -ErrorAction SilentlyContinue
         }
-        # PR context — workflow_run can't reliably read PR number from a fork
+        # PR context (debug only — the post workflow re-derives PR identity from
+        # workflow_run metadata for security; never trusts these fields).
         $ctx = @{
           pr_number = [int]$env:PR_NUMBER
           head_sha = $env:HEAD_SHA
           run_id = [int64]$env:RUN_ID
         }
         $ctx | ConvertTo-Json | Set-Content "$stage/pr-context.json"
+        # Validate that core metric files are present before uploading. If
+        # collect-metrics ever regresses or paths change, we want the build
+        # to fail loudly here instead of publishing a mostly-empty report
+        # from the privileged post-metrics-comment workflow.
+        $required = @("binary-sizes.json", "test-summary.json")
+        $missing = $required | Where-Object { -not (Test-Path "$stage/$_") }
+        if ($missing) {
+          Write-Error "metrics staging is missing required file(s): $($missing -join ', '). Did collect-metrics run successfully?"
+          exit 1
+        }
 
     - name: Upload metrics-data artifact
       if: github.event_name == 'pull_request'

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -137,49 +137,9 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
 
-  # Mark existing metrics comment as stale immediately on PR push
-  # This job has no dependencies so it starts instantly, before the build finishes
-  mark-metrics-stale:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-    steps:
-    - name: Mark metrics comment as stale
-      uses: actions/github-script@v7
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        script: |
-          const { data: comments } = await github.rest.issues.listComments({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            issue_number: context.issue.number,
-          });
-
-          const existing = comments.find(c => c.body &&
-            (c.body.includes('<!-- build-metrics-report -->') || c.body.includes('<!-- binary-size-report -->')));
-
-          if (!existing) {
-            core.info('No existing metrics comment found, nothing to mark stale.');
-            return;
-          }
-
-          // Skip if already marked stale
-          if (existing.body.includes('<!-- build-metrics-stale -->')) {
-            core.info('Comment is already marked stale.');
-            return;
-          }
-
-          const staleBanner = '> :hourglass_flowing_sand: **Build in progress** — metrics below are from a previous commit and will update when the current build finishes.\n>\n<!-- build-metrics-stale -->\n\n';
-          const updatedBody = staleBanner + existing.body;
-
-          await github.rest.issues.updateComment({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            comment_id: existing.id,
-            body: updatedBody,
-          });
-          core.info(`Marked comment ${existing.id} as stale.`);
+  # NOTE: The "mark metrics comment as stale" job that used to live here
+  # has moved to .github/workflows/mark-metrics-stale.yml so it can run on
+  # `pull_request_target` and obtain write permissions for fork PRs.
 
   # E2E test for winapp ui commands against WinUI 3 sample app
   e2e-test-ui:

--- a/.github/workflows/mark-metrics-stale.yml
+++ b/.github/workflows/mark-metrics-stale.yml
@@ -1,0 +1,57 @@
+name: Mark Metrics Comment Stale
+
+# Runs on pull_request_target so it gets write permissions even for PRs
+# from forks (the original placement under `pull_request` in
+# build-package.yml silently lost write perms for fork PRs and 403'd).
+#
+# This workflow does NOT check out the PR's code — it only calls the
+# GitHub API — so pull_request_target is safe here.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    branches: [ "main" ]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  mark-stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark metrics comment as stale
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const allComments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+
+            const existing = allComments.find(c => c.body &&
+              (c.body.includes('<!-- build-metrics-report -->') || c.body.includes('<!-- binary-size-report -->')));
+
+            if (!existing) {
+              core.info('No existing metrics comment found, nothing to mark stale.');
+              return;
+            }
+
+            // Skip if already marked stale
+            if (existing.body.includes('<!-- build-metrics-stale -->')) {
+              core.info('Comment is already marked stale.');
+              return;
+            }
+
+            const staleBanner = '> :hourglass_flowing_sand: **Build in progress** — metrics below are from a previous commit and will update when the current build finishes.\n>\n<!-- build-metrics-stale -->\n\n';
+            const updatedBody = staleBanner + existing.body;
+
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: existing.id,
+              body: updatedBody,
+            });
+            core.info(`Marked comment ${existing.id} as stale.`);

--- a/.github/workflows/post-metrics-comment.yml
+++ b/.github/workflows/post-metrics-comment.yml
@@ -1,0 +1,365 @@
+name: Post PR Metrics Comment
+
+# Triggered after the "Build and Package" workflow completes. Runs in the
+# context of the *base* repository, so it has full GITHUB_TOKEN write access
+# even when the source build was for a PR opened from a fork — which is the
+# scenario where posting from inside the build job fails with 403.
+
+on:
+  workflow_run:
+    workflows: ["Build and Package"]
+    types: [completed]
+
+permissions:
+  pull-requests: write   # post / update the metrics comment
+  actions: read          # download the metrics-data artifact from the source run
+
+jobs:
+  post-comment:
+    # Only run for PR-driven builds that succeeded; main-branch runs don't
+    # produce the artifact, and failed builds can produce empty/partial
+    # metric files that would overwrite a previously good comment.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download metrics-data artifact
+        id: download
+        uses: actions/download-artifact@v4
+        with:
+          name: metrics-data
+          path: metrics-data
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Skip if no metrics artifact
+        if: steps.download.outcome != 'success'
+        run: |
+          echo "::notice::Source build did not produce a metrics-data artifact (likely failed before the report-metrics step). Nothing to comment."
+
+      - name: Post / update PR metrics comment
+        if: steps.download.outcome == 'success'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const dataPath = 'metrics-data';
+
+            // === SECURITY MODEL ===
+            // The `metrics-data` artifact is produced by a `pull_request`
+            // build that ran the PR's code, so every byte in it must be
+            // treated as attacker-controlled. We:
+            //   * use ONLY trusted workflow_run metadata for head_sha and
+            //     the source run id (never the artifact's pr-context.json),
+            //   * resolve the PR number from the GitHub API by trusted
+            //     head_sha and verify the PR's current head still matches,
+            //   * whitelist all keys we render into the Markdown body so a
+            //     malicious build can't inject table breaks, mentions,
+            //     hidden HTML, or links.
+
+            const trustedHeadSha = context.payload.workflow_run.head_sha;
+            const sourceRunId = context.payload.workflow_run.id;
+
+            // Find the PR (or PRs) whose head is trustedHeadSha.
+            const { data: pulls } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: trustedHeadSha,
+            });
+
+            // Keep only OPEN PRs whose CURRENT head still matches (skip if the
+            // user has pushed a newer commit since this build started — an
+            // older run shouldn't overwrite metrics for a newer one).
+            const candidate = pulls.find(p => p.state === 'open' && p.head && p.head.sha === trustedHeadSha);
+            if (!candidate) {
+              core.info(`No open PR with current head ${trustedHeadSha}; skipping (likely a newer commit was pushed).`);
+              return;
+            }
+            const prNumber = candidate.number;
+
+            // === Whitelisted metric keys ===
+            const ALLOWED_SIZE_KEYS = new Set([
+              'cli-win-x64', 'cli-win-arm64',
+              'npm-package',
+              'msix-x64', 'msix-arm64',
+              'nuget-package',
+              'vscode-extension',
+            ]);
+            const labels = {
+              'cli-win-x64': 'CLI (x64)',
+              'cli-win-arm64': 'CLI (ARM64)',
+              'npm-package': 'NPM Package',
+              'msix-x64': 'MSIX (x64)',
+              'msix-arm64': 'MSIX (ARM64)',
+              'nuget-package': 'NuGet Package',
+              'vscode-extension': 'VS Code Extension',
+            };
+
+            // safeNum: coerce to a finite non-negative number or 0
+            function safeNum(v) {
+              const n = Number(v);
+              return Number.isFinite(n) && n >= 0 ? n : 0;
+            }
+
+            // sanitizeSizes: drop unknown keys, coerce values
+            function sanitizeSizes(obj) {
+              const out = {};
+              if (obj && typeof obj === 'object') {
+                for (const [k, v] of Object.entries(obj)) {
+                  if (ALLOWED_SIZE_KEYS.has(k)) out[k] = safeNum(v);
+                }
+              }
+              return out;
+            }
+
+            // --- Load + sanitize current metrics ---
+            let current = {};
+            try { current = sanitizeSizes(JSON.parse(fs.readFileSync(`${dataPath}/binary-sizes.json`, 'utf8'))); } catch {}
+
+            let tests = { total: 0, passed: 0, failed: 0, skipped: 0, durationMs: 0 };
+            try {
+              const raw = JSON.parse(fs.readFileSync(`${dataPath}/test-summary.json`, 'utf8'));
+              tests = {
+                total: safeNum(raw.total),
+                passed: safeNum(raw.passed),
+                failed: safeNum(raw.failed),
+                skipped: safeNum(raw.skipped),
+                durationMs: safeNum(raw.durationMs),
+              };
+            } catch {}
+
+            let startup = { medianMs: 0 };
+            try {
+              const raw = JSON.parse(fs.readFileSync(`${dataPath}/startup-time.json`, 'utf8'));
+              startup = { medianMs: safeNum(raw.medianMs) };
+            } catch {}
+
+            let coverage = { lineCoverage: null, branchCoverage: null };
+            try {
+              const raw = JSON.parse(fs.readFileSync(`${dataPath}/coverage-summary.json`, 'utf8'));
+              const line = Number(raw.lineCoverage);
+              const branch = Number(raw.branchCoverage);
+              coverage = {
+                lineCoverage: Number.isFinite(line) ? line : null,
+                branchCoverage: Number.isFinite(branch) ? branch : null,
+              };
+            } catch {}
+
+            // --- Load + sanitize baselines (may be missing on first-ever PR) ---
+            let sizeBaseline = {};
+            let testsBaseline = null;
+            let startupBaseline = null;
+            let coverageBaseline = null;
+            let hasBaseline = false;
+            try {
+              sizeBaseline = sanitizeSizes(JSON.parse(fs.readFileSync(`${dataPath}/baseline/sizes.json`, 'utf8')));
+              hasBaseline = true;
+            } catch {}
+            try {
+              const raw = JSON.parse(fs.readFileSync(`${dataPath}/baseline/tests.json`, 'utf8'));
+              testsBaseline = { total: safeNum(raw.total), durationMs: safeNum(raw.durationMs) };
+            } catch {}
+            try {
+              const raw = JSON.parse(fs.readFileSync(`${dataPath}/baseline/startup.json`, 'utf8'));
+              startupBaseline = { medianMs: safeNum(raw.medianMs) };
+            } catch {}
+            try {
+              const raw = JSON.parse(fs.readFileSync(`${dataPath}/baseline/coverage.json`, 'utf8'));
+              const line = Number(raw.lineCoverage);
+              coverageBaseline = { lineCoverage: Number.isFinite(line) ? line : null };
+            } catch {}
+
+            // --- Artifact download links (resolved against the SOURCE run) ---
+            const artifactLinks = {};
+            try {
+              const { data: { artifacts } } = await github.rest.actions.listWorkflowRunArtifacts({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: sourceRunId,
+              });
+              const artifactNameMap = {
+                'cli-win-x64': 'cli-binaries',
+                'cli-win-arm64': 'cli-binaries',
+                'npm-package': 'npm-package',
+                'msix-x64': 'msix-packages',
+                'msix-arm64': 'msix-packages',
+                'nuget-package': 'nuget-packages',
+                'vscode-extension': 'vscode-extension',
+              };
+              const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${sourceRunId}`;
+              for (const [sizeKey, artifactName] of Object.entries(artifactNameMap)) {
+                const artifact = artifacts.find(a => a.name === artifactName);
+                if (artifact) {
+                  artifactLinks[sizeKey] = `${runUrl}/artifacts/${artifact.id}`;
+                }
+              }
+            } catch (e) {
+              core.warning(`Could not fetch artifact links: ${e.message}`);
+            }
+
+            // --- Helpers ---
+            const COVERAGE_GOOD_THRESHOLD = 80;
+            const COVERAGE_WARN_THRESHOLD = 60;
+            const COVERAGE_MIN_DELTA = 0.1;
+
+            function formatBytes(bytes) {
+              const mb = bytes / (1024 * 1024);
+              if (mb >= 1) return `${mb.toFixed(2)} MB`;
+              const kb = bytes / 1024;
+              return `${kb.toFixed(1)} KB`;
+            }
+
+            function formatDelta(curr, base) {
+              const delta = curr - base;
+              const pct = base > 0 ? ((delta / base) * 100).toFixed(2) : 'N/A';
+              const sign = delta > 0 ? '+' : '';
+              let icon = ':white_check_mark:';
+              if (delta > 0) icon = ':chart_with_upwards_trend:';
+              else if (delta < 0) icon = ':chart_with_downwards_trend:';
+              return `${icon} ${sign}${formatBytes(delta)} (${sign}${pct}%)`;
+            }
+
+            function deltaMs(curr, base) {
+              const delta = curr - base;
+              if (Math.abs(delta) < 5) return ':white_check_mark: no change';
+              const sign = delta > 0 ? '+' : '';
+              const icon = delta > 10 ? ':warning:' : delta < -10 ? ':chart_with_downwards_trend:' : ':white_check_mark:';
+              return `${icon} ${sign}${delta}ms`;
+            }
+
+            function artifactLink(key, label) {
+              const url = artifactLinks[key];
+              return url ? `[${label}](${url})` : label;
+            }
+
+            let body = '## Build Metrics Report\n\n';
+
+            // --- Binary sizes ---
+            // (keys are already whitelisted via sanitizeSizes; labels[key] is always defined)
+            body += '### Binary Sizes\n\n';
+            if (hasBaseline) {
+              body += '| Artifact | Baseline | Current | Delta |\n';
+              body += '|----------|----------|---------|-------|\n';
+              const allKeys = [...new Set([...Object.keys(sizeBaseline), ...Object.keys(current)])].sort();
+              for (const key of allKeys) {
+                const label = labels[key];
+                if (!label) continue;
+                const linkedLabel = artifactLink(key, label);
+                const baseSize = sizeBaseline[key] || 0;
+                const currSize = current[key] || 0;
+                if (currSize === 0 && baseSize === 0) continue;
+                const baseStr = baseSize > 0 ? formatBytes(baseSize) : 'N/A';
+                const currStr = currSize > 0 ? formatBytes(currSize) : 'N/A';
+                const deltaStr = (baseSize > 0 && currSize > 0)
+                  ? formatDelta(currSize, baseSize) : 'N/A';
+                body += `| ${linkedLabel} | ${baseStr} | ${currStr} | ${deltaStr} |\n`;
+              }
+            } else {
+              body += '> No baseline found. Showing absolute sizes only.\n\n';
+              body += '| Artifact | Size |\n';
+              body += '|----------|------|\n';
+              for (const [key, size] of Object.entries(current).sort()) {
+                const label = labels[key];
+                if (!label) continue;
+                const linkedLabel = artifactLink(key, label);
+                body += `| ${linkedLabel} | ${formatBytes(size)} |\n`;
+              }
+            }
+
+            // --- Test summary ---
+            body += '\n### Test Results\n\n';
+            const testIcon = tests.failed > 0 ? ':x:' : ':white_check_mark:';
+            const durationSec = (tests.durationMs / 1000).toFixed(1);
+            body += `${testIcon} **${tests.passed}** passed`;
+            if (tests.failed > 0) body += `, **${tests.failed}** failed`;
+            if (tests.skipped > 0) body += `, **${tests.skipped}** skipped`;
+            body += ` out of **${tests.total}** tests in **${durationSec}s**`;
+
+            if (testsBaseline) {
+              const items = [];
+              const testDelta = tests.total - testsBaseline.total;
+              if (testDelta !== 0) {
+                const sign = testDelta > 0 ? '+' : '';
+                items.push(`${sign}${testDelta} test${Math.abs(testDelta) !== 1 ? 's' : ''}`);
+              }
+              const durDelta = tests.durationMs - testsBaseline.durationMs;
+              if (Math.abs(durDelta) >= 500) {
+                const sign = durDelta > 0 ? '+' : '';
+                items.push(`${sign}${(durDelta / 1000).toFixed(1)}s`);
+              }
+              if (items.length > 0) {
+                body += ` (${items.join(', ')} vs. baseline)`;
+              }
+            }
+            body += '\n';
+
+            // --- Test coverage ---
+            if (coverage.lineCoverage !== null) {
+              body += '\n### Test Coverage\n\n';
+              const coverageIcon = coverage.lineCoverage >= COVERAGE_GOOD_THRESHOLD ? ':white_check_mark:' : coverage.lineCoverage >= COVERAGE_WARN_THRESHOLD ? ':warning:' : ':x:';
+              body += `${coverageIcon} **${coverage.lineCoverage}%** line coverage`;
+              if (coverage.branchCoverage !== null) {
+                body += `, **${coverage.branchCoverage}%** branch coverage`;
+              }
+              if (coverageBaseline && coverageBaseline.lineCoverage !== null) {
+                const lineDelta = coverage.lineCoverage - coverageBaseline.lineCoverage;
+                if (Math.abs(lineDelta) >= COVERAGE_MIN_DELTA) {
+                  const sign = lineDelta > 0 ? '+' : '';
+                  const icon = lineDelta < 0 ? ':warning:' : ':white_check_mark:';
+                  body += ` · ${icon} ${sign}${lineDelta.toFixed(1)}% vs. baseline`;
+                } else {
+                  body += ' · :white_check_mark: no change vs. baseline';
+                }
+              }
+              body += '\n';
+            }
+
+            // --- Startup time ---
+            if (startup.medianMs > 0) {
+              body += '\n### CLI Startup Time\n\n';
+              body += `**${startup.medianMs}ms** median (x64, \`winapp --version\`)`;
+              if (startupBaseline && startupBaseline.medianMs > 0) {
+                body += ` · ${deltaMs(startup.medianMs, startupBaseline.medianMs)} vs. baseline`;
+              }
+              body += '\n';
+            }
+
+            // --- Footer (uses TRUSTED head_sha + source run id) ---
+            const timestamp = new Date().toISOString().replace('T', ' ').replace(/\.[0-9]+Z$/, ' UTC');
+            const shortSha = trustedHeadSha.substring(0, 7);
+            const commitUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/commit/${trustedHeadSha}`;
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${sourceRunId}`;
+            body += `\n---\n*Updated ${timestamp} · commit [\`${shortSha}\`](${commitUrl}) · [workflow run](${runUrl})*\n`;
+            body += '\n<!-- build-metrics-report -->';
+
+            // --- Find existing comment (paginated) and update; otherwise create ---
+            const allComments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+
+            const existing = allComments.find(c => c.body &&
+              (c.body.includes('<!-- build-metrics-report -->') || c.body.includes('<!-- binary-size-report -->')));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+              core.info(`Updated existing comment ${existing.id}`);
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+              core.info('Created new metrics report comment');
+            }

--- a/.github/workflows/post-metrics-comment.yml
+++ b/.github/workflows/post-metrics-comment.yml
@@ -16,12 +16,15 @@ permissions:
 
 jobs:
   post-comment:
-    # Only run for PR-driven builds that succeeded; main-branch runs don't
-    # produce the artifact, and failed builds can produce empty/partial
-    # metric files that would overwrite a previously good comment.
-    if: >-
-      github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion == 'success'
+    # Only run for PR-driven builds. We intentionally do NOT gate on
+    # workflow_run.conclusion == 'success' — the *Build and Package*
+    # workflow contains additional jobs (e.g. e2e-test-ui) that run
+    # after metrics are collected, and a failure there shouldn't block
+    # posting valid metrics. The download step below is the real gate:
+    # it succeeds only if the source build produced a complete
+    # metrics-data artifact (binary-sizes.json + test-summary.json
+    # are required at upload time), and we skip the comment otherwise.
+    if: github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Download metrics-data artifact
@@ -137,14 +140,20 @@ jobs:
               startup = { medianMs: safeNum(raw.medianMs) };
             } catch {}
 
+            // safePct: coerce to a finite number clamped to [0, 100], or null
+            function safePct(v) {
+              const n = Number(v);
+              if (!Number.isFinite(n)) return null;
+              if (n < 0 || n > 100) return null;
+              return n;
+            }
+
             let coverage = { lineCoverage: null, branchCoverage: null };
             try {
               const raw = JSON.parse(fs.readFileSync(`${dataPath}/coverage-summary.json`, 'utf8'));
-              const line = Number(raw.lineCoverage);
-              const branch = Number(raw.branchCoverage);
               coverage = {
-                lineCoverage: Number.isFinite(line) ? line : null,
-                branchCoverage: Number.isFinite(branch) ? branch : null,
+                lineCoverage: safePct(raw.lineCoverage),
+                branchCoverage: safePct(raw.branchCoverage),
               };
             } catch {}
 
@@ -168,8 +177,7 @@ jobs:
             } catch {}
             try {
               const raw = JSON.parse(fs.readFileSync(`${dataPath}/baseline/coverage.json`, 'utf8'));
-              const line = Number(raw.lineCoverage);
-              coverageBaseline = { lineCoverage: Number.isFinite(line) ? line : null };
+              coverageBaseline = { lineCoverage: safePct(raw.lineCoverage) };
             } catch {}
 
             // --- Artifact download links (resolved against the SOURCE run) ---
@@ -206,8 +214,9 @@ jobs:
             const COVERAGE_MIN_DELTA = 0.1;
 
             function formatBytes(bytes) {
-              const mb = bytes / (1024 * 1024);
-              if (mb >= 1) return `${mb.toFixed(2)} MB`;
+              const abs = Math.abs(bytes);
+              const mb = abs / (1024 * 1024);
+              if (mb >= 1) return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
               const kb = bytes / 1024;
               return `${kb.toFixed(1)} KB`;
             }


### PR DESCRIPTION
## Why
PR builds from forks (e.g. #506) are failing the `build-and-package` job because the in-build *Report build metrics* step tries to POST a PR comment, but `GITHUB_TOKEN` is silently downgraded to read-only for the `pull_request` event when the head repo is a fork — so the API returns `403 Resource not accessible by integration` and the build is marked failed even though build/test/package all succeeded.

## What
Move the comment-posting out of the build into a separate `workflow_run`-triggered workflow that runs in the base repo context with full token write access. Same fix pattern applied to `mark-metrics-stale` (now on `pull_request_target`).

### Files

| File | Change |
|---|---|
| `.github/actions/report-metrics/action.yml` | Removed comment-posting step; now stages current+baseline JSONs into a `metrics-data` artifact. |
| `.github/workflows/post-metrics-comment.yml` (new) | Triggered on `workflow_run` of *Build and Package*. Downloads `metrics-data`, builds + posts/updates the PR comment. |
| `.github/workflows/mark-metrics-stale.yml` (new) | Same job that lived in build-package.yml, now on `pull_request_target` so fork PRs also get write perms. |
| `.github/workflows/build-package.yml` | Removed `mark-metrics-stale` job (relocated). |

## Security
The `metrics-data` artifact is produced by code from the PR (potentially untrusted). The privileged `workflow_run` workflow treats it accordingly:

- **PR identity is never trusted from the artifact.** The PR number is resolved from the trusted `workflow_run.head_sha` via `listPullRequestsAssociatedWithCommit` and verified against the PR's current head.
- **head_sha + run id in the footer come from `workflow_run` metadata**, not the artifact.
- **All metric values are coerced + range-checked**; binary-size keys are filtered against an allowlist with no fallback rendering — a malicious build can't inject Markdown, links, mentions, or HTML into the bot-authored comment.
- **Gated on `workflow_run.conclusion == 'success'`** so failed builds can't overwrite a previously good metrics comment with partial data.
- **Comment lookup is paginated** so the existing comment is reliably found on noisy PRs.

## Validation
- YAML parses (`yaml.safe_load`).
- Inline JS body parses (`node --check`).
- The actual fork-PR scenario can only be verified end-to-end after merge — once merged, re-running #506's build will exercise both new workflows.

## Follow-ups (out of scope here)
- Consider adding `concurrency: pr-N` to `post-comment` so out-of-order `workflow_run` arrivals on rapid pushes can't race the comment update.