### PR TITLE
Bump/vsc v0.1.1

### DIFF
--- a/scripts/start-vsc-release.ps1
+++ b/scripts/start-vsc-release.ps1
@@ -39,6 +39,7 @@ param(
 $ErrorActionPreference = "Stop"
 $ProjectRoot = $PSScriptRoot | Split-Path -Parent
 $VscPackageJsonPath = Join-Path $ProjectRoot "src\winapp-VSC\package.json"
+$VscPackageLockPath = Join-Path $ProjectRoot "src\winapp-VSC\package-lock.json"
 
 # ─── Helpers ────────────────────────────────────────────────────────────────────
 
@@ -182,7 +183,6 @@ try {
 
     # 6. Confirm with user
     Write-Host ""
-    $pad = { param($s, $w) (' ' * [Math]::Max(0, $w - $s.Length)) }
     Write-Host "  VSC Extension Release Plan" -ForegroundColor White
     Write-Host "  ─────────────────────────────────────────────" -ForegroundColor White
     Write-Host "  Release version : $releaseVersion" -ForegroundColor White
@@ -217,8 +217,15 @@ try {
             $updatedJson = $vscPackageJson | ConvertTo-Json -Depth 100
             Set-Content -Path $VscPackageJsonPath -Value $updatedJson -NoNewline
             Write-Info "Updated VS Code extension version: $vscCurrentVersion -> $releaseVersion"
+
+            # Update package-lock.json to keep it in sync
+            $vscDir = Split-Path $VscPackageJsonPath -Parent
+            Push-Location $vscDir
+            npm install --package-lock-only --ignore-scripts 2>&1 | Out-Null
+            Pop-Location
+            Write-Info "Updated package-lock.json to match version $releaseVersion"
         }
-        Invoke-GitOrDryRun -Description "Stage version update" -Arguments @("add", $VscPackageJsonPath)
+        Invoke-GitOrDryRun -Description "Stage version update" -Arguments @("add", $VscPackageJsonPath, $VscPackageLockPath)
         Invoke-GitOrDryRun -Description "Commit version update" -Arguments @("commit", "-m", "Set VS Code extension version to $releaseVersion for release")
     }
 
@@ -244,9 +251,16 @@ try {
         $updatedJson = $vscPackageJson | ConvertTo-Json -Depth 100
         Set-Content -Path $VscPackageJsonPath -Value $updatedJson -NoNewline
         Write-Info "Updated package.json: $releaseVersion -> $nextVersion"
+
+        # Update package-lock.json to keep it in sync
+        $vscDir = Split-Path $VscPackageJsonPath -Parent
+        Push-Location $vscDir
+        npm install --package-lock-only --ignore-scripts 2>&1 | Out-Null
+        Pop-Location
+        Write-Info "Updated package-lock.json to match version $nextVersion"
     }
 
-    Invoke-GitOrDryRun -Description "Stage version bump" -Arguments @("add", $VscPackageJsonPath)
+    Invoke-GitOrDryRun -Description "Stage version bump" -Arguments @("add", $VscPackageJsonPath, $VscPackageLockPath)
     Invoke-GitOrDryRun -Description "Commit version bump" -Arguments @("commit", "-m", "Bump VS Code extension version to $nextVersion for development")
 
     Confirm-Step "Push version bump branch '$bumpBranch' to origin and create PR?"
@@ -262,6 +276,7 @@ try {
     $prBody  = "Auto-generated version bump after releasing VS Code extension v$releaseVersion.`n`nThis PR bumps the patch version in ``src/winapp-VSC/package.json`` from ``$releaseVersion`` to ``$nextVersion`` so that prerelease builds pick up the new version number."
 
     $ghAvailable = Get-Command gh -ErrorAction SilentlyContinue
+    $prCreated = $false
     if (-not $ghAvailable -and -not $DryRun) {
         $encodedTitle = [System.Uri]::EscapeDataString($prTitle)
         $encodedBody  = [System.Uri]::EscapeDataString($prBody)
@@ -278,6 +293,7 @@ try {
             "--title", $prTitle,
             "--body", $prBody
         )
+        $prCreated = $true
         Write-Ok "Pull request created"
     }
 
@@ -289,11 +305,19 @@ try {
     Write-Host "  VSC Extension release started!" -ForegroundColor Green
     Write-Host "  ─────────────────────────────────────────────" -ForegroundColor Green
     Write-Host "  • Release branch '$releaseBranch' pushed" -ForegroundColor Green
-    Write-Host "  • Version bump PR created for $nextVersion" -ForegroundColor Green
+    if ($prCreated) {
+        Write-Host "  • Version bump PR created for $nextVersion" -ForegroundColor Green
+    } else {
+        Write-Host "  • Version bump branch '$bumpBranch' pushed (create PR manually)" -ForegroundColor Green
+    }
     Write-Host "" -ForegroundColor Green
     Write-Host "  Next steps:" -ForegroundColor Green
     Write-Host "  1. Monitor the VSC release pipeline" -ForegroundColor Green
-    Write-Host "  2. Review & merge the version bump PR" -ForegroundColor Green
+    if ($prCreated) {
+        Write-Host "  2. Review & merge the version bump PR" -ForegroundColor Green
+    } else {
+        Write-Host "  2. Create & merge the version bump PR using the link above" -ForegroundColor Green
+    }
     Write-Host "  ─────────────────────────────────────────────" -ForegroundColor Green
     Write-Host ""
 

--- a/scripts/start-vsc-release.ps1
+++ b/scripts/start-vsc-release.ps1
@@ -182,19 +182,19 @@ try {
 
     # 6. Confirm with user
     Write-Host ""
-    Write-Host "  ┌─────────────────────────────────────────────┐" -ForegroundColor White
-    Write-Host "  │  VSC Extension Release Plan                  │" -ForegroundColor White
-    Write-Host "  │                                             │" -ForegroundColor White
-    Write-Host "  │  Release version : $releaseVersion$((' ' * (25 - $releaseVersion.Length)))│" -ForegroundColor White
-    Write-Host "  │  Release branch  : $releaseBranch$((' ' * (25 - $releaseBranch.Length)))│" -ForegroundColor White
-    Write-Host "  │  Next dev version: $nextVersion$((' ' * (25 - $nextVersion.Length)))│" -ForegroundColor White
-    Write-Host "  │  Bump branch     : $bumpBranch$((' ' * (25 - $bumpBranch.Length)))│" -ForegroundColor White
-    Write-Host "  │                                             │" -ForegroundColor White
-    Write-Host "  │  Steps:                                     │" -ForegroundColor White
-    Write-Host "  │  1. Create & push '$releaseBranch'$((' ' * (10 - $releaseBranch.Length)))│" -ForegroundColor White
-    Write-Host "  │  2. Bump version to $nextVersion on main$((' ' * (9 - $nextVersion.Length)))│" -ForegroundColor White
-    Write-Host "  │  3. Create PR to merge bump into main       │" -ForegroundColor White
-    Write-Host "  └─────────────────────────────────────────────┘" -ForegroundColor White
+    $pad = { param($s, $w) (' ' * [Math]::Max(0, $w - $s.Length)) }
+    Write-Host "  VSC Extension Release Plan" -ForegroundColor White
+    Write-Host "  ─────────────────────────────────────────────" -ForegroundColor White
+    Write-Host "  Release version : $releaseVersion" -ForegroundColor White
+    Write-Host "  Release branch  : $releaseBranch" -ForegroundColor White
+    Write-Host "  Next dev version: $nextVersion" -ForegroundColor White
+    Write-Host "  Bump branch     : $bumpBranch" -ForegroundColor White
+    Write-Host "" -ForegroundColor White
+    Write-Host "  Steps:" -ForegroundColor White
+    Write-Host "  1. Create & push '$releaseBranch'" -ForegroundColor White
+    Write-Host "  2. Bump version to $nextVersion on main" -ForegroundColor White
+    Write-Host "  3. Create PR to merge bump into main" -ForegroundColor White
+    Write-Host "  ─────────────────────────────────────────────" -ForegroundColor White
 
     Confirm-Step "Does this release plan look correct? Proceed?"
 
@@ -286,17 +286,15 @@ try {
     Invoke-GitOrDryRun -Description "Switch back to main" -Arguments @("checkout", "main")
 
     Write-Host ""
-    Write-Host "╔══════════════════════════════════════════════╗" -ForegroundColor Green
-    Write-Host "║  VSC Extension release started!              ║" -ForegroundColor Green
-    Write-Host "╠══════════════════════════════════════════════╣" -ForegroundColor Green
-    Write-Host "║                                              ║" -ForegroundColor Green
-    Write-Host "║  • Release branch '$releaseBranch' pushed$((' ' * (10 - $releaseBranch.Length)))║" -ForegroundColor Green
-    Write-Host "║  • Version bump PR created for $nextVersion$((' ' * (10 - $nextVersion.Length)))║" -ForegroundColor Green
-    Write-Host "║                                              ║" -ForegroundColor Green
-    Write-Host "║  Next steps:                                 ║" -ForegroundColor Green
-    Write-Host "║  1. Monitor the VSC release pipeline         ║" -ForegroundColor Green
-    Write-Host "║  2. Review & merge the version bump PR       ║" -ForegroundColor Green
-    Write-Host "╚══════════════════════════════════════════════╝" -ForegroundColor Green
+    Write-Host "  VSC Extension release started!" -ForegroundColor Green
+    Write-Host "  ─────────────────────────────────────────────" -ForegroundColor Green
+    Write-Host "  • Release branch '$releaseBranch' pushed" -ForegroundColor Green
+    Write-Host "  • Version bump PR created for $nextVersion" -ForegroundColor Green
+    Write-Host "" -ForegroundColor Green
+    Write-Host "  Next steps:" -ForegroundColor Green
+    Write-Host "  1. Monitor the VSC release pipeline" -ForegroundColor Green
+    Write-Host "  2. Review & merge the version bump PR" -ForegroundColor Green
+    Write-Host "  ─────────────────────────────────────────────" -ForegroundColor Green
     Write-Host ""
 
 } catch {

--- a/src/winapp-VSC/package-lock.json
+++ b/src/winapp-VSC/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "winapp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "winapp",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "glob": "^13.0.6"
       },
@@ -856,6 +856,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -1134,6 +1135,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1669,6 +1671,7 @@
       "integrity": "sha512-uYixubwmqJZH+KLVYIVKY1JQt7tysXhtj21WSvjcSmU5SVNzMus1bgLe+pAt816yQ8opKfheVVoPLqvVMGejYw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3268,6 +3271,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3320,6 +3324,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/winapp-VSC/package.json
+++ b/src/winapp-VSC/package.json
@@ -4,7 +4,7 @@
   "description": "WinApp extension for Visual Studio Code to assist in building, debugging, and packaging Windows applications using the WinAppCLI.",
   "publisher": "Microsoft-WinAppCLI",
   "icon": "images/icon.png",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/WinAppCli.git"


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does and why -->
Bump VSCE to v0.1.1 + fix vsc release script formatting. 

## Usage Example

<!-- If this PR adds or changes commands, flags, or APIs, include a short code snippet -->
<!-- Example:
```bash
winapp store app list
```
-->

## Related Issue

<!-- Link to any related issues: Fixes #123, Closes #456, Related to #789 -->

## Type of Change

<!-- Keep the applicable line(s), delete the rest -->
- 🔧 Config/build

## AI Description

<!-- ai-description-start -->
This pull request updates the VS Code Extension release script to improve formatting and synchronizes the `package-lock.json` with the version updates for the extension. Additionally, it modifies the script to add the new package lock path as a parameter during git operations to ensure consistency in version handling. 

```bash
Invoke-GitOrDryRun -Description "Stage version update" -Arguments @("add", $VscPackageJsonPath, $VscPackageLockPath)
Invoke-GitOrDryRun -Description "Stage version bump" -Arguments @("add", $VscPackageJsonPath, $VscPackageLockPath)
```
<!-- ai-description-end -->
