### PR TITLE
fix(electron): clearer messaging when Electron 42+ binary missing

### DIFF
--- a/docs/guides/electron/setup.md
+++ b/docs/guides/electron/setup.md
@@ -99,16 +99,28 @@ To ensure the Windows SDKs are available when other developers clone your projec
 ```json
 {
   "scripts": {
-    "postinstall": "npx install-electron && winapp restore && winapp node add-electron-debug-identity"
+    "postinstall": "winapp restore && winapp node add-electron-debug-identity"
   }
 }
 ```
 
-This script automatically runs after `npm install` and does three things:
+This script automatically runs after `npm install` and does two things:
 
-1. **`npx install-electron`** - Downloads the Electron binary into `node_modules/electron/dist/`. Required for Electron 42+, which no longer downloads its binary during `npm install` ([release notes](https://github.com/electron/electron/releases/tag/v42.0.0)). On Electron < 42 the binary is already present after `npm install`, so this step is a no-op there — you can omit it if you pin to an older version.
-2. **`winapp restore`** - Downloads and restores all Windows SDK packages to the `.winapp/` folder
-3. **`winapp node add-electron-debug-identity`** - Registers your Electron app with debug identity (more on this in the next steps)
+1. **`winapp restore`** - Downloads and restores all Windows SDK packages to the `.winapp/` folder
+2. **`winapp node add-electron-debug-identity`** - Registers your Electron app with debug identity (more on this in the next steps)
+
+> [!IMPORTANT]
+> **Electron 42 and newer**: As of Electron 42, the binary is no longer downloaded automatically during `npm install` ([release notes](https://github.com/electron/electron/releases/tag/v42.0.0)). You must download it explicitly before `add-electron-debug-identity` runs:
+>
+> ```json
+> {
+>   "scripts": {
+>     "postinstall": "npx --no-install install-electron && winapp restore && winapp node add-electron-debug-identity"
+>   }
+> }
+> ```
+>
+> The `--no-install` flag ensures `npx` only runs the `install-electron` bin shipped by your installed Electron package and never silently downloads anything from the registry. If you pin to Electron < 42, omit this step — the binary is already in place after `npm install`.
 
 Now run `npm install` to trigger the postinstall script and configure the Windows environment:
 
@@ -128,10 +140,28 @@ Create `scripts/postinstall.js`:
 ```javascript
 if (process.platform === 'win32') {
   const { execSync } = require('child_process');
+  const fs = require('fs');
+  const path = require('path');
+
+  // Electron 42+ ships an `install-electron` bin and skips the postinstall download.
+  // Run it only when present, and use `--no-install` so npx never silently fetches
+  // anything from the registry.
+  const installElectronBin = path.join(
+    'node_modules', '.bin',
+    process.platform === 'win32' ? 'install-electron.cmd' : 'install-electron'
+  );
+  const steps = [];
+  if (fs.existsSync(installElectronBin)) {
+    steps.push('npx --no-install install-electron');
+  }
+  steps.push(
+    'npx winapp restore',
+    'npx winapp cert generate --if-exists skip',
+    'npx winapp node add-electron-debug-identity'
+  );
+
   try {
-    execSync('npx install-electron && npx winapp restore && npx winapp cert generate --if-exists skip && npx winapp node add-electron-debug-identity', {
-      stdio: 'inherit'
-    });
+    execSync(steps.join(' && '), { stdio: 'inherit' });
   } catch (error) {
     console.warn('Warning: Windows-specific setup failed. If you are not developing Windows features, you can ignore this.');
   }

--- a/docs/guides/electron/setup.md
+++ b/docs/guides/electron/setup.md
@@ -99,15 +99,16 @@ To ensure the Windows SDKs are available when other developers clone your projec
 ```json
 {
   "scripts": {
-    "postinstall": "winapp restore && winapp node add-electron-debug-identity"
+    "postinstall": "npx install-electron && winapp restore && winapp node add-electron-debug-identity"
   }
 }
 ```
 
-This script automatically runs after `npm install` and does two things:
+This script automatically runs after `npm install` and does three things:
 
-1. **`winapp restore`** - Downloads and restores all Windows SDK packages to the `.winapp/` folder
-2. **`winapp node add-electron-debug-identity`** - Registers your Electron app with debug identity (more on this in the next steps)
+1. **`npx install-electron`** - Downloads the Electron binary into `node_modules/electron/dist/`. Required for Electron 42+, which no longer downloads its binary during `npm install` ([release notes](https://github.com/electron/electron/releases/tag/v42.0.0)). On Electron < 42 the binary is already present after `npm install`, so this step is a no-op there — you can omit it if you pin to an older version.
+2. **`winapp restore`** - Downloads and restores all Windows SDK packages to the `.winapp/` folder
+3. **`winapp node add-electron-debug-identity`** - Registers your Electron app with debug identity (more on this in the next steps)
 
 Now run `npm install` to trigger the postinstall script and configure the Windows environment:
 
@@ -128,7 +129,7 @@ Create `scripts/postinstall.js`:
 if (process.platform === 'win32') {
   const { execSync } = require('child_process');
   try {
-    execSync('npx winapp restore && npx winapp cert generate --if-exists skip && npx winapp node add-electron-debug-identity', {
+    execSync('npx install-electron && npx winapp restore && npx winapp cert generate --if-exists skip && npx winapp node add-electron-debug-identity', {
       stdio: 'inherit'
     });
   } catch (error) {

--- a/samples/electron/test.Tests.ps1
+++ b/samples/electron/test.Tests.ps1
@@ -149,12 +149,13 @@ Describe "Electron Sample" {
         It "Should download the Electron binary" -Skip:$script:skip {
             # Electron 42+ no longer downloads its binary during `npm install` (see issue #524).
             # Trigger the download explicitly so `add-electron-debug-identity` can find electron.exe.
+            # `install-electron` was added in Electron 42; older versions auto-download via
+            # postinstall, so the bin is absent and `npx --no-install` exits non-zero. Either
+            # outcome is fine as long as electron.exe ends up on disk — the Should -Exist below
+            # is the real assertion.
             Push-Location $script:appDir
             try {
-                Invoke-Expression "npx --no-install install-electron 2>&1"
-                # `install-electron` was added in Electron 42; older versions auto-download via
-                # postinstall, in which case the script is absent and npx exits non-zero. Either
-                # outcome is fine as long as electron.exe ends up on disk.
+                & npx --no-install install-electron 2>&1 | ForEach-Object { Write-Host $_ }
                 $exe = Join-Path $script:appDir "node_modules\electron\dist\electron.exe"
                 $exe | Should -Exist
             } finally { Pop-Location }

--- a/samples/electron/test.Tests.ps1
+++ b/samples/electron/test.Tests.ps1
@@ -146,6 +146,20 @@ Describe "Electron Sample" {
             } finally { Pop-Location }
         }
 
+        It "Should download the Electron binary" -Skip:$script:skip {
+            # Electron 42+ no longer downloads its binary during `npm install` (see issue #524).
+            # Trigger the download explicitly so `add-electron-debug-identity` can find electron.exe.
+            Push-Location $script:appDir
+            try {
+                Invoke-Expression "npx --no-install install-electron 2>&1"
+                # `install-electron` was added in Electron 42; older versions auto-download via
+                # postinstall, in which case the script is absent and npx exits non-zero. Either
+                # outcome is fine as long as electron.exe ends up on disk.
+                $exe = Join-Path $script:appDir "node_modules\electron\dist\electron.exe"
+                $exe | Should -Exist
+            } finally { Pop-Location }
+        }
+
         It "Should add Electron debug identity" -Skip:$script:skip {
             Push-Location $script:appDir
             try {

--- a/src/winapp-CLI/WinApp.Cli.Tests/EndToEndTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/EndToEndTests.cs
@@ -582,7 +582,7 @@ public class EndToEndTests : BaseCommandTests
         Assert.AreNotEqual(0, result.ExitCode, "Command should fail when electron.exe does not exist.");
         var combinedOutput = $"{result.Output}\n{result.Error}";
         Assert.IsTrue(
-            combinedOutput.Contains("Electron executable not found at:", StringComparison.OrdinalIgnoreCase),
+            combinedOutput.Contains("Electron is not installed", StringComparison.OrdinalIgnoreCase),
             $"Expected Node-layer electron missing error to be surfaced. Output: {combinedOutput}");
     }
 

--- a/src/winapp-CLI/WinApp.Cli.Tests/EndToEndTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/EndToEndTests.cs
@@ -581,8 +581,12 @@ public class EndToEndTests : BaseCommandTests
         // Assert
         Assert.AreNotEqual(0, result.ExitCode, "Command should fail when electron.exe does not exist.");
         var combinedOutput = $"{result.Output}\n{result.Error}";
+        // Either branch of the new error messaging is acceptable: "Electron is not installed"
+        // (no node_modules/electron) or "binary was not found" (node_modules/electron present
+        // but exe missing, e.g. Electron 42+ before `install-electron` runs).
         Assert.IsTrue(
-            combinedOutput.Contains("Electron is not installed", StringComparison.OrdinalIgnoreCase),
+            combinedOutput.Contains("Electron is not installed", StringComparison.OrdinalIgnoreCase)
+                || combinedOutput.Contains("binary was not found", StringComparison.OrdinalIgnoreCase),
             $"Expected Node-layer electron missing error to be surfaced. Output: {combinedOutput}");
     }
 

--- a/src/winapp-npm/src/msix-utils.ts
+++ b/src/winapp-npm/src/msix-utils.ts
@@ -90,7 +90,51 @@ export async function addElectronDebugIdentity(
     const electronPackageJsonPath = path.join(process.cwd(), 'node_modules', 'electron', 'package.json');
 
     if (!fsSync.existsSync(electronExePath)) {
-      throw new Error(`Electron executable not found at: ${electronExePath}`);
+      const electronDir = path.join(process.cwd(), 'node_modules', 'electron');
+      if (!fsSync.existsSync(electronDir)) {
+        throw new Error(
+          `Electron is not installed in this project. Expected to find it at:\n` +
+            `  ${electronDir}\n\n` +
+            `Run \`npm install\` from your project root, then re-run this command.`
+        );
+      }
+
+      // node_modules/electron exists but the binary is missing. As of Electron 42
+      // (released 2026-05-06), the postinstall step that downloaded the binary was
+      // removed for supply-chain hardening. The binary is now downloaded lazily on
+      // first launch, or on demand via the new `install-electron` script.
+      let installedVersion: string | undefined;
+      if (fsSync.existsSync(electronPackageJsonPath)) {
+        try {
+          installedVersion = JSON.parse(fsSync.readFileSync(electronPackageJsonPath, 'utf-8')).version as
+            | string
+            | undefined;
+        } catch {
+          // Ignore errors reading package.json
+        }
+      }
+      const major = installedVersion ? parseInt(installedVersion.split('.')[0], 10) : NaN;
+      const versionLabel = installedVersion ? ` (v${installedVersion})` : '';
+
+      if (!Number.isNaN(major) && major >= 42) {
+        throw new Error(
+          `Electron${versionLabel} is installed, but its binary was not found at:\n` +
+            `  ${electronExePath}\n\n` +
+            `Starting with Electron 42, the binary is no longer downloaded automatically ` +
+            `during \`npm install\`. Download it once with:\n\n` +
+            `  npx install-electron\n\n` +
+            `Then re-run \`winapp node add-electron-debug-identity\`. ` +
+            `If you use a postinstall script, add \`npx install-electron\` before this command. ` +
+            `See https://github.com/electron/electron/releases/tag/v42.0.0 for details.`
+        );
+      }
+
+      throw new Error(
+        `Electron${versionLabel} is installed, but its binary was not found at:\n` +
+          `  ${electronExePath}\n\n` +
+          `Try reinstalling Electron with \`npm install electron --force\`, ` +
+          `or run \`npx install-electron\` to download the binary on demand.`
+      );
     }
 
     // Get current Electron version from package.json


### PR DESCRIPTION
Fixes #524.

Electron **42.0.0** (released 2026-05-06) removed the postinstall step that downloaded its binary into `node_modules/electron/dist/` (supply-chain hardening). The binary is now downloaded lazily on first launch, or explicitly via the new `install-electron` script. Our `add-electron-debug-identity` command was throwing a terse `Electron executable not found at: <path>` and leaving users with no path forward — and breaking the `electron` sample test on every PR.

We deliberately do **not** auto-download the binary from our SDK (keeps us out of Electron's install business and avoids surprising network calls). Instead, we surface clear, actionable messages.

### Changes

- **`src/winapp-npm/src/msix-utils.ts`** — replace the terse error with three case-specific messages:
  - `node_modules/electron` missing → `Electron is not installed in this project. ... Run 
pm install ...`
  - Electron ≥ 42 installed, exe missing → explains the postinstall change and instructs to run `npx install-electron`, with a link to the v42 release notes
  - Other case → reinstall hint
- **`samples/electron/test.Tests.ps1`** — add a `Should download the Electron binary` step that runs `npx --no-install install-electron` before `add-electron-debug-identity`. Unblocks the Phase 1 from-scratch flow that pulls `electron@latest` via `create-electron-app@latest`.
- **`docs/guides/electron/setup.md`** — update the recommended postinstall scripts (both the simple JSON snippet and the cross-platform `scripts/postinstall.js` variant) to include `npx install-electron` for Electron 42+.
- **`src/winapp-CLI/WinApp.Cli.Tests/EndToEndTests.cs`** — update the assertion to match the new `Electron is not installed` substring.

`samples/electron/package.json` is pinned to `electron@39.8.5` and the old auto-download flow still works there, so Phase 2 of the sample test is unchanged.

### Verification

- `npm run format:check && npm run lint && npm run compile` clean.
- `scripts/build-cli.ps1 -SkipTests -SkipMsix` succeeds end-to-end (CLI, npm, VSIX, NuGet).
- Smoke-tested all four error-message branches by stubbing `node_modules/electron` with each scenario:

  | Scenario | Output (excerpt) |
  | --- | --- |
  | No `node_modules/electron` | `Electron is not installed in this project. ... Run \`npm install\` ...` |
  | Electron 42 installed, exe missing | `Electron (v42.0.0) is installed, but its binary was not found ... Starting with Electron 42 ... npx install-electron` |
  | Electron 39 installed, exe missing | `Electron (v39.8.5) is installed, but its binary was not found ... Try reinstalling ...` |
  | `electron` dir present, no package.json | falls through to legacy reinstall hint without a version label |

Real test of the end-to-end fix will land via this PR's own `test-samples` workflow run.