### PR TITLE
Auto-update auto-merge PRs when main is pushed

### DIFF
--- a/.github/workflows/auto-update-prs.yml
+++ b/.github/workflows/auto-update-prs.yml
@@ -34,14 +34,20 @@ jobs:
           set -euo pipefail
 
           # List open PRs targeting main that have auto-merge enabled. Skip
-          # drafts and PRs from forks (update-branch can't push to fork
-          # branches with GITHUB_TOKEN).
+          # drafts and PRs whose head branch lives in a different repository
+          # (forks, sibling repos), since update-branch can't push to those
+          # with GITHUB_TOKEN. Match the full nameWithOwner so a same-org
+          # fork or sibling repo isn't mistaken for the canonical repo.
           prs=$(gh pr list \
             --base main \
             --state open \
-            --limit 200 \
-            --json number,isDraft,headRepositoryOwner,autoMergeRequest \
-            --jq '.[] | select(.isDraft == false) | select(.autoMergeRequest != null) | select(.headRepositoryOwner.login == "${{ github.repository_owner }}") | .number')
+            --limit 500 \
+            --json number,isDraft,headRepository,headRepositoryOwner,autoMergeRequest \
+            --jq ".[]
+                  | select(.isDraft == false)
+                  | select(.autoMergeRequest != null)
+                  | select((.headRepositoryOwner.login + \"/\" + .headRepository.name) == \"${GH_REPO}\")
+                  | .number")
 
           if [ -z "$prs" ]; then
             echo "No auto-merge-enabled PRs to update."
@@ -51,14 +57,26 @@ jobs:
           for pr in $prs; do
             echo "::group::PR #$pr"
             # 202 = update queued, 422 = already up to date or has conflicts.
-            # We tolerate 422 so one stuck PR doesn't fail the whole job.
-            if gh api \
+            # We tolerate 422 so one stuck PR doesn't fail the whole job, but
+            # any other non-success status (auth, rate limit, outage) fails
+            # loudly so regressions don't silently no-op the workflow.
+            set +e
+            output=$(gh api \
                 --method PUT \
                 -H "Accept: application/vnd.github+json" \
-                "/repos/${GH_REPO}/pulls/${pr}/update-branch"; then
+                "/repos/${GH_REPO}/pulls/${pr}/update-branch" 2>&1)
+            exit_code=$?
+            set -e
+
+            if [ $exit_code -eq 0 ]; then
               echo "Update queued for PR #$pr"
+            elif echo "$output" | grep -q "HTTP 422"; then
+              echo "Skipped PR #$pr (HTTP 422: already up to date, has conflicts, or not updatable)"
             else
-              echo "Skipped PR #$pr (already up to date, has conflicts, or not updatable)"
+              echo "::error::Unexpected failure updating PR #$pr"
+              echo "$output"
+              echo "::endgroup::"
+              exit 1
             fi
             echo "::endgroup::"
           done

--- a/.github/workflows/auto-update-prs.yml
+++ b/.github/workflows/auto-update-prs.yml
@@ -1,0 +1,64 @@
+name: Auto-update PRs
+
+# When commits land on main, update every open PR targeting main that has
+# auto-merge enabled, so the branch is current with main. This lets GitHub
+# auto-merge actually fire instead of waiting for someone to click
+# "Update branch".
+#
+# Uses the "Update pull request branch" API:
+#   PUT /repos/{owner}/{repo}/pulls/{pull_number}/update-branch
+# This honors the repo's merge-queue / merge method settings (merge or rebase).
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: auto-update-prs-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update auto-merge-enabled PRs targeting main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # List open PRs targeting main that have auto-merge enabled. Skip
+          # drafts and PRs from forks (update-branch can't push to fork
+          # branches with GITHUB_TOKEN).
+          prs=$(gh pr list \
+            --base main \
+            --state open \
+            --limit 200 \
+            --json number,isDraft,headRepositoryOwner,autoMergeRequest \
+            --jq '.[] | select(.isDraft == false) | select(.autoMergeRequest != null) | select(.headRepositoryOwner.login == "${{ github.repository_owner }}") | .number')
+
+          if [ -z "$prs" ]; then
+            echo "No auto-merge-enabled PRs to update."
+            exit 0
+          fi
+
+          for pr in $prs; do
+            echo "::group::PR #$pr"
+            # 202 = update queued, 422 = already up to date or has conflicts.
+            # We tolerate 422 so one stuck PR doesn't fail the whole job.
+            if gh api \
+                --method PUT \
+                -H "Accept: application/vnd.github+json" \
+                "/repos/${GH_REPO}/pulls/${pr}/update-branch"; then
+              echo "Update queued for PR #$pr"
+            else
+              echo "Skipped PR #$pr (already up to date, has conflicts, or not updatable)"
+            fi
+            echo "::endgroup::"
+          done


### PR DESCRIPTION
## Problem

When multiple PRs are queued behind each other, GitHub's auto-merge waits for each PR's branch to be up-to-date with main before merging. Today that requires someone to click `Update branch` on every PR after each merge, which is tedious and the checks take a long time.

## Fix

Add `.github/workflows/auto-update-prs.yml` which triggers on every push to `main` and:

1. Lists all open, non-draft PRs targeting main that have **auto-merge enabled** (and aren't from forks - `GITHUB_TOKEN` can't push to fork branches).
2. Calls the GitHub `PUT /repos/{owner}/{repo}/pulls/{pull_number}/update-branch` API on each one - the same thing the green `Update branch` button does. It honors the repo's configured merge method (merge or rebase).

Result: PRs with auto-merge enabled stay current with main automatically, and the auto-merge queue can flow without manual intervention.

## Notes

- Uses the built-in `GITHUB_TOKEN`; no PAT or secrets needed.
- 422 responses (already up-to-date / conflicts) are tolerated so one stuck PR doesn't fail the run.
- `concurrency` is configured with `cancel-in-progress: false` so rapid pushes to main don't cancel an in-flight update batch.
- Only auto-merge-enabled PRs are touched, so this won't spam CI on draft / WIP branches.