### PR TITLE
[Plugin] Backfilling content from Awesome Copilot SKILLS doc

### DIFF
--- a/.github/plugin/skills/winapp-cli/troubleshoot/SKILL.md
+++ b/.github/plugin/skills/winapp-cli/troubleshoot/SKILL.md
@@ -24,6 +24,8 @@ Use this skill when:
 | "Failed to add package identity" | Stale debug identity or untrusted cert | `Get-AppxPackage *yourapp* \| Remove-AppxPackage` to clean up, then `winapp cert install` and retry |
 | "Certificate file already exists" | `devcert.pfx` already present | Use `winapp cert generate --if-exists overwrite` or `--if-exists skip` |
 | "Manifest already exists" | `Package.appxmanifest` already present | Use `winapp manifest generate --if-exists overwrite` or edit manifest directly |
+| `run` / `create-debug-identity` registration error `0x800704EC` | Developer Mode is disabled | Enable it in **Settings → Privacy & security → For developers**, or `Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock' -Name AllowDevelopmentWithoutDevLicense -Value 1`, then retry |
+| `run` / `create-debug-identity` registration error `0x80073CFB` | Package already registered with a conflicting identity | Run `winapp unregister` (or `winapp unregister --force` if the package was registered from a different project tree), then retry |
 
 ## Command selection guide
 

--- a/.github/plugin/skills/winapp-cli/ui-automation/SKILL.md
+++ b/.github/plugin/skills/winapp-cli/ui-automation/SKILL.md
@@ -174,6 +174,17 @@ winapp ui invoke btn-open-e6f7 -w <dialog-hwnd>
 ```
 Note: The filename input in standard file dialogs typically has AutomationId `1148`. Use `inspect -w <dialog-hwnd> --interactive` to discover the actual slugs.
 
+## JSON output envelopes (v0.3.1+)
+
+The `--json` envelope for `ui inspect`, `ui get-focused`, `ui search`, and `ui wait-for` was reshaped in v0.3.1. Pre-0.3.1 parsers will silently break — most fields were renamed, removed, or moved into envelopes. Highlights:
+
+- `ui inspect --json` now nests elements under `windows[].elements[]` (was a flat `elements[]`).
+- `ui get-focused --json` always emits an envelope — `{ "hasFocus": false }` or `{ "hasFocus": true, "element": {...} }` (was bare `null`).
+- `ui search --json` / `ui wait-for --json` may include an `invokableAncestor` field (element-shaped) on each match.
+- Per-element `id`, `parentSelector`, and `windowHandle` are **removed** — use `selector` as the public handle.
+
+Full schemas with examples: [`references/ui-json-envelope.md`](./references/ui-json-envelope.md).
+
 ## Related skills
 - `winapp-setup` for adding Windows SDK to your project
 - `winapp-package` for packaging apps as MSIX

--- a/.github/plugin/skills/winapp-cli/ui-automation/SKILL.md
+++ b/.github/plugin/skills/winapp-cli/ui-automation/SKILL.md
@@ -309,7 +309,8 @@ Capture the target window or element as a PNG image. When multiple windows exist
 | Option | Description | Default |
 |--------|-------------|---------|
 | `--app` | Target app (process name, window title, or PID). Lists windows if ambiguous. | (none) |
-| `--capture-screen` | Capture from screen (includes popups/overlays) instead of window rendering. Brings window to foreground first. | (none) |
+| `--capture-screen` | Capture from screen DC via BitBlt (includes popups/overlays not owned by the target). Implies --focus. | (none) |
+| `--focus` | Bring the target window to the foreground before capture. Already implied by --capture-screen. | (none) |
 | `--json` | Format output as JSON | (none) |
 | `--output` | Save output to file path (e.g., screenshot) | (none) |
 | `--window` | Target window by HWND (stable handle from list output). Takes precedence over --app. | (none) |

--- a/.github/plugin/skills/winapp-cli/ui-automation/SKILL.md
+++ b/.github/plugin/skills/winapp-cli/ui-automation/SKILL.md
@@ -309,8 +309,7 @@ Capture the target window or element as a PNG image. When multiple windows exist
 | Option | Description | Default |
 |--------|-------------|---------|
 | `--app` | Target app (process name, window title, or PID). Lists windows if ambiguous. | (none) |
-| `--capture-screen` | Capture from screen DC via BitBlt (includes popups/overlays not owned by the target). Implies --focus. | (none) |
-| `--focus` | Bring the target window to the foreground before capture. Already implied by --capture-screen. | (none) |
+| `--capture-screen` | Capture from screen (includes popups/overlays) instead of window rendering. Brings window to foreground first. | (none) |
 | `--json` | Format output as JSON | (none) |
 | `--output` | Save output to file path (e.g., screenshot) | (none) |
 | `--window` | Target window by HWND (stable handle from list output). Takes precedence over --app. | (none) |

--- a/.github/plugin/skills/winapp-cli/ui-automation/references/ui-json-envelope.md
+++ b/.github/plugin/skills/winapp-cli/ui-automation/references/ui-json-envelope.md
@@ -1,0 +1,87 @@
+# `winapp ui --json` envelope (v0.3.1+)
+
+The `--json` output for the `winapp ui` command group was reshaped in v0.3.1.
+Generate parsers against these shapes — pre-0.3.1 parsers will silently break
+because most fields were renamed, removed, or moved into envelopes.
+
+## `ui inspect --json`
+
+Top-level shape (elements are now nested under `windows[]`, not flat):
+
+```json
+{
+  "depth": 0,
+  "interactive": false,
+  "hideDisabled": false,
+  "hideOffscreen": false,
+  "windows": [
+    {
+      "hwnd": "0x...",
+      "title": "...",
+      "className": "...",
+      "elementCount": 0,
+      "elements": [
+        {
+          "selector": "...",
+          "name": "...",
+          "controlType": "...",
+          "children": [ ... ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+Pre-0.3.1 the shape was `{ "elements": [...] }`. Per-element `id`, `depth`,
+`parentSelector`, and `windowHandle` fields have been **removed** — `selector`
+is the public handle.
+
+## `ui inspect --ancestors --json`
+
+Ancestors are now nested as a parent → child chain keyed by `Depth=i`
+(previously emitted as sibling roots).
+
+## `ui inspect --interactive`
+
+Non-interactive ancestors are collapsed and surfaced as `ancestorPath` on
+surviving descendants. `+more` markers indicate truncated subtrees in both
+text and JSON modes.
+
+## `ui get-focused --json`
+
+Always emits an envelope (never a bare value):
+
+- No focus: `{ "hasFocus": false }`
+- With focus: `{ "hasFocus": true, "element": { ... } }`
+
+Pre-0.3.1 emitted bare `null` when nothing was focused.
+
+## `ui search --json` / `ui wait-for --json`
+
+Both commands return matching elements using the same element shape as
+`ui inspect` (so `selector`, `name`, `controlType`, `children`, etc.).
+Each match may also include an `invokableAncestor` field — itself an
+element-shaped object — pointing to the nearest parent that supports
+`InvokePattern` (useful when a search hits a non-invokable element
+like a label inside a button).
+
+```json
+[
+  {
+    "selector": "btn-save-c3d4",
+    "name": "Save",
+    "controlType": "Button",
+    "children": [ ... ],
+    "invokableAncestor": {
+      "selector": "btn-save-c3d4",
+      "name": "Save",
+      "controlType": "Button"
+    }
+  }
+]
+```
+
+The internal `id`, `parentSelector`, and `windowHandle` fields are
+**scrubbed** from results — both at the top level and inside any nested
+`invokableAncestor`. Don't depend on them; use `selector` as the handle.

--- a/.github/plugin/skills/winapp-cli/ui-automation/references/ui-json-envelope.md
+++ b/.github/plugin/skills/winapp-cli/ui-automation/references/ui-json-envelope.md
@@ -69,13 +69,13 @@ like a label inside a button).
 ```json
 [
   {
-    "selector": "btn-save-c3d4",
+    "selector": "txt-save-label-a1b2",
     "name": "Save",
-    "controlType": "Button",
+    "controlType": "Text",
     "children": [ ... ],
     "invokableAncestor": {
       "selector": "btn-save-c3d4",
-      "name": "Save",
+      "name": "Save button",
       "controlType": "Button"
     }
   }

--- a/.github/plugin/skills/winapp-cli/ui-automation/references/ui-json-envelope.md
+++ b/.github/plugin/skills/winapp-cli/ui-automation/references/ui-json-envelope.md
@@ -33,9 +33,9 @@ Top-level shape (elements are now nested under `windows[]`, not flat):
 }
 ```
 
-Pre-0.3.1 the shape was `{ "elements": [...] }`. Per-element `id`, `depth`,
-`parentSelector`, and `windowHandle` fields have been **removed** — `selector`
-is the public handle.
+Pre-0.3.1 the shape was `{ "elements": [...] }`. Per-element `id`,
+`parentSelector`, and `windowHandle` fields have been **removed** —
+`selector` is the public handle.
 
 ## `ui inspect --ancestors --json`
 

--- a/docs/cli-schema.json
+++ b/docs/cli-schema.json
@@ -2535,20 +2535,7 @@
               "recursive": false
             },
             "--capture-screen": {
-              "description": "Capture from screen DC via BitBlt (includes popups/overlays not owned by the target). Implies --focus.",
-              "hidden": false,
-              "valueType": "System.Boolean",
-              "hasDefaultValue": true,
-              "defaultValue": false,
-              "arity": {
-                "minimum": 0,
-                "maximum": 1
-              },
-              "required": false,
-              "recursive": false
-            },
-            "--focus": {
-              "description": "Bring the target window to the foreground before capture. Already implied by --capture-screen.",
+              "description": "Capture from screen (includes popups/overlays) instead of window rendering. Brings window to foreground first.",
               "hidden": false,
               "valueType": "System.Boolean",
               "hasDefaultValue": true,

--- a/docs/cli-schema.json
+++ b/docs/cli-schema.json
@@ -2535,7 +2535,20 @@
               "recursive": false
             },
             "--capture-screen": {
-              "description": "Capture from screen (includes popups/overlays) instead of window rendering. Brings window to foreground first.",
+              "description": "Capture from screen DC via BitBlt (includes popups/overlays not owned by the target). Implies --focus.",
+              "hidden": false,
+              "valueType": "System.Boolean",
+              "hasDefaultValue": true,
+              "defaultValue": false,
+              "arity": {
+                "minimum": 0,
+                "maximum": 1
+              },
+              "required": false,
+              "recursive": false
+            },
+            "--focus": {
+              "description": "Bring the target window to the foreground before capture. Already implied by --capture-screen.",
               "hidden": false,
               "valueType": "System.Boolean",
               "hasDefaultValue": true,

--- a/docs/fragments/skills/winapp-cli/troubleshoot.md
+++ b/docs/fragments/skills/winapp-cli/troubleshoot.md
@@ -19,6 +19,8 @@ Use this skill when:
 | "Failed to add package identity" | Stale debug identity or untrusted cert | `Get-AppxPackage *yourapp* \| Remove-AppxPackage` to clean up, then `winapp cert install` and retry |
 | "Certificate file already exists" | `devcert.pfx` already present | Use `winapp cert generate --if-exists overwrite` or `--if-exists skip` |
 | "Manifest already exists" | `Package.appxmanifest` already present | Use `winapp manifest generate --if-exists overwrite` or edit manifest directly |
+| `run` / `create-debug-identity` registration error `0x800704EC` | Developer Mode is disabled | Enable it in **Settings → Privacy & security → For developers**, or `Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock' -Name AllowDevelopmentWithoutDevLicense -Value 1`, then retry |
+| `run` / `create-debug-identity` registration error `0x80073CFB` | Package already registered with a conflicting identity | Run `winapp unregister` (or `winapp unregister --force` if the package was registered from a different project tree), then retry |
 
 ## Command selection guide
 

--- a/docs/fragments/skills/winapp-cli/ui-automation.md
+++ b/docs/fragments/skills/winapp-cli/ui-automation.md
@@ -178,7 +178,7 @@ The `--json` envelope for `ui inspect`, `ui get-focused`, `ui search`, and `ui w
 - `ui search --json` / `ui wait-for --json` may include an `invokableAncestor` field (element-shaped) on each match.
 - Per-element `id`, `parentSelector`, and `windowHandle` are **removed** — use `selector` as the public handle.
 
-Full schemas with examples: [`references/ui-json-envelope.md`](./references/ui-json-envelope.md).
+Full schemas with examples: `references/ui-json-envelope.md`.
 
 ## Related skills
 - `winapp-setup` for adding Windows SDK to your project

--- a/docs/fragments/skills/winapp-cli/ui-automation.md
+++ b/docs/fragments/skills/winapp-cli/ui-automation.md
@@ -169,6 +169,17 @@ winapp ui invoke btn-open-e6f7 -w <dialog-hwnd>
 ```
 Note: The filename input in standard file dialogs typically has AutomationId `1148`. Use `inspect -w <dialog-hwnd> --interactive` to discover the actual slugs.
 
+## JSON output envelopes (v0.3.1+)
+
+The `--json` envelope for `ui inspect`, `ui get-focused`, `ui search`, and `ui wait-for` was reshaped in v0.3.1. Pre-0.3.1 parsers will silently break — most fields were renamed, removed, or moved into envelopes. Highlights:
+
+- `ui inspect --json` now nests elements under `windows[].elements[]` (was a flat `elements[]`).
+- `ui get-focused --json` always emits an envelope — `{ "hasFocus": false }` or `{ "hasFocus": true, "element": {...} }` (was bare `null`).
+- `ui search --json` / `ui wait-for --json` may include an `invokableAncestor` field (element-shaped) on each match.
+- Per-element `id`, `parentSelector`, and `windowHandle` are **removed** — use `selector` as the public handle.
+
+Full schemas with examples: [`references/ui-json-envelope.md`](./references/ui-json-envelope.md).
+
 ## Related skills
 - `winapp-setup` for adding Windows SDK to your project
 - `winapp-package` for packaging apps as MSIX

--- a/docs/npm-usage.md
+++ b/docs/npm-usage.md
@@ -1,3 +1,4 @@
+<!-- mslearn: true -->
 <!-- AUTO-GENERATED — DO NOT EDIT -->
 <!-- Regenerate with: cd src/winapp-npm && npm run generate-docs -->
 
@@ -335,12 +336,10 @@ function run(options: RunOptions): Promise<WinappResult>
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
 | `inputFolder` | `string` | Yes | Input folder containing the app to run |
-| `appArgs` | `string \| undefined` | No | Arguments to pass to the launched application. Provide after -- (e.g., winapp run . -- --flag value). |
-| `args` | `string \| undefined` | No | Command-line arguments to pass to the application. Alternatively, use -- followed by arguments to avoid escaping (e.g., winapp run . -- --flag value). |
+| `args` | `string \| undefined` | No | Command-line arguments to pass to the application |
 | `clean` | `boolean \| undefined` | No | Remove the existing package's application data (LocalState, settings, etc.) before re-deploying. By default, application data is preserved across re-deployments. |
 | `debugOutput` | `boolean \| undefined` | No | Capture OutputDebugString messages and first-chance exceptions from the launched application. Only one debugger can attach to a process at a time, so other debuggers (Visual Studio, VS Code) cannot be used simultaneously. Use --no-launch instead if you need to attach a different debugger. Cannot be combined with --no-launch or --json. |
 | `detach` | `boolean \| undefined` | No | Launch the application and return immediately without waiting for it to exit. Useful for CI/automation where you need to interact with the app after launch. Prints the PID to stdout (or in JSON with --json). |
-| `executable` | `string \| undefined` | No | Path to the executable relative to the input folder. Use to disambiguate when the manifest contains a $targetnametoken$ placeholder and multiple .exe files are present in the input folder. |
 | `json` | `boolean \| undefined` | No | Format output as JSON |
 | `manifest` | `string \| undefined` | No | Path to the Package.appxmanifest (default: auto-detect from input folder or current directory) |
 | `noLaunch` | `boolean \| undefined` | No | Only create the debug identity and register the package without launching the application |
@@ -597,8 +596,7 @@ function uiScreenshot(options?: UiScreenshotOptions): Promise<WinappResult>
 |----------|------|----------|-------------|
 | `selector` | `string \| undefined` | No | Semantic slug (e.g., btn-minimize-d1a0) or text to search by name/automationId |
 | `app` | `string \| undefined` | No | Target app (process name, window title, or PID). Lists windows if ambiguous. |
-| `captureScreen` | `boolean \| undefined` | No | Capture from screen DC via BitBlt (includes popups/overlays not owned by the target). Implies --focus. |
-| `focus` | `boolean \| undefined` | No | Bring the target window to the foreground before capture. Already implied by --capture-screen. |
+| `captureScreen` | `boolean \| undefined` | No | Capture from screen (includes popups/overlays) instead of window rendering. Brings window to foreground first. |
 | `json` | `boolean \| undefined` | No | Format output as JSON |
 | `output` | `string \| undefined` | No | Save output to file path (e.g., screenshot) |
 | `window` | `number \| undefined` | No | Target window by HWND (stable handle from list output). Takes precedence over --app. |
@@ -1246,12 +1244,10 @@ type ManifestTemplates = "packaged" | "sparse"
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
 | `inputFolder` | `string` | Yes | Input folder containing the app to run |
-| `appArgs` | `string \| undefined` | No | Arguments to pass to the launched application. Provide after -- (e.g., winapp run . -- --flag value). |
-| `args` | `string \| undefined` | No | Command-line arguments to pass to the application. Alternatively, use -- followed by arguments to avoid escaping (e.g., winapp run . -- --flag value). |
+| `args` | `string \| undefined` | No | Command-line arguments to pass to the application |
 | `clean` | `boolean \| undefined` | No | Remove the existing package's application data (LocalState, settings, etc.) before re-deploying. By default, application data is preserved across re-deployments. |
 | `debugOutput` | `boolean \| undefined` | No | Capture OutputDebugString messages and first-chance exceptions from the launched application. Only one debugger can attach to a process at a time, so other debuggers (Visual Studio, VS Code) cannot be used simultaneously. Use --no-launch instead if you need to attach a different debugger. Cannot be combined with --no-launch or --json. |
 | `detach` | `boolean \| undefined` | No | Launch the application and return immediately without waiting for it to exit. Useful for CI/automation where you need to interact with the app after launch. Prints the PID to stdout (or in JSON with --json). |
-| `executable` | `string \| undefined` | No | Path to the executable relative to the input folder. Use to disambiguate when the manifest contains a $targetnametoken$ placeholder and multiple .exe files are present in the input folder. |
 | `json` | `boolean \| undefined` | No | Format output as JSON |
 | `manifest` | `string \| undefined` | No | Path to the Package.appxmanifest (default: auto-detect from input folder or current directory) |
 | `noLaunch` | `boolean \| undefined` | No | Only create the debug identity and register the package without launching the application |
@@ -1400,8 +1396,7 @@ type ManifestTemplates = "packaged" | "sparse"
 |----------|------|----------|-------------|
 | `selector` | `string \| undefined` | No | Semantic slug (e.g., btn-minimize-d1a0) or text to search by name/automationId |
 | `app` | `string \| undefined` | No | Target app (process name, window title, or PID). Lists windows if ambiguous. |
-| `captureScreen` | `boolean \| undefined` | No | Capture from screen DC via BitBlt (includes popups/overlays not owned by the target). Implies --focus. |
-| `focus` | `boolean \| undefined` | No | Bring the target window to the foreground before capture. Already implied by --capture-screen. |
+| `captureScreen` | `boolean \| undefined` | No | Capture from screen (includes popups/overlays) instead of window rendering. Brings window to foreground first. |
 | `json` | `boolean \| undefined` | No | Format output as JSON |
 | `output` | `string \| undefined` | No | Save output to file path (e.g., screenshot) |
 | `window` | `number \| undefined` | No | Target window by HWND (stable handle from list output). Takes precedence over --app. |

--- a/docs/npm-usage.md
+++ b/docs/npm-usage.md
@@ -336,10 +336,12 @@ function run(options: RunOptions): Promise<WinappResult>
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
 | `inputFolder` | `string` | Yes | Input folder containing the app to run |
-| `args` | `string \| undefined` | No | Command-line arguments to pass to the application |
+| `appArgs` | `string \| undefined` | No | Arguments to pass to the launched application. Provide after -- (e.g., winapp run . -- --flag value). |
+| `args` | `string \| undefined` | No | Command-line arguments to pass to the application. Alternatively, use -- followed by arguments to avoid escaping (e.g., winapp run . -- --flag value). |
 | `clean` | `boolean \| undefined` | No | Remove the existing package's application data (LocalState, settings, etc.) before re-deploying. By default, application data is preserved across re-deployments. |
 | `debugOutput` | `boolean \| undefined` | No | Capture OutputDebugString messages and first-chance exceptions from the launched application. Only one debugger can attach to a process at a time, so other debuggers (Visual Studio, VS Code) cannot be used simultaneously. Use --no-launch instead if you need to attach a different debugger. Cannot be combined with --no-launch or --json. |
 | `detach` | `boolean \| undefined` | No | Launch the application and return immediately without waiting for it to exit. Useful for CI/automation where you need to interact with the app after launch. Prints the PID to stdout (or in JSON with --json). |
+| `executable` | `string \| undefined` | No | Path to the executable relative to the input folder. Use to disambiguate when the manifest contains a $targetnametoken$ placeholder and multiple .exe files are present in the input folder. |
 | `json` | `boolean \| undefined` | No | Format output as JSON |
 | `manifest` | `string \| undefined` | No | Path to the Package.appxmanifest (default: auto-detect from input folder or current directory) |
 | `noLaunch` | `boolean \| undefined` | No | Only create the debug identity and register the package without launching the application |
@@ -596,7 +598,8 @@ function uiScreenshot(options?: UiScreenshotOptions): Promise<WinappResult>
 |----------|------|----------|-------------|
 | `selector` | `string \| undefined` | No | Semantic slug (e.g., btn-minimize-d1a0) or text to search by name/automationId |
 | `app` | `string \| undefined` | No | Target app (process name, window title, or PID). Lists windows if ambiguous. |
-| `captureScreen` | `boolean \| undefined` | No | Capture from screen (includes popups/overlays) instead of window rendering. Brings window to foreground first. |
+| `captureScreen` | `boolean \| undefined` | No | Capture from screen DC via BitBlt (includes popups/overlays not owned by the target). Implies --focus. |
+| `focus` | `boolean \| undefined` | No | Bring the target window to the foreground before capture. Already implied by --capture-screen. |
 | `json` | `boolean \| undefined` | No | Format output as JSON |
 | `output` | `string \| undefined` | No | Save output to file path (e.g., screenshot) |
 | `window` | `number \| undefined` | No | Target window by HWND (stable handle from list output). Takes precedence over --app. |
@@ -1244,10 +1247,12 @@ type ManifestTemplates = "packaged" | "sparse"
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
 | `inputFolder` | `string` | Yes | Input folder containing the app to run |
-| `args` | `string \| undefined` | No | Command-line arguments to pass to the application |
+| `appArgs` | `string \| undefined` | No | Arguments to pass to the launched application. Provide after -- (e.g., winapp run . -- --flag value). |
+| `args` | `string \| undefined` | No | Command-line arguments to pass to the application. Alternatively, use -- followed by arguments to avoid escaping (e.g., winapp run . -- --flag value). |
 | `clean` | `boolean \| undefined` | No | Remove the existing package's application data (LocalState, settings, etc.) before re-deploying. By default, application data is preserved across re-deployments. |
 | `debugOutput` | `boolean \| undefined` | No | Capture OutputDebugString messages and first-chance exceptions from the launched application. Only one debugger can attach to a process at a time, so other debuggers (Visual Studio, VS Code) cannot be used simultaneously. Use --no-launch instead if you need to attach a different debugger. Cannot be combined with --no-launch or --json. |
 | `detach` | `boolean \| undefined` | No | Launch the application and return immediately without waiting for it to exit. Useful for CI/automation where you need to interact with the app after launch. Prints the PID to stdout (or in JSON with --json). |
+| `executable` | `string \| undefined` | No | Path to the executable relative to the input folder. Use to disambiguate when the manifest contains a $targetnametoken$ placeholder and multiple .exe files are present in the input folder. |
 | `json` | `boolean \| undefined` | No | Format output as JSON |
 | `manifest` | `string \| undefined` | No | Path to the Package.appxmanifest (default: auto-detect from input folder or current directory) |
 | `noLaunch` | `boolean \| undefined` | No | Only create the debug identity and register the package without launching the application |
@@ -1396,7 +1401,8 @@ type ManifestTemplates = "packaged" | "sparse"
 |----------|------|----------|-------------|
 | `selector` | `string \| undefined` | No | Semantic slug (e.g., btn-minimize-d1a0) or text to search by name/automationId |
 | `app` | `string \| undefined` | No | Target app (process name, window title, or PID). Lists windows if ambiguous. |
-| `captureScreen` | `boolean \| undefined` | No | Capture from screen (includes popups/overlays) instead of window rendering. Brings window to foreground first. |
+| `captureScreen` | `boolean \| undefined` | No | Capture from screen DC via BitBlt (includes popups/overlays not owned by the target). Implies --focus. |
+| `focus` | `boolean \| undefined` | No | Bring the target window to the foreground before capture. Already implied by --capture-screen. |
 | `json` | `boolean \| undefined` | No | Format output as JSON |
 | `output` | `string \| undefined` | No | Save output to file path (e.g., screenshot) |
 | `window` | `number \| undefined` | No | Target window by HWND (stable handle from list output). Takes precedence over --app. |

--- a/docs/npm-usage.md
+++ b/docs/npm-usage.md
@@ -1,4 +1,3 @@
-<!-- mslearn: true -->
 <!-- AUTO-GENERATED — DO NOT EDIT -->
 <!-- Regenerate with: cd src/winapp-npm && npm run generate-docs -->
 
@@ -336,10 +335,12 @@ function run(options: RunOptions): Promise<WinappResult>
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
 | `inputFolder` | `string` | Yes | Input folder containing the app to run |
-| `args` | `string \| undefined` | No | Command-line arguments to pass to the application |
+| `appArgs` | `string \| undefined` | No | Arguments to pass to the launched application. Provide after -- (e.g., winapp run . -- --flag value). |
+| `args` | `string \| undefined` | No | Command-line arguments to pass to the application. Alternatively, use -- followed by arguments to avoid escaping (e.g., winapp run . -- --flag value). |
 | `clean` | `boolean \| undefined` | No | Remove the existing package's application data (LocalState, settings, etc.) before re-deploying. By default, application data is preserved across re-deployments. |
 | `debugOutput` | `boolean \| undefined` | No | Capture OutputDebugString messages and first-chance exceptions from the launched application. Only one debugger can attach to a process at a time, so other debuggers (Visual Studio, VS Code) cannot be used simultaneously. Use --no-launch instead if you need to attach a different debugger. Cannot be combined with --no-launch or --json. |
 | `detach` | `boolean \| undefined` | No | Launch the application and return immediately without waiting for it to exit. Useful for CI/automation where you need to interact with the app after launch. Prints the PID to stdout (or in JSON with --json). |
+| `executable` | `string \| undefined` | No | Path to the executable relative to the input folder. Use to disambiguate when the manifest contains a $targetnametoken$ placeholder and multiple .exe files are present in the input folder. |
 | `json` | `boolean \| undefined` | No | Format output as JSON |
 | `manifest` | `string \| undefined` | No | Path to the Package.appxmanifest (default: auto-detect from input folder or current directory) |
 | `noLaunch` | `boolean \| undefined` | No | Only create the debug identity and register the package without launching the application |
@@ -596,7 +597,8 @@ function uiScreenshot(options?: UiScreenshotOptions): Promise<WinappResult>
 |----------|------|----------|-------------|
 | `selector` | `string \| undefined` | No | Semantic slug (e.g., btn-minimize-d1a0) or text to search by name/automationId |
 | `app` | `string \| undefined` | No | Target app (process name, window title, or PID). Lists windows if ambiguous. |
-| `captureScreen` | `boolean \| undefined` | No | Capture from screen (includes popups/overlays) instead of window rendering. Brings window to foreground first. |
+| `captureScreen` | `boolean \| undefined` | No | Capture from screen DC via BitBlt (includes popups/overlays not owned by the target). Implies --focus. |
+| `focus` | `boolean \| undefined` | No | Bring the target window to the foreground before capture. Already implied by --capture-screen. |
 | `json` | `boolean \| undefined` | No | Format output as JSON |
 | `output` | `string \| undefined` | No | Save output to file path (e.g., screenshot) |
 | `window` | `number \| undefined` | No | Target window by HWND (stable handle from list output). Takes precedence over --app. |
@@ -1244,10 +1246,12 @@ type ManifestTemplates = "packaged" | "sparse"
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
 | `inputFolder` | `string` | Yes | Input folder containing the app to run |
-| `args` | `string \| undefined` | No | Command-line arguments to pass to the application |
+| `appArgs` | `string \| undefined` | No | Arguments to pass to the launched application. Provide after -- (e.g., winapp run . -- --flag value). |
+| `args` | `string \| undefined` | No | Command-line arguments to pass to the application. Alternatively, use -- followed by arguments to avoid escaping (e.g., winapp run . -- --flag value). |
 | `clean` | `boolean \| undefined` | No | Remove the existing package's application data (LocalState, settings, etc.) before re-deploying. By default, application data is preserved across re-deployments. |
 | `debugOutput` | `boolean \| undefined` | No | Capture OutputDebugString messages and first-chance exceptions from the launched application. Only one debugger can attach to a process at a time, so other debuggers (Visual Studio, VS Code) cannot be used simultaneously. Use --no-launch instead if you need to attach a different debugger. Cannot be combined with --no-launch or --json. |
 | `detach` | `boolean \| undefined` | No | Launch the application and return immediately without waiting for it to exit. Useful for CI/automation where you need to interact with the app after launch. Prints the PID to stdout (or in JSON with --json). |
+| `executable` | `string \| undefined` | No | Path to the executable relative to the input folder. Use to disambiguate when the manifest contains a $targetnametoken$ placeholder and multiple .exe files are present in the input folder. |
 | `json` | `boolean \| undefined` | No | Format output as JSON |
 | `manifest` | `string \| undefined` | No | Path to the Package.appxmanifest (default: auto-detect from input folder or current directory) |
 | `noLaunch` | `boolean \| undefined` | No | Only create the debug identity and register the package without launching the application |
@@ -1396,7 +1400,8 @@ type ManifestTemplates = "packaged" | "sparse"
 |----------|------|----------|-------------|
 | `selector` | `string \| undefined` | No | Semantic slug (e.g., btn-minimize-d1a0) or text to search by name/automationId |
 | `app` | `string \| undefined` | No | Target app (process name, window title, or PID). Lists windows if ambiguous. |
-| `captureScreen` | `boolean \| undefined` | No | Capture from screen (includes popups/overlays) instead of window rendering. Brings window to foreground first. |
+| `captureScreen` | `boolean \| undefined` | No | Capture from screen DC via BitBlt (includes popups/overlays not owned by the target). Implies --focus. |
+| `focus` | `boolean \| undefined` | No | Bring the target window to the foreground before capture. Already implied by --capture-screen. |
 | `json` | `boolean \| undefined` | No | Format output as JSON |
 | `output` | `string \| undefined` | No | Save output to file path (e.g., screenshot) |
 | `window` | `number \| undefined` | No | Target window by HWND (stable handle from list output). Takes precedence over --app. |

--- a/src/winapp-npm/scripts/generate-docs.mjs
+++ b/src/winapp-npm/scripts/generate-docs.mjs
@@ -325,7 +325,9 @@ function generate() {
   const lines = [];
   const L = (s = '') => lines.push(s);
 
-  L('<!-- mslearn: true -->');
+  L('---');
+  L('ms.custom: mslearn');
+  L('---');
   L('<!-- AUTO-GENERATED — DO NOT EDIT -->');
   L('<!-- Regenerate with: cd src/winapp-npm && npm run generate-docs -->');
   L();

--- a/src/winapp-npm/scripts/generate-docs.mjs
+++ b/src/winapp-npm/scripts/generate-docs.mjs
@@ -325,6 +325,7 @@ function generate() {
   const lines = [];
   const L = (s = '') => lines.push(s);
 
+  L('<!-- mslearn: true -->');
   L('<!-- AUTO-GENERATED — DO NOT EDIT -->');
   L('<!-- Regenerate with: cd src/winapp-npm && npm run generate-docs -->');
   L();


### PR DESCRIPTION
Since we are listing our plugin in Awesome Copilot's marketplace we are removing the standalone SKILL doc that currently exists in that repository. That document had a couple of trouble shooting tips and information of json enveloping with the `ui` command that we did not currently explain in our plugin. This PR backfills that information so that when we go live next, the plugin will be fully up to date.

This PR also contains a change that makes sure one of the auto generated docs that is supposed to be on MS Learn maintains the mslearn indicator after regeneration.