### PR TITLE
Fix error where update notice checked prerelease versions incorrectly and improperly references cached test output

### DIFF
--- a/src/winapp-CLI/WinApp.Cli.Tests/UpdateNotificationGatingTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/UpdateNotificationGatingTests.cs
@@ -23,6 +23,15 @@ public class UpdateNotificationGatingTests
     private string? _savedCaller;
     private string? _savedUpdateCheck;
 
+    // All environment variable names checked by CIEnvironmentDetectorForTelemetry
+    private static readonly string[] CiVarNames =
+    [
+        "CI", "GITHUB_ACTIONS", "TF_BUILD", "APPVEYOR", "TRAVIS", "CIRCLECI",
+        "TEAMCITY_VERSION", "JB_SPACE_API_URL",
+        "CODEBUILD_BUILD_ID", "AWS_REGION", "BUILD_ID", "BUILD_URL", "PROJECT_ID"
+    ];
+    private Dictionary<string, string?> _savedCiVars = [];
+
     [TestInitialize]
     public void Setup()
     {
@@ -38,15 +47,17 @@ public class UpdateNotificationGatingTests
         _savedCacheDir = Environment.GetEnvironmentVariable("WINAPP_CLI_CACHE_DIRECTORY");
         _savedCaller = Environment.GetEnvironmentVariable("WINAPP_CLI_CALLER");
         _savedUpdateCheck = Environment.GetEnvironmentVariable("WINAPP_CLI_UPDATE_CHECK");
+        _savedCiVars = CiVarNames.ToDictionary(name => name, name => Environment.GetEnvironmentVariable(name));
 
         Environment.SetEnvironmentVariable("WINAPP_CLI_CACHE_DIRECTORY", _tempCacheDir);
         Environment.SetEnvironmentVariable("WINAPP_CLI_CALLER", null);
         Environment.SetEnvironmentVariable("WINAPP_CLI_UPDATE_CHECK", null);
 
         // Clear CI vars to avoid suppression
-        Environment.SetEnvironmentVariable("CI", null);
-        Environment.SetEnvironmentVariable("GITHUB_ACTIONS", null);
-        Environment.SetEnvironmentVariable("TF_BUILD", null);
+        foreach (var name in CiVarNames)
+        {
+            Environment.SetEnvironmentVariable(name, null);
+        }
     }
 
     [TestCleanup]
@@ -55,6 +66,10 @@ public class UpdateNotificationGatingTests
         Environment.SetEnvironmentVariable("WINAPP_CLI_CACHE_DIRECTORY", _savedCacheDir);
         Environment.SetEnvironmentVariable("WINAPP_CLI_CALLER", _savedCaller);
         Environment.SetEnvironmentVariable("WINAPP_CLI_UPDATE_CHECK", _savedUpdateCheck);
+        foreach (var (name, value) in _savedCiVars)
+        {
+            Environment.SetEnvironmentVariable(name, value);
+        }
 
         try { Directory.Delete(_tempCacheDir, recursive: true); } catch { /* best effort */ }
     }

--- a/src/winapp-CLI/WinApp.Cli.Tests/UpdateNotificationGatingTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/UpdateNotificationGatingTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Globalization;
+using WinApp.Cli.Services;
 
 namespace WinApp.Cli.Tests;
 
@@ -28,7 +29,7 @@ public class UpdateNotificationGatingTests
         // Create temp cache directory and seed with a "newer" version
         _tempCacheDir = Path.Combine(Path.GetTempPath(), $"winapp_gating_test_{Guid.NewGuid():N}");
         Directory.CreateDirectory(_tempCacheDir);
-        SeedUpdateCheckCache("5.0.0");
+        SeedUpdateCheckCache(GetGuaranteedNewerVersion());
 
         // Create first-run marker so FirstRunService doesn't trigger logging
         File.Create(Path.Combine(_tempCacheDir, ".first-run-complete")).Dispose();
@@ -123,6 +124,14 @@ public class UpdateNotificationGatingTests
     {
         var content = $"{DateTimeOffset.UtcNow.ToString("O", CultureInfo.InvariantCulture)}\n{version}\n";
         File.WriteAllText(Path.Combine(_tempCacheDir, ".update-check"), content);
+    }
+
+    private static string GetGuaranteedNewerVersion()
+    {
+        var currentCore = UpdateNotificationService.GetCoreVersion(WinApp.Cli.Helpers.VersionHelper.GetVersionString());
+        return Version.TryParse(currentCore, out var parsed)
+            ? $"{parsed.Major + 1}.0.0"
+            : "5.0.0";
     }
 
     /// <summary>

--- a/src/winapp-CLI/WinApp.Cli.Tests/UpdateNotificationGatingTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/UpdateNotificationGatingTests.cs
@@ -28,7 +28,7 @@ public class UpdateNotificationGatingTests
         // Create temp cache directory and seed with a "newer" version
         _tempCacheDir = Path.Combine(Path.GetTempPath(), $"winapp_gating_test_{Guid.NewGuid():N}");
         Directory.CreateDirectory(_tempCacheDir);
-        SeedUpdateCheckCache("99.0.0");
+        SeedUpdateCheckCache("5.0.0");
 
         // Create first-run marker so FirstRunService doesn't trigger logging
         File.Create(Path.Combine(_tempCacheDir, ".first-run-complete")).Dispose();

--- a/src/winapp-CLI/WinApp.Cli.Tests/UpdateNotificationServiceTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/UpdateNotificationServiceTests.cs
@@ -27,6 +27,14 @@ public class UpdateNotificationServiceTests : BaseCommandTests
     ];
     private Dictionary<string, string?> _savedCiVars = [];
 
+    private static string GetGuaranteedNewerVersion()
+    {
+        var currentCore = UpdateNotificationService.GetCoreVersion(VersionHelper.GetVersionString());
+        return Version.TryParse(currentCore, out var parsed)
+            ? $"{parsed.Major + 1}.0.0"
+            : "5.0.0";
+    }
+
     [TestInitialize]
     public void Setup()
     {
@@ -34,6 +42,7 @@ public class UpdateNotificationServiceTests : BaseCommandTests
         _concreteService = (UpdateNotificationService)_updateNotificationService;
         // Prevent background HTTP calls during unit tests
         _concreteService.SkipBackgroundRefreshForTesting = true;
+        _concreteService.CurrentVersionProvider = VersionHelper.GetVersionString;
         // Redirect notification output to the test console for assertion capture
         _concreteService.NotificationConsole = TestAnsiConsole;
 
@@ -99,27 +108,30 @@ public class UpdateNotificationServiceTests : BaseCommandTests
     [TestMethod]
     public void CheckAndNotify_CachedNewerVersion_DisplaysNotification()
     {
+        var newerVersion = GetGuaranteedNewerVersion();
+
         // Pre-populate cache with a newer version and stale "shown" date
         var cacheDir = _testCacheDirectory.FullName;
         var cacheFile = Path.Combine(cacheDir, ".update-check");
         Directory.CreateDirectory(cacheDir);
-        File.WriteAllText(cacheFile, $"{DateTime.UtcNow:O}\n5.0.0\n2020-01-01");
+        File.WriteAllText(cacheFile, $"{DateTime.UtcNow:O}\n{newerVersion}\n2020-01-01");
 
         _updateNotificationService.CheckAndNotify();
 
         var output = TestAnsiConsole.Output;
-        Assert.IsTrue(output.Contains("5.0.0"), $"Expected notification with version, got: {output}");
+        Assert.IsTrue(output.Contains(newerVersion), $"Expected notification with version, got: {output}");
         Assert.IsTrue(output.Contains("available"), $"Expected 'available' in notification, got: {output}");
     }
 
     [TestMethod]
     public void CheckAndNotify_CachedNewerVersion_AlreadyShownToday_NoNotification()
     {
+        var newerVersion = GetGuaranteedNewerVersion();
         var today = DateTime.UtcNow.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
         var cacheDir = _testCacheDirectory.FullName;
         var cacheFile = Path.Combine(cacheDir, ".update-check");
         Directory.CreateDirectory(cacheDir);
-        File.WriteAllText(cacheFile, $"{DateTime.UtcNow:O}\n5.0.0\n{today}");
+        File.WriteAllText(cacheFile, $"{DateTime.UtcNow:O}\n{newerVersion}\n{today}");
 
         _updateNotificationService.CheckAndNotify();
 
@@ -159,10 +171,11 @@ public class UpdateNotificationServiceTests : BaseCommandTests
     [TestMethod]
     public void CheckAndNotify_ShowsNotice_UpdatesLastShownDate()
     {
+        var newerVersion = GetGuaranteedNewerVersion();
         var cacheDir = _testCacheDirectory.FullName;
         var cacheFilePath = Path.Combine(cacheDir, ".update-check");
         Directory.CreateDirectory(cacheDir);
-        File.WriteAllText(cacheFilePath, $"{DateTime.UtcNow:O}\n5.0.0\n2020-01-01");
+        File.WriteAllText(cacheFilePath, $"{DateTime.UtcNow:O}\n{newerVersion}\n2020-01-01");
 
         _updateNotificationService.CheckAndNotify();
 
@@ -193,11 +206,12 @@ public class UpdateNotificationServiceTests : BaseCommandTests
     [TestMethod]
     public void CheckAndNotify_NpmCaller_ShowsNpmUpgradeHint()
     {
+        var newerVersion = GetGuaranteedNewerVersion();
         Environment.SetEnvironmentVariable("WINAPP_CLI_CALLER", "npm");
         var cacheDir = _testCacheDirectory.FullName;
         var cacheFile = Path.Combine(cacheDir, ".update-check");
         Directory.CreateDirectory(cacheDir);
-        File.WriteAllText(cacheFile, $"{DateTime.UtcNow:O}\n5.0.0\n2020-01-01");
+        File.WriteAllText(cacheFile, $"{DateTime.UtcNow:O}\n{newerVersion}\n2020-01-01");
 
         _updateNotificationService.CheckAndNotify();
 
@@ -208,11 +222,12 @@ public class UpdateNotificationServiceTests : BaseCommandTests
     [TestMethod]
     public void CheckAndNotify_NodejsPackageCaller_ShowsNpmUpgradeHint()
     {
+        var newerVersion = GetGuaranteedNewerVersion();
         Environment.SetEnvironmentVariable("WINAPP_CLI_CALLER", "nodejs-package");
         var cacheDir = _testCacheDirectory.FullName;
         var cacheFile = Path.Combine(cacheDir, ".update-check");
         Directory.CreateDirectory(cacheDir);
-        File.WriteAllText(cacheFile, $"{DateTime.UtcNow:O}\n5.0.0\n2020-01-01");
+        File.WriteAllText(cacheFile, $"{DateTime.UtcNow:O}\n{newerVersion}\n2020-01-01");
 
         _updateNotificationService.CheckAndNotify();
 
@@ -223,11 +238,12 @@ public class UpdateNotificationServiceTests : BaseCommandTests
     [TestMethod]
     public void CheckAndNotify_NuGetCaller_ShowsNuGetUpgradeHint()
     {
+        var newerVersion = GetGuaranteedNewerVersion();
         Environment.SetEnvironmentVariable("WINAPP_CLI_CALLER", "nuget-package");
         var cacheDir = _testCacheDirectory.FullName;
         var cacheFile = Path.Combine(cacheDir, ".update-check");
         Directory.CreateDirectory(cacheDir);
-        File.WriteAllText(cacheFile, $"{DateTime.UtcNow:O}\n5.0.0\n2020-01-01");
+        File.WriteAllText(cacheFile, $"{DateTime.UtcNow:O}\n{newerVersion}\n2020-01-01");
 
         _updateNotificationService.CheckAndNotify();
 
@@ -238,11 +254,12 @@ public class UpdateNotificationServiceTests : BaseCommandTests
     [TestMethod]
     public void CheckAndNotify_StandaloneExe_ShowsReleasesPageHint()
     {
+        var newerVersion = GetGuaranteedNewerVersion();
         // No WINAPP_CLI_CALLER set, defaults to standalone exe
         var cacheDir = _testCacheDirectory.FullName;
         var cacheFile = Path.Combine(cacheDir, ".update-check");
         Directory.CreateDirectory(cacheDir);
-        File.WriteAllText(cacheFile, $"{DateTime.UtcNow:O}\n5.0.0\n2020-01-01");
+        File.WriteAllText(cacheFile, $"{DateTime.UtcNow:O}\n{newerVersion}\n2020-01-01");
 
         _updateNotificationService.CheckAndNotify();
 
@@ -253,11 +270,12 @@ public class UpdateNotificationServiceTests : BaseCommandTests
     [TestMethod]
     public void CheckAndNotify_OptOutEnvVar_NoNotification()
     {
+        var newerVersion = GetGuaranteedNewerVersion();
         Environment.SetEnvironmentVariable("WINAPP_CLI_UPDATE_CHECK", "0");
         var cacheDir = _testCacheDirectory.FullName;
         var cacheFile = Path.Combine(cacheDir, ".update-check");
         Directory.CreateDirectory(cacheDir);
-        File.WriteAllText(cacheFile, $"{DateTime.UtcNow:O}\n5.0.0\n2020-01-01");
+        File.WriteAllText(cacheFile, $"{DateTime.UtcNow:O}\n{newerVersion}\n2020-01-01");
 
         _updateNotificationService.CheckAndNotify();
 
@@ -268,11 +286,12 @@ public class UpdateNotificationServiceTests : BaseCommandTests
     [TestMethod]
     public void CheckAndNotify_CIEnvironment_NoNotification()
     {
+        var newerVersion = GetGuaranteedNewerVersion();
         Environment.SetEnvironmentVariable("CI", "true");
         var cacheDir = _testCacheDirectory.FullName;
         var cacheFile = Path.Combine(cacheDir, ".update-check");
         Directory.CreateDirectory(cacheDir);
-        File.WriteAllText(cacheFile, $"{DateTime.UtcNow:O}\n5.0.0\n2020-01-01");
+        File.WriteAllText(cacheFile, $"{DateTime.UtcNow:O}\n{newerVersion}\n2020-01-01");
 
         _updateNotificationService.CheckAndNotify();
 
@@ -483,31 +502,85 @@ public class UpdateNotificationServiceTests : BaseCommandTests
     [TestMethod]
     public void IsUnreasonableVersion_NormalVersion_ReturnsFalse()
     {
-        Assert.IsFalse(UpdateNotificationService.IsUnreasonableVersion("5.0.0"));
+        Assert.IsFalse(UpdateNotificationService.IsUnreasonableVersion("5.0.0", "1.0.0"));
     }
 
     [TestMethod]
     public void IsUnreasonableVersion_HighVersion_ReturnsTrue()
     {
-        Assert.IsTrue(UpdateNotificationService.IsUnreasonableVersion("99.0.0"));
+        Assert.IsTrue(UpdateNotificationService.IsUnreasonableVersion("99.0.0", "1.0.0"));
     }
 
     [TestMethod]
     public void IsUnreasonableVersion_TestArtifactVersion_ReturnsTrue()
     {
-        Assert.IsTrue(UpdateNotificationService.IsUnreasonableVersion("999.0.0"));
+        Assert.IsTrue(UpdateNotificationService.IsUnreasonableVersion("999.0.0", "1.0.0"));
     }
 
     [TestMethod]
     public void IsUnreasonableVersion_BoundaryVersion_ReturnsFalse()
     {
-        Assert.IsFalse(UpdateNotificationService.IsUnreasonableVersion("49.0.0"));
+        Assert.IsFalse(UpdateNotificationService.IsUnreasonableVersion("21.0.0", "1.0.0"));
     }
 
     [TestMethod]
-    public void IsUnreasonableVersion_ExactThreshold_ReturnsTrue()
+    public void IsUnreasonableVersion_AboveThreshold_ReturnsTrue()
     {
-        Assert.IsTrue(UpdateNotificationService.IsUnreasonableVersion("50.0.0"));
+        Assert.IsTrue(UpdateNotificationService.IsUnreasonableVersion("22.0.0", "1.0.0"));
+    }
+
+    [TestMethod]
+    public void IsUnreasonableVersion_WithVPrefix_ParsesAndReturnsTrue()
+    {
+        Assert.IsTrue(UpdateNotificationService.IsUnreasonableVersion("v999.0.0", "1.0.0"));
+    }
+
+    [TestMethod]
+    public void CheckAndNotify_CurrentPreRelease_CachedStableSameCore_DisplaysNotification()
+    {
+        _concreteService.CurrentVersionProvider = () => "1.2.0-rc.1";
+        var cacheDir = _testCacheDirectory.FullName;
+        var cacheFile = Path.Combine(cacheDir, ".update-check");
+        Directory.CreateDirectory(cacheDir);
+        File.WriteAllText(cacheFile, $"{DateTime.UtcNow:O}\n1.2.0\n2020-01-01");
+
+        _updateNotificationService.CheckAndNotify();
+
+        var output = TestAnsiConsole.Output;
+        Assert.IsTrue(output.Contains("1.2.0"), $"Expected notification with version, got: {output}");
+        Assert.IsTrue(output.Contains("available"), $"Expected notification for stable release over prerelease, got: {output}");
+    }
+
+    [TestMethod]
+    public void CheckAndNotify_CurrentPreRelease_CachedStableHigherCore_DisplaysNotification()
+    {
+        _concreteService.CurrentVersionProvider = () => "0.3.2-prerelease.73";
+        var cacheDir = _testCacheDirectory.FullName;
+        var cacheFile = Path.Combine(cacheDir, ".update-check");
+        Directory.CreateDirectory(cacheDir);
+        File.WriteAllText(cacheFile, $"{DateTime.UtcNow:O}\n0.4.0\n2020-01-01");
+
+        _updateNotificationService.CheckAndNotify();
+
+        var output = TestAnsiConsole.Output;
+        Assert.IsTrue(output.Contains("0.4.0"), $"Expected notification with version, got: {output}");
+        Assert.IsTrue(output.Contains("available"), $"Expected notification for higher stable version, got: {output}");
+    }
+
+    [TestMethod]
+    public void CheckAndNotify_CurrentPreRelease_CachedStableSameCoreWithBranchLabel_DisplaysNotification()
+    {
+        _concreteService.CurrentVersionProvider = () => "0.3.2-prerelease.73";
+        var cacheDir = _testCacheDirectory.FullName;
+        var cacheFile = Path.Combine(cacheDir, ".update-check");
+        Directory.CreateDirectory(cacheDir);
+        File.WriteAllText(cacheFile, $"{DateTime.UtcNow:O}\n0.3.2\n2020-01-01");
+
+        _updateNotificationService.CheckAndNotify();
+
+        var output = TestAnsiConsole.Output;
+        Assert.IsTrue(output.Contains("0.3.2"), $"Expected notification with version, got: {output}");
+        Assert.IsTrue(output.Contains("available"), $"Expected notification for stable release over prerelease, got: {output}");
     }
 
     [TestMethod]

--- a/src/winapp-CLI/WinApp.Cli.Tests/UpdateNotificationServiceTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/UpdateNotificationServiceTests.cs
@@ -446,42 +446,6 @@ public class UpdateNotificationServiceTests : BaseCommandTests
     }
 
     [TestMethod]
-    public void IsPreReleaseVersion_StableVersion_ReturnsFalse()
-    {
-        Assert.IsFalse(UpdateNotificationService.IsPreReleaseVersion("1.0.0"));
-    }
-
-    [TestMethod]
-    public void IsPreReleaseVersion_PreReleaseVersion_ReturnsTrue()
-    {
-        Assert.IsTrue(UpdateNotificationService.IsPreReleaseVersion("1.0.0-prerelease.73"));
-    }
-
-    [TestMethod]
-    public void IsPreReleaseVersion_BetaVersion_ReturnsTrue()
-    {
-        Assert.IsTrue(UpdateNotificationService.IsPreReleaseVersion("0.3.2-beta.1"));
-    }
-
-    [TestMethod]
-    public void IsPreReleaseVersion_WithBuildMetadata_ReturnsFalse()
-    {
-        Assert.IsFalse(UpdateNotificationService.IsPreReleaseVersion("1.0.0+build123"));
-    }
-
-    [TestMethod]
-    public void IsPreReleaseVersion_PreReleaseWithBuildMetadata_ReturnsTrue()
-    {
-        Assert.IsTrue(UpdateNotificationService.IsPreReleaseVersion("1.0.0-rc.1+build456"));
-    }
-
-    [TestMethod]
-    public void IsPreReleaseVersion_BranchPrereleaseLabel_ReturnsTrue()
-    {
-        Assert.IsTrue(UpdateNotificationService.IsPreReleaseVersion("0.3.2-dev-my-feature.42"));
-    }
-
-    [TestMethod]
     public void GetCoreVersion_StableVersion_ReturnsSame()
     {
         Assert.AreEqual("1.0.0", UpdateNotificationService.GetCoreVersion("1.0.0"));
@@ -596,8 +560,65 @@ public class UpdateNotificationServiceTests : BaseCommandTests
         var output = TestAnsiConsole.Output;
         Assert.IsFalse(output.Contains("available"), $"Should not notify for unreasonable version, got: {output}");
 
-        // Verify the cache was cleaned
+        // Verify the cache was fully cleaned (including LastCheck so refresh triggers immediately)
         var cache = UpdateNotificationService.ReadCache(new FileInfo(cacheFile));
         Assert.AreEqual("", cache.LatestVersion, "Unreasonable version should be cleared from cache");
+        Assert.AreEqual("", cache.LastShownDate, "LastShownDate should be cleared from cache");
+        Assert.IsNull(cache.LastCheck, "LastCheck should be null so background refresh triggers immediately");
+    }
+
+    [TestMethod]
+    public void IsUnreasonableVersion_UnparseableCached_ReturnsFalse()
+    {
+        // Corrupt/garbage cached versions should not be considered "unreasonable" — they just fail to parse
+        Assert.IsFalse(UpdateNotificationService.IsUnreasonableVersion("garbage", "1.0.0"));
+        Assert.IsFalse(UpdateNotificationService.IsUnreasonableVersion("", "1.0.0"));
+        Assert.IsFalse(UpdateNotificationService.IsUnreasonableVersion("1", "1.0.0"));
+        Assert.IsFalse(UpdateNotificationService.IsUnreasonableVersion("1.x", "1.0.0"));
+    }
+
+    [TestMethod]
+    public void IsUnreasonableVersion_UnparseableCurrent_ReturnsFalse()
+    {
+        // If the current version can't be parsed, don't flag anything as unreasonable
+        Assert.IsFalse(UpdateNotificationService.IsUnreasonableVersion("99.0.0", "garbage"));
+        Assert.IsFalse(UpdateNotificationService.IsUnreasonableVersion("99.0.0", ""));
+        Assert.IsFalse(UpdateNotificationService.IsUnreasonableVersion("99.0.0", "abc.def"));
+    }
+
+    [TestMethod]
+    public void CheckAndNotify_GarbageCachedVersion_DoesNotNotifyOrThrow()
+    {
+        var cacheDir = _testCacheDirectory.FullName;
+        var cacheFile = Path.Combine(cacheDir, ".update-check");
+        Directory.CreateDirectory(cacheDir);
+        // A corrupt cache file should not crash or display a notification
+        File.WriteAllText(cacheFile, $"{DateTime.UtcNow:O}\ngarbage\n2020-01-01");
+
+        _updateNotificationService.CheckAndNotify();
+
+        var output = TestAnsiConsole.Output;
+        Assert.IsFalse(output.Contains("available"), $"Should not notify for garbage version, got: {output}");
+    }
+
+    [TestMethod]
+    public void CheckAndNotify_CurrentVersionProviderThrows_DoesNotCrashAndDoesNotNotify()
+    {
+        _concreteService.CurrentVersionProvider = () => throw new InvalidOperationException("Simulated failure");
+
+        var cacheDir = _testCacheDirectory.FullName;
+        var cacheFile = Path.Combine(cacheDir, ".update-check");
+        Directory.CreateDirectory(cacheDir);
+        File.WriteAllText(cacheFile, $"{DateTime.UtcNow:O}\n5.0.0\n2020-01-01");
+
+        // Should not throw — the outer try/catch should absorb it
+        _updateNotificationService.CheckAndNotify();
+
+        var output = TestAnsiConsole.Output;
+        Assert.IsFalse(output.Contains("available"), $"Should not notify when provider throws, got: {output}");
+
+        // Cache should be unchanged (no mutation)
+        var cache = UpdateNotificationService.ReadCache(new FileInfo(cacheFile));
+        Assert.AreEqual("5.0.0", cache.LatestVersion, "Cache should not be mutated when provider throws");
     }
 }

--- a/src/winapp-CLI/WinApp.Cli.Tests/UpdateNotificationServiceTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/UpdateNotificationServiceTests.cs
@@ -88,7 +88,7 @@ public class UpdateNotificationServiceTests : BaseCommandTests
         var cacheFile = new FileInfo(Path.Combine(_testCacheDirectory.FullName, ".update-check"));
         // Write an existing cache with a lastShownDate
         cacheFile.Directory?.Create();
-        File.WriteAllText(cacheFile.FullName, $"{DateTime.UtcNow.AddHours(-25):O}\n999.0.0\n2026-01-15");
+        File.WriteAllText(cacheFile.FullName, $"{DateTime.UtcNow.AddHours(-25):O}\n5.0.0\n2026-01-15");
 
         await _concreteService.RefreshCacheAsync(cacheFile);
 
@@ -103,12 +103,12 @@ public class UpdateNotificationServiceTests : BaseCommandTests
         var cacheDir = _testCacheDirectory.FullName;
         var cacheFile = Path.Combine(cacheDir, ".update-check");
         Directory.CreateDirectory(cacheDir);
-        File.WriteAllText(cacheFile, $"{DateTime.UtcNow:O}\n999.0.0\n2020-01-01");
+        File.WriteAllText(cacheFile, $"{DateTime.UtcNow:O}\n5.0.0\n2020-01-01");
 
         _updateNotificationService.CheckAndNotify();
 
         var output = TestAnsiConsole.Output;
-        Assert.IsTrue(output.Contains("999.0.0"), $"Expected notification with version, got: {output}");
+        Assert.IsTrue(output.Contains("5.0.0"), $"Expected notification with version, got: {output}");
         Assert.IsTrue(output.Contains("available"), $"Expected 'available' in notification, got: {output}");
     }
 
@@ -119,7 +119,7 @@ public class UpdateNotificationServiceTests : BaseCommandTests
         var cacheDir = _testCacheDirectory.FullName;
         var cacheFile = Path.Combine(cacheDir, ".update-check");
         Directory.CreateDirectory(cacheDir);
-        File.WriteAllText(cacheFile, $"{DateTime.UtcNow:O}\n999.0.0\n{today}");
+        File.WriteAllText(cacheFile, $"{DateTime.UtcNow:O}\n5.0.0\n{today}");
 
         _updateNotificationService.CheckAndNotify();
 
@@ -162,7 +162,7 @@ public class UpdateNotificationServiceTests : BaseCommandTests
         var cacheDir = _testCacheDirectory.FullName;
         var cacheFilePath = Path.Combine(cacheDir, ".update-check");
         Directory.CreateDirectory(cacheDir);
-        File.WriteAllText(cacheFilePath, $"{DateTime.UtcNow:O}\n999.0.0\n2020-01-01");
+        File.WriteAllText(cacheFilePath, $"{DateTime.UtcNow:O}\n5.0.0\n2020-01-01");
 
         _updateNotificationService.CheckAndNotify();
 
@@ -197,7 +197,7 @@ public class UpdateNotificationServiceTests : BaseCommandTests
         var cacheDir = _testCacheDirectory.FullName;
         var cacheFile = Path.Combine(cacheDir, ".update-check");
         Directory.CreateDirectory(cacheDir);
-        File.WriteAllText(cacheFile, $"{DateTime.UtcNow:O}\n999.0.0\n2020-01-01");
+        File.WriteAllText(cacheFile, $"{DateTime.UtcNow:O}\n5.0.0\n2020-01-01");
 
         _updateNotificationService.CheckAndNotify();
 
@@ -212,7 +212,7 @@ public class UpdateNotificationServiceTests : BaseCommandTests
         var cacheDir = _testCacheDirectory.FullName;
         var cacheFile = Path.Combine(cacheDir, ".update-check");
         Directory.CreateDirectory(cacheDir);
-        File.WriteAllText(cacheFile, $"{DateTime.UtcNow:O}\n999.0.0\n2020-01-01");
+        File.WriteAllText(cacheFile, $"{DateTime.UtcNow:O}\n5.0.0\n2020-01-01");
 
         _updateNotificationService.CheckAndNotify();
 
@@ -227,7 +227,7 @@ public class UpdateNotificationServiceTests : BaseCommandTests
         var cacheDir = _testCacheDirectory.FullName;
         var cacheFile = Path.Combine(cacheDir, ".update-check");
         Directory.CreateDirectory(cacheDir);
-        File.WriteAllText(cacheFile, $"{DateTime.UtcNow:O}\n999.0.0\n2020-01-01");
+        File.WriteAllText(cacheFile, $"{DateTime.UtcNow:O}\n5.0.0\n2020-01-01");
 
         _updateNotificationService.CheckAndNotify();
 
@@ -242,7 +242,7 @@ public class UpdateNotificationServiceTests : BaseCommandTests
         var cacheDir = _testCacheDirectory.FullName;
         var cacheFile = Path.Combine(cacheDir, ".update-check");
         Directory.CreateDirectory(cacheDir);
-        File.WriteAllText(cacheFile, $"{DateTime.UtcNow:O}\n999.0.0\n2020-01-01");
+        File.WriteAllText(cacheFile, $"{DateTime.UtcNow:O}\n5.0.0\n2020-01-01");
 
         _updateNotificationService.CheckAndNotify();
 
@@ -257,7 +257,7 @@ public class UpdateNotificationServiceTests : BaseCommandTests
         var cacheDir = _testCacheDirectory.FullName;
         var cacheFile = Path.Combine(cacheDir, ".update-check");
         Directory.CreateDirectory(cacheDir);
-        File.WriteAllText(cacheFile, $"{DateTime.UtcNow:O}\n999.0.0\n2020-01-01");
+        File.WriteAllText(cacheFile, $"{DateTime.UtcNow:O}\n5.0.0\n2020-01-01");
 
         _updateNotificationService.CheckAndNotify();
 
@@ -272,7 +272,7 @@ public class UpdateNotificationServiceTests : BaseCommandTests
         var cacheDir = _testCacheDirectory.FullName;
         var cacheFile = Path.Combine(cacheDir, ".update-check");
         Directory.CreateDirectory(cacheDir);
-        File.WriteAllText(cacheFile, $"{DateTime.UtcNow:O}\n999.0.0\n2020-01-01");
+        File.WriteAllText(cacheFile, $"{DateTime.UtcNow:O}\n5.0.0\n2020-01-01");
 
         _updateNotificationService.CheckAndNotify();
 
@@ -287,11 +287,11 @@ public class UpdateNotificationServiceTests : BaseCommandTests
         var cacheDir = _testCacheDirectory.FullName;
         var cacheFilePath = Path.Combine(cacheDir, ".update-check");
         Directory.CreateDirectory(cacheDir);
-        File.WriteAllText(cacheFilePath, $"{DateTime.UtcNow:O}\n999.0.0");
+        File.WriteAllText(cacheFilePath, $"{DateTime.UtcNow:O}\n5.0.0");
 
         var cache = UpdateNotificationService.ReadCache(new FileInfo(cacheFilePath));
 
-        Assert.AreEqual("999.0.0", cache.LatestVersion);
+        Assert.AreEqual("5.0.0", cache.LatestVersion);
         Assert.AreEqual("", cache.LastShownDate, "Missing lastShownDate should default to empty (never shown)");
     }
 
@@ -460,5 +460,65 @@ public class UpdateNotificationServiceTests : BaseCommandTests
     public void IsPreReleaseVersion_BranchPrereleaseLabel_ReturnsTrue()
     {
         Assert.IsTrue(UpdateNotificationService.IsPreReleaseVersion("0.3.2-dev-my-feature.42"));
+    }
+
+    [TestMethod]
+    public void GetCoreVersion_StableVersion_ReturnsSame()
+    {
+        Assert.AreEqual("1.0.0", UpdateNotificationService.GetCoreVersion("1.0.0"));
+    }
+
+    [TestMethod]
+    public void GetCoreVersion_PreReleaseVersion_StripsPrerelease()
+    {
+        Assert.AreEqual("0.3.2", UpdateNotificationService.GetCoreVersion("0.3.2-prerelease.73"));
+    }
+
+    [TestMethod]
+    public void GetCoreVersion_WithBuildMetadata_StripsBoth()
+    {
+        Assert.AreEqual("1.0.0", UpdateNotificationService.GetCoreVersion("1.0.0-rc.1+build456"));
+    }
+
+    [TestMethod]
+    public void IsUnreasonableVersion_NormalVersion_ReturnsFalse()
+    {
+        Assert.IsFalse(UpdateNotificationService.IsUnreasonableVersion("5.0.0"));
+    }
+
+    [TestMethod]
+    public void IsUnreasonableVersion_HighVersion_ReturnsTrue()
+    {
+        Assert.IsTrue(UpdateNotificationService.IsUnreasonableVersion("99.0.0"));
+    }
+
+    [TestMethod]
+    public void IsUnreasonableVersion_TestArtifactVersion_ReturnsTrue()
+    {
+        Assert.IsTrue(UpdateNotificationService.IsUnreasonableVersion("999.0.0"));
+    }
+
+    [TestMethod]
+    public void IsUnreasonableVersion_BoundaryVersion_ReturnsFalse()
+    {
+        Assert.IsFalse(UpdateNotificationService.IsUnreasonableVersion("49.0.0"));
+    }
+
+    [TestMethod]
+    public void CheckAndNotify_UnreasonableCachedVersion_DiscardsAndNoNotification()
+    {
+        var cacheDir = _testCacheDirectory.FullName;
+        var cacheFile = Path.Combine(cacheDir, ".update-check");
+        Directory.CreateDirectory(cacheDir);
+        File.WriteAllText(cacheFile, $"{DateTime.UtcNow:O}\n999.0.0\n2020-01-01");
+
+        _updateNotificationService.CheckAndNotify();
+
+        var output = TestAnsiConsole.Output;
+        Assert.IsFalse(output.Contains("available"), $"Should not notify for unreasonable version, got: {output}");
+
+        // Verify the cache was cleaned
+        var cache = UpdateNotificationService.ReadCache(new FileInfo(cacheFile));
+        Assert.AreEqual("", cache.LatestVersion, "Unreasonable version should be cleared from cache");
     }
 }

--- a/src/winapp-CLI/WinApp.Cli.Tests/UpdateNotificationServiceTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/UpdateNotificationServiceTests.cs
@@ -425,4 +425,40 @@ public class UpdateNotificationServiceTests : BaseCommandTests
         using var doc = JsonDocument.Parse("""{"tag_name":"v2.0.0-beta.1"}""");
         Assert.AreEqual("2.0.0-beta.1", UpdateNotificationService.ParseTagName(doc));
     }
+
+    [TestMethod]
+    public void IsPreReleaseVersion_StableVersion_ReturnsFalse()
+    {
+        Assert.IsFalse(UpdateNotificationService.IsPreReleaseVersion("1.0.0"));
+    }
+
+    [TestMethod]
+    public void IsPreReleaseVersion_PreReleaseVersion_ReturnsTrue()
+    {
+        Assert.IsTrue(UpdateNotificationService.IsPreReleaseVersion("1.0.0-prerelease.73"));
+    }
+
+    [TestMethod]
+    public void IsPreReleaseVersion_BetaVersion_ReturnsTrue()
+    {
+        Assert.IsTrue(UpdateNotificationService.IsPreReleaseVersion("0.3.2-beta.1"));
+    }
+
+    [TestMethod]
+    public void IsPreReleaseVersion_WithBuildMetadata_ReturnsFalse()
+    {
+        Assert.IsFalse(UpdateNotificationService.IsPreReleaseVersion("1.0.0+build123"));
+    }
+
+    [TestMethod]
+    public void IsPreReleaseVersion_PreReleaseWithBuildMetadata_ReturnsTrue()
+    {
+        Assert.IsTrue(UpdateNotificationService.IsPreReleaseVersion("1.0.0-rc.1+build456"));
+    }
+
+    [TestMethod]
+    public void IsPreReleaseVersion_BranchPrereleaseLabel_ReturnsTrue()
+    {
+        Assert.IsTrue(UpdateNotificationService.IsPreReleaseVersion("0.3.2-dev-my-feature.42"));
+    }
 }

--- a/src/winapp-CLI/WinApp.Cli.Tests/UpdateNotificationServiceTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/UpdateNotificationServiceTests.cs
@@ -505,6 +505,12 @@ public class UpdateNotificationServiceTests : BaseCommandTests
     }
 
     [TestMethod]
+    public void IsUnreasonableVersion_ExactThreshold_ReturnsTrue()
+    {
+        Assert.IsTrue(UpdateNotificationService.IsUnreasonableVersion("50.0.0"));
+    }
+
+    [TestMethod]
     public void CheckAndNotify_UnreasonableCachedVersion_DiscardsAndNoNotification()
     {
         var cacheDir = _testCacheDirectory.FullName;

--- a/src/winapp-CLI/WinApp.Cli/Services/UpdateNotificationService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/UpdateNotificationService.cs
@@ -57,7 +57,8 @@ internal class UpdateNotificationService(
             // Paranoia: discard cached versions that look like test artifacts (e.g., 99.0.0, 999.0.0)
             if (!string.IsNullOrEmpty(cache.LatestVersion) && IsUnreasonableVersion(cache.LatestVersion, currentVersion))
             {
-                cache = cache with { LatestVersion = "", LastShownDate = "" };
+                logger.LogDebug("Discarded unreasonable cached update version {Version}", cache.LatestVersion);
+                cache = cache with { LastCheck = null, LatestVersion = "", LastShownDate = "" };
                 WriteCacheFile(cacheFile, cache);
             }
 
@@ -183,16 +184,34 @@ internal class UpdateNotificationService(
         NotificationConsole.MarkupLine($"[yellow]v{Markup.Escape(newVersion)} is available. To update, {Markup.Escape(upgradeHint)}.[/]");
     }
 
-    internal static bool IsPreReleaseVersion(string version)
+    /// <summary>
+    /// Parses a SemVer-like version string into its core <see cref="Version"/> and optional prerelease suffix.
+    /// Handles v-prefix, build metadata (+...), and prerelease (-...) in a single pass.
+    /// </summary>
+    private static bool TryParseSemVer(string value, out Version coreVersion, out string? prerelease)
     {
-        // Strip build metadata (+...)
-        var plusIdx = version.IndexOf('+');
-        if (plusIdx >= 0)
+        coreVersion = new Version(0, 0);
+        prerelease = null;
+
+        if (value.StartsWith('v') || value.StartsWith('V'))
         {
-            version = version[..plusIdx];
+            value = value[1..];
         }
 
-        return version.Contains('-');
+        var plusIdx = value.IndexOf('+');
+        if (plusIdx >= 0)
+        {
+            value = value[..plusIdx];
+        }
+
+        var dashIdx = value.IndexOf('-');
+        if (dashIdx >= 0)
+        {
+            prerelease = value[(dashIdx + 1)..];
+            value = value[..dashIdx];
+        }
+
+        return Version.TryParse(value, out coreVersion!);
     }
 
     /// <summary>
@@ -201,14 +220,7 @@ internal class UpdateNotificationService(
     /// </summary>
     internal static string GetCoreVersion(string version)
     {
-        var plusIdx = version.IndexOf('+');
-        if (plusIdx >= 0)
-        {
-            version = version[..plusIdx];
-        }
-
-        var dashIdx = version.IndexOf('-');
-        return dashIdx >= 0 ? version[..dashIdx] : version;
+        return TryParseSemVer(version, out var core, out _) ? core.ToString() : version;
     }
 
     /// <summary>
@@ -217,51 +229,17 @@ internal class UpdateNotificationService(
     /// </summary>
     internal static bool IsUnreasonableVersion(string version, string currentVersion)
     {
-        if (!TryParseMajorVersion(version, out var cachedMajor)
-            || !TryParseMajorVersion(currentVersion, out var currentMajor))
+        if (!TryParseSemVer(version, out var cachedCore, out _)
+            || !TryParseSemVer(currentVersion, out var currentCore, out _))
         {
             return false;
         }
 
-        return cachedMajor > currentMajor + MaxReasonableFutureMajorDelta;
-    }
-
-    private static bool TryParseMajorVersion(string version, out int major)
-    {
-        var core = GetCoreVersion(version);
-        if (core.StartsWith('v') || core.StartsWith('V'))
-        {
-            core = core[1..];
-        }
-
-        var dotIdx = core.IndexOf('.');
-        var majorStr = dotIdx >= 0 ? core[..dotIdx] : core;
-        return int.TryParse(majorStr, out major);
+        return cachedCore.Major > currentCore.Major + MaxReasonableFutureMajorDelta;
     }
 
     internal static bool IsNewerVersion(string latest, string current)
     {
-        static bool TryParseSemVer(string value, out Version coreVersion, out string? prerelease)
-        {
-            coreVersion = new Version(0, 0);
-            prerelease = null;
-
-            var plusIdx = value.IndexOf('+');
-            if (plusIdx >= 0)
-            {
-                value = value[..plusIdx];
-            }
-
-            var dashIdx = value.IndexOf('-');
-            if (dashIdx >= 0)
-            {
-                prerelease = value[(dashIdx + 1)..];
-                value = value[..dashIdx];
-            }
-
-            return Version.TryParse(value, out coreVersion!);
-        }
-
         if (!TryParseSemVer(latest, out var latestCore, out var latestPre))
         {
             return false;

--- a/src/winapp-CLI/WinApp.Cli/Services/UpdateNotificationService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/UpdateNotificationService.cs
@@ -47,6 +47,13 @@ internal class UpdateNotificationService(
                 return;
             }
 
+            // Prerelease builds are always ahead of the latest stable release —
+            // never show an update notice for them.
+            if (IsPreReleaseVersion(VersionHelper.GetVersionString()))
+            {
+                return;
+            }
+
             var cacheFile = GetUpdateCheckFile();
             var cache = ReadCache(cacheFile);
 
@@ -170,6 +177,18 @@ internal class UpdateNotificationService(
         };
 
         NotificationConsole.MarkupLine($"[yellow]v{Markup.Escape(newVersion)} is available. To update, {Markup.Escape(upgradeHint)}.[/]");
+    }
+
+    internal static bool IsPreReleaseVersion(string version)
+    {
+        // Strip build metadata (+...)
+        var plusIdx = version.IndexOf('+');
+        if (plusIdx >= 0)
+        {
+            version = version[..plusIdx];
+        }
+
+        return version.Contains('-');
     }
 
     internal static bool IsNewerVersion(string latest, string current)

--- a/src/winapp-CLI/WinApp.Cli/Services/UpdateNotificationService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/UpdateNotificationService.cs
@@ -53,7 +53,7 @@ internal class UpdateNotificationService(
             // Paranoia: discard cached versions that look like test artifacts (e.g., 99.0.0, 999.0.0)
             if (!string.IsNullOrEmpty(cache.LatestVersion) && IsUnreasonableVersion(cache.LatestVersion))
             {
-                cache = cache with { LatestVersion = "" };
+                cache = cache with { LatestVersion = "", LastShownDate = "" };
                 WriteCacheFile(cacheFile, cache);
             }
 
@@ -218,6 +218,8 @@ internal class UpdateNotificationService(
     /// <summary>
     /// Detects unreasonably high version numbers that likely came from test fixtures
     /// (e.g., 99.0.0, 999.0.0). Any major version ≥ 50 is considered unreasonable.
+    /// TODO: This threshold assumes the product stays below v50 for the foreseeable future.
+    /// Revisit if the project ever approaches major version 50.
     /// </summary>
     internal static bool IsUnreasonableVersion(string version)
     {

--- a/src/winapp-CLI/WinApp.Cli/Services/UpdateNotificationService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/UpdateNotificationService.cs
@@ -21,10 +21,12 @@ internal class UpdateNotificationService(
     private const string GitHubApiLatestRelease = "https://api.github.com/repos/microsoft/winappcli/releases/latest";
     private const string UpdateCheckFileName = ".update-check";
     private const int CheckIntervalHours = 24;
+    private const int MaxReasonableFutureMajorDelta = 20;
     private static readonly TimeSpan FirstRunRefreshTimeout = TimeSpan.FromMilliseconds(250);
 
     // For testing only — when true, skips the fire-and-forget background network refresh
     internal bool SkipBackgroundRefreshForTesting;
+    internal Func<string> CurrentVersionProvider { get; set; } = VersionHelper.GetVersionString;
 
     // The console used for upgrade notices. Defaults to stderr so scripted commands
     // (e.g. get-winapp-path, --version) are never corrupted. Tests can override to capture output.
@@ -50,24 +52,18 @@ internal class UpdateNotificationService(
             var cacheFile = GetUpdateCheckFile();
             var cache = ReadCache(cacheFile);
 
+            var currentVersion = CurrentVersionProvider();
+
             // Paranoia: discard cached versions that look like test artifacts (e.g., 99.0.0, 999.0.0)
-            if (!string.IsNullOrEmpty(cache.LatestVersion) && IsUnreasonableVersion(cache.LatestVersion))
+            if (!string.IsNullOrEmpty(cache.LatestVersion) && IsUnreasonableVersion(cache.LatestVersion, currentVersion))
             {
                 cache = cache with { LatestVersion = "", LastShownDate = "" };
                 WriteCacheFile(cacheFile, cache);
             }
 
             // Show notice if a newer version is cached and not yet shown today.
-            // For prerelease builds, compare against the core version only — a prerelease
-            // like "0.3.2-prerelease.73" is conceptually at or ahead of stable "0.3.2",
-            // but should still be notified about a genuinely newer stable like "0.4.0".
-            var currentVersion = VersionHelper.GetVersionString();
-            var effectiveCurrentVersion = IsPreReleaseVersion(currentVersion)
-                ? GetCoreVersion(currentVersion)
-                : currentVersion;
-
             if (!string.IsNullOrEmpty(cache.LatestVersion)
-                && IsNewerVersion(cache.LatestVersion, effectiveCurrentVersion)
+                && IsNewerVersion(cache.LatestVersion, currentVersion)
                 && cache.LastShownDate != DateTime.UtcNow.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture))
             {
                 DisplayUpdateNotification(cache.LatestVersion);
@@ -216,17 +212,31 @@ internal class UpdateNotificationService(
     }
 
     /// <summary>
-    /// Detects unreasonably high version numbers that likely came from test fixtures
-    /// (e.g., 99.0.0, 999.0.0). Any major version ≥ 50 is considered unreasonable.
-    /// TODO: This threshold assumes the product stays below v50 for the foreseeable future.
-    /// Revisit if the project ever approaches major version 50.
+    /// Detects unreasonably high cached version numbers that likely came from test fixtures
+    /// (e.g., 99.0.0, 999.0.0) by comparing against the current CLI major version.
     /// </summary>
-    internal static bool IsUnreasonableVersion(string version)
+    internal static bool IsUnreasonableVersion(string version, string currentVersion)
+    {
+        if (!TryParseMajorVersion(version, out var cachedMajor)
+            || !TryParseMajorVersion(currentVersion, out var currentMajor))
+        {
+            return false;
+        }
+
+        return cachedMajor > currentMajor + MaxReasonableFutureMajorDelta;
+    }
+
+    private static bool TryParseMajorVersion(string version, out int major)
     {
         var core = GetCoreVersion(version);
+        if (core.StartsWith('v') || core.StartsWith('V'))
+        {
+            core = core[1..];
+        }
+
         var dotIdx = core.IndexOf('.');
         var majorStr = dotIdx >= 0 ? core[..dotIdx] : core;
-        return int.TryParse(majorStr, out var major) && major >= 50;
+        return int.TryParse(majorStr, out major);
     }
 
     internal static bool IsNewerVersion(string latest, string current)

--- a/src/winapp-CLI/WinApp.Cli/Services/UpdateNotificationService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/UpdateNotificationService.cs
@@ -47,19 +47,27 @@ internal class UpdateNotificationService(
                 return;
             }
 
-            // Prerelease builds are always ahead of the latest stable release —
-            // never show an update notice for them.
-            if (IsPreReleaseVersion(VersionHelper.GetVersionString()))
-            {
-                return;
-            }
-
             var cacheFile = GetUpdateCheckFile();
             var cache = ReadCache(cacheFile);
 
-            // Show notice if a newer version is cached and not yet shown today
+            // Paranoia: discard cached versions that look like test artifacts (e.g., 99.0.0, 999.0.0)
+            if (!string.IsNullOrEmpty(cache.LatestVersion) && IsUnreasonableVersion(cache.LatestVersion))
+            {
+                cache = cache with { LatestVersion = "" };
+                WriteCacheFile(cacheFile, cache);
+            }
+
+            // Show notice if a newer version is cached and not yet shown today.
+            // For prerelease builds, compare against the core version only — a prerelease
+            // like "0.3.2-prerelease.73" is conceptually at or ahead of stable "0.3.2",
+            // but should still be notified about a genuinely newer stable like "0.4.0".
+            var currentVersion = VersionHelper.GetVersionString();
+            var effectiveCurrentVersion = IsPreReleaseVersion(currentVersion)
+                ? GetCoreVersion(currentVersion)
+                : currentVersion;
+
             if (!string.IsNullOrEmpty(cache.LatestVersion)
-                && IsNewerVersion(cache.LatestVersion, VersionHelper.GetVersionString())
+                && IsNewerVersion(cache.LatestVersion, effectiveCurrentVersion)
                 && cache.LastShownDate != DateTime.UtcNow.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture))
             {
                 DisplayUpdateNotification(cache.LatestVersion);
@@ -189,6 +197,34 @@ internal class UpdateNotificationService(
         }
 
         return version.Contains('-');
+    }
+
+    /// <summary>
+    /// Returns the core version without prerelease suffix or build metadata.
+    /// E.g., "0.3.2-prerelease.73+abc" → "0.3.2"
+    /// </summary>
+    internal static string GetCoreVersion(string version)
+    {
+        var plusIdx = version.IndexOf('+');
+        if (plusIdx >= 0)
+        {
+            version = version[..plusIdx];
+        }
+
+        var dashIdx = version.IndexOf('-');
+        return dashIdx >= 0 ? version[..dashIdx] : version;
+    }
+
+    /// <summary>
+    /// Detects unreasonably high version numbers that likely came from test fixtures
+    /// (e.g., 99.0.0, 999.0.0). Any major version ≥ 50 is considered unreasonable.
+    /// </summary>
+    internal static bool IsUnreasonableVersion(string version)
+    {
+        var core = GetCoreVersion(version);
+        var dotIdx = core.IndexOf('.');
+        var majorStr = dotIdx >= 0 ? core[..dotIdx] : core;
+        return int.TryParse(majorStr, out var major) && major >= 50;
     }
 
     internal static bool IsNewerVersion(string latest, string current)


### PR DESCRIPTION
fixes #538 

Changes:
* Added function to check if a version is prerelease, and to only consider core version when deciding whether or not show update check
* Added check to ensure cached versioning info hasn't been malformed by tests
* Updated corresponding tests