### PR TITLE
MSIX Bundle Support for pack command

### DIFF
--- a/.github/plugin/agents/winapp.agent.md
+++ b/.github/plugin/agents/winapp.agent.md
@@ -100,18 +100,21 @@ Want to inspect or interact with a running app's UI?
 **Key options:** `--setup-sdks stable|preview|experimental|none`
 **Requires:** `winapp.yaml`
 
-### `winapp package <input-folder>` (alias: `winapp pack`)
-**Purpose:** Create an MSIX installer from a built app.
-**When to use:** After building your app, when you want to create a distributable MSIX package.
+### `winapp package <input-folder...>` (alias: `winapp pack`)
+**Purpose:** Create an MSIX package (single folder) or MSIX bundle (multiple folders).
+**When to use:** After building your app, when you want to create a distributable MSIX package or a multi-architecture bundle.
 **Key options:**
-- `--cert <path>` — sign the package in one step
+- `--cert <path>` — sign the package/bundle in one step
 - `--cert-password <pwd>` — certificate password (default: `password`)
 - `--manifest <path>` — explicit manifest path (default: auto-detect from input folder or cwd)
-- `--output <path>` — output `.msix` filename
-- `--self-contained` — bundle Windows App SDK runtime
+- `--output <path>` — output `.msix` or `.msixbundle` filename
+- `--self-contained` — bundle Windows App SDK runtime (arch-aware for bundles)
 - `--generate-cert` — auto-generate a certificate
 - `--install-cert` — also install the certificate on the machine
 - `--skip-pri` — skip PRI resource file generation
+**Bundle usage:** Pass multiple folders to create a bundle:
+  `winapp pack ./publish/x64 ./publish/arm64`
+  Each folder's architecture is auto-detected from the executable PE header.
 **Requires:** Built app output directory + `appxmanifest.xml`
 
 ### `winapp create-debug-identity [entrypoint]`

--- a/.github/plugin/skills/winapp-cli/package/SKILL.md
+++ b/.github/plugin/skills/winapp-cli/package/SKILL.md
@@ -111,6 +111,32 @@ winapp create-external-catalog "./bin/Release"
 winapp create-external-catalog "./bin/Release" --recursive --output ./catalog/CodeIntegrityExternal.cat
 ```
 
+### Bundling multiple architectures
+
+Create an MSIX bundle from multiple per-architecture build outputs:
+
+```powershell
+# Create unsigned bundle for Store submission (x64 + arm64)
+winapp package ./publish/x64 ./publish/arm64
+
+# Create signed bundle for sideloading
+winapp package ./publish/x64 ./publish/arm64 --cert ./devcert.pfx
+
+# Self-contained bundle with Windows App SDK runtime per arch
+winapp package ./publish/x64 ./publish/arm64 --self-contained --generate-cert
+```
+
+**How it works:** When multiple input folders are passed, `winapp package`:
+1. Detects the architecture of each folder's primary executable from its PE header
+2. Validates that all slices share the same Identity, Capabilities, and Dependencies
+3. Packs each folder into an intermediate unsigned `.msix`
+4. Bundles them into a single `.msixbundle` using `makeappx bundle`
+5. Signs only the bundle (not individual slices) — the signature covers all packages inside
+
+**Output:** `<Name>_<Version>_<arch1>_<arch2>.msixbundle` (architectures sorted alphabetically).
+
+**Store submission:** An unsigned bundle is valid for Store upload — Partner Center signs it with your reserved identity certificate. For sideloading, pass `--cert` or `--generate-cert`.
+
 This hashes executables in the specified directories so Windows trusts them when running with sparse package identity.
 
 ## CI/CD
@@ -167,7 +193,7 @@ Create MSIX installer from your built app. Run after building your app. A manife
 <!-- auto-generated from cli-schema.json -->
 | Argument | Required | Description |
 |----------|----------|-------------|
-| `<input-folder>` | Yes | Input folder with package layout |
+| `<input-folder>` | Yes | One or more input folders with package layout. Pass multiple folders to create an MSIX bundle (e.g., winapp pack ./publish/x64 ./publish/arm64). |
 
 #### Options
 <!-- auto-generated from cli-schema.json -->

--- a/.github/plugin/skills/winapp-cli/package/SKILL.md
+++ b/.github/plugin/skills/winapp-cli/package/SKILL.md
@@ -206,7 +206,7 @@ Create MSIX installer from your built app. Run after building your app. A manife
 | `--install-cert` | Install certificate to machine | (none) |
 | `--manifest` | Path to AppX manifest file (default: auto-detect from input folder or current directory) | (none) |
 | `--name` | Package name (default: from manifest) | (none) |
-| `--output` | Output msix file name for the generated package (defaults to <name>_<version>_<arch>.msix, falling back to <name>_<version>.msix, <name>_<arch>.msix, or <name>.msix when version/arch can't be determined) | (none) |
+| `--output` | Output file name for the generated package (.msix) or bundle (.msixbundle). Defaults to <name>_<version>_<arch>.msix for single packages, or <name>_<version>_<arch1>_<arch2>.msixbundle for bundles. | (none) |
 | `--publisher` | Publisher name for certificate generation | (none) |
 | `--self-contained` | Bundle Windows App SDK runtime for self-contained deployment | (none) |
 | `--skip-pri` | Skip PRI file generation | (none) |

--- a/.github/plugin/skills/winapp-cli/package/SKILL.md
+++ b/.github/plugin/skills/winapp-cli/package/SKILL.md
@@ -128,10 +128,18 @@ winapp package ./publish/x64 ./publish/arm64 --self-contained --generate-cert
 
 **How it works:** When multiple input folders are passed, `winapp package`:
 1. Detects the architecture of each folder's primary executable from its PE header
-2. Validates that all slices share the same Identity, Capabilities, and Dependencies
-3. Packs each folder into an intermediate unsigned `.msix`
-4. Bundles them into a single `.msixbundle` using `makeappx bundle`
-5. Signs only the bundle (not individual slices) — the signature covers all packages inside
+2. Resolves a manifest for each slice (see below)
+3. Validates that all slices share the same Identity, Capabilities, and Dependencies
+4. Packs each folder into an intermediate unsigned `.msix`
+5. Bundles them into a single `.msixbundle` using `makeappx bundle`
+6. Signs only the bundle (not individual slices) — the signature covers all packages inside
+
+**Manifest resolution:** Each slice needs a manifest. Resolution order:
+- `--manifest <path>` uses one manifest for all slices (architecture auto-stamped per folder)
+- Per-folder `Package.appxmanifest` if present in the input folder
+- Fallback to `Package.appxmanifest` in the current working directory
+
+The `ProcessorArchitecture` is always force-set to the detected architecture per-slice. All other Identity fields must be consistent across slices.
 
 **Output:** `<Name>_<Version>_<arch1>_<arch2>.msixbundle` (architectures sorted alphabetically).
 

--- a/.github/plugin/skills/winapp-cli/signing/SKILL.md
+++ b/.github/plugin/skills/winapp-cli/signing/SKILL.md
@@ -74,6 +74,10 @@ winapp sign ./myapp.msix ./devcert.pfx --password MySecurePassword
 winapp sign ./myapp.msix ./production.pfx --timestamp http://timestamp.digicert.com
 ```
 
+### Bundle signing
+
+When packaging multiple architectures into an `.msixbundle`, only the bundle needs to be signed — the signature covers all packages inside. The individual `.msix` slices do not need separate signatures.
+
 Note: The `package` command can sign automatically when you pass `--cert`, so you often don't need `sign` separately.
 
 ## Recommended workflow

--- a/.github/plugin/skills/winapp-cli/ui-automation/SKILL.md
+++ b/.github/plugin/skills/winapp-cli/ui-automation/SKILL.md
@@ -183,7 +183,7 @@ The `--json` envelope for `ui inspect`, `ui get-focused`, `ui search`, and `ui w
 - `ui search --json` / `ui wait-for --json` may include an `invokableAncestor` field (element-shaped) on each match.
 - Per-element `id`, `parentSelector`, and `windowHandle` are **removed** — use `selector` as the public handle.
 
-Full schemas with examples: [`references/ui-json-envelope.md`](./references/ui-json-envelope.md).
+Full schemas with examples: `references/ui-json-envelope.md`.
 
 ## Related skills
 - `winapp-setup` for adding Windows SDK to your project

--- a/docs/cli-schema.json
+++ b/docs/cli-schema.json
@@ -1180,7 +1180,7 @@
           "recursive": false
         },
         "--output": {
-          "description": "Output msix file name for the generated package (defaults to <name>_<version>_<arch>.msix, falling back to <name>_<version>.msix, <name>_<arch>.msix, or <name>.msix when version/arch can't be determined)",
+          "description": "Output file name for the generated package (.msix) or bundle (.msixbundle). Defaults to <name>_<version>_<arch>.msix for single packages, or <name>_<version>_<arch1>_<arch2>.msixbundle for bundles.",
           "hidden": false,
           "valueType": "System.IO.FileInfo",
           "hasDefaultValue": false,

--- a/docs/cli-schema.json
+++ b/docs/cli-schema.json
@@ -1078,14 +1078,13 @@
       ],
       "arguments": {
         "input-folder": {
-          "description": "Input folder with package layout",
+          "description": "One or more input folders with package layout. Pass multiple folders to create an MSIX bundle (e.g., winapp pack ./publish/x64 ./publish/arm64).",
           "order": 0,
           "hidden": false,
-          "valueType": "System.IO.DirectoryInfo",
+          "valueType": "System.IO.DirectoryInfo[]",
           "hasDefaultValue": false,
           "arity": {
-            "minimum": 1,
-            "maximum": 1
+            "minimum": 1
           }
         }
       },

--- a/docs/fragments/skills/winapp-cli/package.md
+++ b/docs/fragments/skills/winapp-cli/package.md
@@ -106,6 +106,32 @@ winapp create-external-catalog "./bin/Release"
 winapp create-external-catalog "./bin/Release" --recursive --output ./catalog/CodeIntegrityExternal.cat
 ```
 
+### Bundling multiple architectures
+
+Create an MSIX bundle from multiple per-architecture build outputs:
+
+```powershell
+# Create unsigned bundle for Store submission (x64 + arm64)
+winapp package ./publish/x64 ./publish/arm64
+
+# Create signed bundle for sideloading
+winapp package ./publish/x64 ./publish/arm64 --cert ./devcert.pfx
+
+# Self-contained bundle with Windows App SDK runtime per arch
+winapp package ./publish/x64 ./publish/arm64 --self-contained --generate-cert
+```
+
+**How it works:** When multiple input folders are passed, `winapp package`:
+1. Detects the architecture of each folder's primary executable from its PE header
+2. Validates that all slices share the same Identity, Capabilities, and Dependencies
+3. Packs each folder into an intermediate unsigned `.msix`
+4. Bundles them into a single `.msixbundle` using `makeappx bundle`
+5. Signs only the bundle (not individual slices) — the signature covers all packages inside
+
+**Output:** `<Name>_<Version>_<arch1>_<arch2>.msixbundle` (architectures sorted alphabetically).
+
+**Store submission:** An unsigned bundle is valid for Store upload — Partner Center signs it with your reserved identity certificate. For sideloading, pass `--cert` or `--generate-cert`.
+
 This hashes executables in the specified directories so Windows trusts them when running with sparse package identity.
 
 ## CI/CD

--- a/docs/fragments/skills/winapp-cli/package.md
+++ b/docs/fragments/skills/winapp-cli/package.md
@@ -123,10 +123,18 @@ winapp package ./publish/x64 ./publish/arm64 --self-contained --generate-cert
 
 **How it works:** When multiple input folders are passed, `winapp package`:
 1. Detects the architecture of each folder's primary executable from its PE header
-2. Validates that all slices share the same Identity, Capabilities, and Dependencies
-3. Packs each folder into an intermediate unsigned `.msix`
-4. Bundles them into a single `.msixbundle` using `makeappx bundle`
-5. Signs only the bundle (not individual slices) — the signature covers all packages inside
+2. Resolves a manifest for each slice (see below)
+3. Validates that all slices share the same Identity, Capabilities, and Dependencies
+4. Packs each folder into an intermediate unsigned `.msix`
+5. Bundles them into a single `.msixbundle` using `makeappx bundle`
+6. Signs only the bundle (not individual slices) — the signature covers all packages inside
+
+**Manifest resolution:** Each slice needs a manifest. Resolution order:
+- `--manifest <path>` uses one manifest for all slices (architecture auto-stamped per folder)
+- Per-folder `Package.appxmanifest` if present in the input folder
+- Fallback to `Package.appxmanifest` in the current working directory
+
+The `ProcessorArchitecture` is always force-set to the detected architecture per-slice. All other Identity fields must be consistent across slices.
 
 **Output:** `<Name>_<Version>_<arch1>_<arch2>.msixbundle` (architectures sorted alphabetically).
 

--- a/docs/fragments/skills/winapp-cli/signing.md
+++ b/docs/fragments/skills/winapp-cli/signing.md
@@ -69,6 +69,10 @@ winapp sign ./myapp.msix ./devcert.pfx --password MySecurePassword
 winapp sign ./myapp.msix ./production.pfx --timestamp http://timestamp.digicert.com
 ```
 
+### Bundle signing
+
+When packaging multiple architectures into an `.msixbundle`, only the bundle needs to be signed — the signature covers all packages inside. The individual `.msix` slices do not need separate signatures.
+
 Note: The `package` command can sign automatically when you pass `--cert`, so you often don't need `sign` separately.
 
 ## Recommended workflow

--- a/docs/guides/packaging-cli.md
+++ b/docs/guides/packaging-cli.md
@@ -186,7 +186,10 @@ Get-AppxPackage *YourCLI* | Remove-AppxPackage
 
 1. Once you are ready for distribution, you can sign your MSIX with a code signing certificate from a Certificate Authority so your users don't have to install a self-signed certificate
 2. The Microsoft Store will sign the MSIX for you, no need to sign before submission.
-3. You might need to create multiple MSIX packages, one for each architecture you support (x64, Arm64)
+3. To create a multi-architecture bundle (`.msixbundle`) for x64 + Arm64, pass multiple input folders:
+   ```powershell
+   winapp pack ./publish/x64 ./publish/arm64 --cert ./devcert.pfx
+   ```
 
 ## Next Steps
 

--- a/docs/npm-usage.md
+++ b/docs/npm-usage.md
@@ -29,6 +29,9 @@ await certGenerate({ install: true });
 
 // Package the built app
 await packageApp({ inputFolder: './dist', cert: './devcert.pfx' });
+
+// Create a multi-architecture bundle
+await packageApp({ inputFolder: ['./publish/x64', './publish/arm64'] });
 ```
 
 ## Common types
@@ -289,7 +292,7 @@ function packageApp(options: PackageOptions): Promise<WinappResult>
 
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
-| `inputFolder` | `string` | Yes | One or more input folders with package layout. Pass multiple folders to create an MSIX bundle (e.g., winapp pack ./publish/x64 ./publish/arm64). |
+| `inputFolder` | `string \| string[]` | Yes | One or more input folders with package layout. Pass a single string for one package, or an array for a multi-architecture bundle. |
 | `cert` | `string \| undefined` | No | Path to signing certificate (will auto-sign if provided) |
 | `certPassword` | `string \| undefined` | No | Certificate password (default: password) |
 | `executable` | `string \| undefined` | No | Path to the executable relative to the input folder. |
@@ -1218,7 +1221,7 @@ type ManifestTemplates = "packaged" | "sparse"
 
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
-| `inputFolder` | `string` | Yes | One or more input folders with package layout. Pass multiple folders to create an MSIX bundle (e.g., winapp pack ./publish/x64 ./publish/arm64). |
+| `inputFolder` | `string \| string[]` | Yes | One or more input folders with package layout. Pass a single string for one package, or an array for a multi-architecture bundle. |
 | `cert` | `string \| undefined` | No | Path to signing certificate (will auto-sign if provided) |
 | `certPassword` | `string \| undefined` | No | Certificate password (default: password) |
 | `executable` | `string \| undefined` | No | Path to the executable relative to the input folder. |

--- a/docs/npm-usage.md
+++ b/docs/npm-usage.md
@@ -1,4 +1,6 @@
-<!-- mslearn: true -->
+---
+ms.custom: mslearn
+---
 <!-- AUTO-GENERATED — DO NOT EDIT -->
 <!-- Regenerate with: cd src/winapp-npm && npm run generate-docs -->
 
@@ -287,7 +289,7 @@ function packageApp(options: PackageOptions): Promise<WinappResult>
 
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
-| `inputFolder` | `string` | Yes | Input folder with package layout |
+| `inputFolder` | `string` | Yes | One or more input folders with package layout. Pass multiple folders to create an MSIX bundle (e.g., winapp pack ./publish/x64 ./publish/arm64). |
 | `cert` | `string \| undefined` | No | Path to signing certificate (will auto-sign if provided) |
 | `certPassword` | `string \| undefined` | No | Certificate password (default: password) |
 | `executable` | `string \| undefined` | No | Path to the executable relative to the input folder. |
@@ -295,7 +297,7 @@ function packageApp(options: PackageOptions): Promise<WinappResult>
 | `installCert` | `boolean \| undefined` | No | Install certificate to machine |
 | `manifest` | `string \| undefined` | No | Path to AppX manifest file (default: auto-detect from input folder or current directory) |
 | `name` | `string \| undefined` | No | Package name (default: from manifest) |
-| `output` | `string \| undefined` | No | Output msix file name for the generated package (defaults to <name>_<version>_<arch>.msix, falling back to <name>_<version>.msix, <name>_<arch>.msix, or <name>.msix when version/arch can't be determined) |
+| `output` | `string \| undefined` | No | Output file name for the generated package (.msix) or bundle (.msixbundle). Defaults to <name>_<version>_<arch>.msix for single packages, or <name>_<version>_<arch1>_<arch2>.msixbundle for bundles. |
 | `publisher` | `string \| undefined` | No | Publisher name for certificate generation |
 | `selfContained` | `boolean \| undefined` | No | Bundle Windows App SDK runtime for self-contained deployment |
 | `skipPri` | `boolean \| undefined` | No | Skip PRI file generation |
@@ -1216,7 +1218,7 @@ type ManifestTemplates = "packaged" | "sparse"
 
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
-| `inputFolder` | `string` | Yes | Input folder with package layout |
+| `inputFolder` | `string` | Yes | One or more input folders with package layout. Pass multiple folders to create an MSIX bundle (e.g., winapp pack ./publish/x64 ./publish/arm64). |
 | `cert` | `string \| undefined` | No | Path to signing certificate (will auto-sign if provided) |
 | `certPassword` | `string \| undefined` | No | Certificate password (default: password) |
 | `executable` | `string \| undefined` | No | Path to the executable relative to the input folder. |
@@ -1224,7 +1226,7 @@ type ManifestTemplates = "packaged" | "sparse"
 | `installCert` | `boolean \| undefined` | No | Install certificate to machine |
 | `manifest` | `string \| undefined` | No | Path to AppX manifest file (default: auto-detect from input folder or current directory) |
 | `name` | `string \| undefined` | No | Package name (default: from manifest) |
-| `output` | `string \| undefined` | No | Output msix file name for the generated package (defaults to <name>_<version>_<arch>.msix, falling back to <name>_<version>.msix, <name>_<arch>.msix, or <name>.msix when version/arch can't be determined) |
+| `output` | `string \| undefined` | No | Output file name for the generated package (.msix) or bundle (.msixbundle). Defaults to <name>_<version>_<arch>.msix for single packages, or <name>_<version>_<arch1>_<arch2>.msixbundle for bundles. |
 | `publisher` | `string \| undefined` | No | Publisher name for certificate generation |
 | `selfContained` | `boolean \| undefined` | No | Bundle Windows App SDK runtime for self-contained deployment |
 | `skipPri` | `boolean \| undefined` | No | Skip PRI file generation |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -254,6 +254,31 @@ winapp pack ./publish/x64 ./publish/arm64 --self-contained --generate-cert
 
 The command auto-detects each folder's architecture from the primary executable's PE header, validates consistency across slices (Identity, Capabilities, Dependencies), and produces a `<Name>_<Version>_<arch1>_<arch2>.msixbundle`.
 
+**Manifest resolution for bundles:**
+
+Each slice in the bundle needs a manifest. The command resolves manifests in this order:
+
+1. **`--manifest <path>`** — If specified, this single manifest is used for all slices. The `ProcessorArchitecture` is automatically updated per-slice to match the detected architecture.
+
+2. **Per-folder manifest** — If each input folder contains a `Package.appxmanifest` (or `appxmanifest.xml`), that folder's manifest is used for its slice.
+
+3. **Current directory fallback** — If a folder has no manifest, the command looks for `Package.appxmanifest` in the current working directory and uses it (with architecture auto-stamped).
+
+In all cases, the manifest is automatically updated: placeholders are resolved, dependencies are injected, and the `ProcessorArchitecture` is force-set to the detected architecture. After resolution, a cross-slice validation ensures that Identity (Name, Version, Publisher), Capabilities, and Dependencies are consistent across all slices — only `ProcessorArchitecture` may differ.
+
+```bash
+# Option 1: Single shared manifest (simplest for most projects)
+# Place Package.appxmanifest in your project root and run from there
+winapp pack ./publish/x64 ./publish/arm64
+
+# Option 2: Explicit manifest path
+winapp pack ./publish/x64 ./publish/arm64 --manifest ./src/Package.appxmanifest
+
+# Option 3: Per-folder manifests (useful if slices have different app extensions)
+# Each folder already contains its own Package.appxmanifest
+winapp pack ./publish/x64 ./publish/arm64
+```
+
 ---
 
 ### create-debug-identity

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -163,7 +163,7 @@ winapp pack <input-folder> [input-folder...] [options]
 
 **Options:**
 
-- `--output <filename>` - Output MSIX file name (default: `<name>_<version>_<arch>.msix`, falling back to `<name>_<version>.msix`, `<name>_<arch>.msix`, or `<name>.msix` when version/arch can't be determined)
+- `--output <filename>` - Output file name. For single packages: `<name>_<version>_<arch>.msix` (falling back to `<name>_<version>.msix`, `<name>_<arch>.msix`, or `<name>.msix`). For bundles: `<name>_<version>_<arch1>_<arch2>.msixbundle`.
 - `--name <name>` - Package name (default: from manifest)
 - `--manifest <path>` - Path to manifest file (`Package.appxmanifest` preferred, `appxmanifest.xml` also supported; default: auto-detect)
 - `--cert <path>` - Path to signing certificate (enables auto-signing)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -151,13 +151,15 @@ winapp update --setup-sdks experimental
 
 Create MSIX packages from prepared application directories. Requires a manifest file (`Package.appxmanifest` preferred, `appxmanifest.xml` also supported) to be present in the target directory, in the current directory, or passed with the `--manifest` option. (run `init` or `manifest generate` to create a manifest)
 
+Pass multiple input folders to create an `.msixbundle` for multi-architecture distribution (see [Multi-architecture bundles](#multi-architecture-bundles) below).
+
 ```bash
-winapp pack <input-folder> [options]
+winapp pack <input-folder> [input-folder...] [options]
 ```
 
 **Arguments:**
 
-- `input-folder` - Directory containing the application files to package
+- `input-folder` - One or more directories containing the application files to package. Pass multiple folders (e.g., `./publish/x64 ./publish/arm64`) to create an MSIX bundle.
 
 **Options:**
 
@@ -213,6 +215,23 @@ winapp pack ./dist --generate-cert --install-cert --self-contained
 # Package with explicit executable (resolves $targetnametoken$ in manifest)
 winapp pack ./dist --executable MyApp.exe
 ```
+
+#### Multi-architecture bundles
+
+When multiple input folders are passed, `winapp pack` creates an `.msixbundle` containing one `.msix` per architecture:
+
+```bash
+# Create unsigned bundle for Microsoft Store submission
+winapp pack ./publish/x64 ./publish/arm64
+
+# Create signed bundle for sideloading
+winapp pack ./publish/x64 ./publish/arm64 --cert ./devcert.pfx
+
+# Self-contained bundle
+winapp pack ./publish/x64 ./publish/arm64 --self-contained --generate-cert
+```
+
+The command auto-detects each folder's architecture from the primary executable's PE header, validates consistency across slices (Identity, Capabilities, Dependencies), and produces a `<Name>_<Version>_<arch1>_<arch2>.msixbundle`.
 
 ---
 

--- a/samples/dotnet-app/test.Tests.ps1
+++ b/samples/dotnet-app/test.Tests.ps1
@@ -158,6 +158,37 @@ Describe ".NET App Guide Workflow" {
                 $msix | Should -Not -BeNullOrEmpty
             }
         }
+
+        Context "Multi-architecture Bundle" {
+            It "Should publish for x64" -Skip:$script:skip {
+                Push-Location $script:projectDir
+                try {
+                    Invoke-Expression "dotnet publish -c Release -r win-x64 --self-contained false -o publish/x64"
+                    $LASTEXITCODE | Should -Be 0
+                } finally { Pop-Location }
+            }
+
+            It "Should publish for arm64" -Skip:$script:skip {
+                Push-Location $script:projectDir
+                try {
+                    Invoke-Expression "dotnet publish -c Release -r win-arm64 --self-contained false -o publish/arm64"
+                    $LASTEXITCODE | Should -Be 0
+                } finally { Pop-Location }
+            }
+
+            It "Should create an MSIX bundle from both folders" -Skip:$script:skip {
+                Push-Location $script:projectDir
+                try {
+                    Invoke-WinappCommand -Arguments "pack publish/x64 publish/arm64 --manifest Package.appxmanifest --cert devcert.pfx"
+                } finally { Pop-Location }
+            }
+
+            It "Should have produced an .msixbundle file" -Skip:$script:skip {
+                $bundle = Get-ChildItem -Path $script:projectDir -Filter "*.msixbundle" |
+                    Select-Object -First 1
+                $bundle | Should -Not -BeNullOrEmpty
+            }
+        }
     }
 
     Context "Phase 2: Sample Build Check" {

--- a/src/winapp-CLI/WinApp.Cli.Tests/BundleServiceTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/BundleServiceTests.cs
@@ -1,0 +1,117 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Spectre.Console.Testing;
+using WinApp.Cli.ConsoleTasks;
+using WinApp.Cli.Services;
+using WinApp.Cli.Tools;
+
+namespace WinApp.Cli.Tests;
+
+[TestClass]
+public class BundleServiceTests
+{
+    private DirectoryInfo _tempDir = null!;
+    private CapturingBuildToolsService _buildToolsService = null!;
+    private BundleService _service = null!;
+    private TaskContext _taskContext = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _tempDir = new DirectoryInfo(Path.Combine(Path.GetTempPath(), $"BundleSvcTest_{Guid.NewGuid():N}"));
+        _tempDir.Create();
+        _buildToolsService = new CapturingBuildToolsService();
+        _service = new BundleService(_buildToolsService, NullLogger<BundleService>.Instance);
+
+        var task = new GroupableTask("test", null);
+        var console = new TestConsole();
+        var logger = NullLogger<BundleService>.Instance;
+        var renderLock = new Lock();
+        _taskContext = new TaskContext(task, null, console, logger, renderLock);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (_tempDir.Exists)
+        {
+            _tempDir.Delete(recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public async Task CreateBundleAsync_EmptyList_ThrowsArgumentException()
+    {
+        var output = new FileInfo(Path.Combine(_tempDir.FullName, "out.msixbundle"));
+
+        await Assert.ThrowsExactlyAsync<ArgumentException>(() =>
+            _service.CreateBundleAsync([], output, _taskContext));
+    }
+
+    [TestMethod]
+    public async Task CreateBundleAsync_MultipleMsixFiles_InvokesMakeappxBundleWithCorrectArgs()
+    {
+        // Arrange
+        var file1 = CreateFakeMsix("app_x64.msix");
+        var file2 = CreateFakeMsix("app_arm64.msix");
+        var output = new FileInfo(Path.Combine(_tempDir.FullName, "output", "app.msixbundle"));
+
+        // Act
+        await _service.CreateBundleAsync([file1, file2], output, _taskContext);
+
+        // Assert
+        Assert.AreEqual(1, _buildToolsService.Invocations.Count);
+        var (toolName, args) = _buildToolsService.Invocations[0];
+        Assert.AreEqual("makeappx.exe", toolName);
+        StringAssert.Contains(args, "bundle");
+        StringAssert.Contains(args, "/p");
+        StringAssert.Contains(args, "app.msixbundle");
+    }
+
+    [TestMethod]
+    public async Task CreateBundleAsync_CreatesOutputDirectory()
+    {
+        // Arrange
+        var file1 = CreateFakeMsix("slice.msix");
+        var outputDir = Path.Combine(_tempDir.FullName, "nested", "dir");
+        var output = new FileInfo(Path.Combine(outputDir, "bundle.msixbundle"));
+
+        // Act
+        await _service.CreateBundleAsync([file1], output, _taskContext);
+
+        // Assert
+        Assert.IsTrue(Directory.Exists(outputDir));
+    }
+
+    private FileInfo CreateFakeMsix(string name)
+    {
+        var path = Path.Combine(_tempDir.FullName, name);
+        File.WriteAllText(path, "fake msix content");
+        return new FileInfo(path);
+    }
+
+    /// <summary>
+    /// Captures build tool invocations without actually running anything.
+    /// </summary>
+    private sealed class CapturingBuildToolsService : IBuildToolsService
+    {
+        public List<(string ToolName, string Arguments)> Invocations { get; } = [];
+
+        public FileInfo? GetBuildToolPath(string toolName) => new(Path.Combine(Path.GetTempPath(), toolName));
+
+        public Task<FileInfo> EnsureBuildToolAvailableAsync(string toolName, TaskContext taskContext, CancellationToken cancellationToken = default)
+            => Task.FromResult(new FileInfo(Path.Combine(Path.GetTempPath(), toolName)));
+
+        public Task<DirectoryInfo?> EnsureBuildToolsAsync(TaskContext taskContext, bool forceLatest = false, CancellationToken cancellationToken = default)
+            => Task.FromResult<DirectoryInfo?>(null);
+
+        public Task<(string stdout, string stderr)> RunBuildToolAsync(Tool tool, string arguments, TaskContext taskContext, bool printErrors = true, CancellationToken cancellationToken = default)
+        {
+            Invocations.Add((tool.ExecutableName, arguments));
+            return Task.FromResult(("", ""));
+        }
+    }
+}

--- a/src/winapp-CLI/WinApp.Cli.Tests/BundleValidationServiceTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/BundleValidationServiceTests.cs
@@ -203,4 +203,148 @@ public class BundleValidationServiceTests
     }
 
     #endregion
+
+    #region PackageDependency Consistency
+
+    [TestMethod]
+    public void Validate_MismatchedPackageDependency_ReturnsError()
+    {
+        var xml1 = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<Package xmlns=""http://schemas.microsoft.com/appx/manifest/foundation/windows10"">
+  <Identity Name=""App"" Publisher=""CN=Test"" Version=""1.0.0.0"" ProcessorArchitecture=""x64"" />
+  <Dependencies>
+    <TargetDeviceFamily Name=""Windows.Desktop"" MinVersion=""10.0.19041.0"" MaxVersionTested=""10.0.22621.0"" />
+    <PackageDependency Name=""Microsoft.VCLibs.140.00"" MinVersion=""14.0.30704.0"" Publisher=""CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"" />
+  </Dependencies>
+  <Applications>
+    <Application Id=""App"" Executable=""a.exe"" EntryPoint=""Windows.FullTrustApplication"" />
+  </Applications>
+</Package>";
+        var xml2 = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<Package xmlns=""http://schemas.microsoft.com/appx/manifest/foundation/windows10"">
+  <Identity Name=""App"" Publisher=""CN=Test"" Version=""1.0.0.0"" ProcessorArchitecture=""arm64"" />
+  <Dependencies>
+    <TargetDeviceFamily Name=""Windows.Desktop"" MinVersion=""10.0.19041.0"" MaxVersionTested=""10.0.22621.0"" />
+    <PackageDependency Name=""Microsoft.VCLibs.140.00"" MinVersion=""14.0.33519.0"" Publisher=""CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"" />
+  </Dependencies>
+  <Applications>
+    <Application Id=""App"" Executable=""a.exe"" EntryPoint=""Windows.FullTrustApplication"" />
+  </Applications>
+</Package>";
+
+        var manifests = new[] { AppxManifestDocument.Parse(xml1), AppxManifestDocument.Parse(xml2) };
+        var arches = new[] { "x64", "arm64" };
+        var folders = new[] { CreateFolder("x64"), CreateFolder("arm64") };
+
+        var errors = _service.Validate(manifests, arches, folders);
+
+        Assert.IsTrue(errors.Any(e => e.Field == "Dependencies/PackageDependency"));
+    }
+
+    [TestMethod]
+    public void Validate_MatchingPackageDependencies_NoErrors()
+    {
+        var xml1 = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<Package xmlns=""http://schemas.microsoft.com/appx/manifest/foundation/windows10"">
+  <Identity Name=""App"" Publisher=""CN=Test"" Version=""1.0.0.0"" ProcessorArchitecture=""x64"" />
+  <Dependencies>
+    <TargetDeviceFamily Name=""Windows.Desktop"" MinVersion=""10.0.19041.0"" MaxVersionTested=""10.0.22621.0"" />
+    <PackageDependency Name=""Microsoft.VCLibs.140.00"" MinVersion=""14.0.30704.0"" Publisher=""CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"" />
+  </Dependencies>
+  <Applications>
+    <Application Id=""App"" Executable=""a.exe"" EntryPoint=""Windows.FullTrustApplication"" />
+  </Applications>
+</Package>";
+        var xml2 = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<Package xmlns=""http://schemas.microsoft.com/appx/manifest/foundation/windows10"">
+  <Identity Name=""App"" Publisher=""CN=Test"" Version=""1.0.0.0"" ProcessorArchitecture=""arm64"" />
+  <Dependencies>
+    <TargetDeviceFamily Name=""Windows.Desktop"" MinVersion=""10.0.19041.0"" MaxVersionTested=""10.0.22621.0"" />
+    <PackageDependency Name=""Microsoft.VCLibs.140.00"" MinVersion=""14.0.30704.0"" Publisher=""CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"" />
+  </Dependencies>
+  <Applications>
+    <Application Id=""App"" Executable=""a.exe"" EntryPoint=""Windows.FullTrustApplication"" />
+  </Applications>
+</Package>";
+
+        var manifests = new[] { AppxManifestDocument.Parse(xml1), AppxManifestDocument.Parse(xml2) };
+        var arches = new[] { "x64", "arm64" };
+        var folders = new[] { CreateFolder("x64"), CreateFolder("arm64") };
+
+        var errors = _service.Validate(manifests, arches, folders);
+
+        Assert.AreEqual(0, errors.Count);
+    }
+
+    #endregion
+
+    #region TargetDeviceFamily Consistency
+
+    [TestMethod]
+    public void Validate_MismatchedTargetDeviceFamily_ReturnsError()
+    {
+        var xml1 = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<Package xmlns=""http://schemas.microsoft.com/appx/manifest/foundation/windows10"">
+  <Identity Name=""App"" Publisher=""CN=Test"" Version=""1.0.0.0"" ProcessorArchitecture=""x64"" />
+  <Dependencies>
+    <TargetDeviceFamily Name=""Windows.Desktop"" MinVersion=""10.0.19041.0"" MaxVersionTested=""10.0.22621.0"" />
+  </Dependencies>
+  <Applications>
+    <Application Id=""App"" Executable=""a.exe"" EntryPoint=""Windows.FullTrustApplication"" />
+  </Applications>
+</Package>";
+        var xml2 = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<Package xmlns=""http://schemas.microsoft.com/appx/manifest/foundation/windows10"">
+  <Identity Name=""App"" Publisher=""CN=Test"" Version=""1.0.0.0"" ProcessorArchitecture=""arm64"" />
+  <Dependencies>
+    <TargetDeviceFamily Name=""Windows.Desktop"" MinVersion=""10.0.22000.0"" MaxVersionTested=""10.0.22621.0"" />
+  </Dependencies>
+  <Applications>
+    <Application Id=""App"" Executable=""a.exe"" EntryPoint=""Windows.FullTrustApplication"" />
+  </Applications>
+</Package>";
+
+        var manifests = new[] { AppxManifestDocument.Parse(xml1), AppxManifestDocument.Parse(xml2) };
+        var arches = new[] { "x64", "arm64" };
+        var folders = new[] { CreateFolder("x64"), CreateFolder("arm64") };
+
+        var errors = _service.Validate(manifests, arches, folders);
+
+        Assert.IsTrue(errors.Any(e => e.Field == "Dependencies/TargetDeviceFamily"));
+    }
+
+    [TestMethod]
+    public void Validate_MatchingTargetDeviceFamily_NoErrors()
+    {
+        var xml1 = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<Package xmlns=""http://schemas.microsoft.com/appx/manifest/foundation/windows10"">
+  <Identity Name=""App"" Publisher=""CN=Test"" Version=""1.0.0.0"" ProcessorArchitecture=""x64"" />
+  <Dependencies>
+    <TargetDeviceFamily Name=""Windows.Desktop"" MinVersion=""10.0.19041.0"" MaxVersionTested=""10.0.22621.0"" />
+  </Dependencies>
+  <Applications>
+    <Application Id=""App"" Executable=""a.exe"" EntryPoint=""Windows.FullTrustApplication"" />
+  </Applications>
+</Package>";
+        var xml2 = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<Package xmlns=""http://schemas.microsoft.com/appx/manifest/foundation/windows10"">
+  <Identity Name=""App"" Publisher=""CN=Test"" Version=""1.0.0.0"" ProcessorArchitecture=""arm64"" />
+  <Dependencies>
+    <TargetDeviceFamily Name=""Windows.Desktop"" MinVersion=""10.0.19041.0"" MaxVersionTested=""10.0.22621.0"" />
+  </Dependencies>
+  <Applications>
+    <Application Id=""App"" Executable=""a.exe"" EntryPoint=""Windows.FullTrustApplication"" />
+  </Applications>
+</Package>";
+
+        var manifests = new[] { AppxManifestDocument.Parse(xml1), AppxManifestDocument.Parse(xml2) };
+        var arches = new[] { "x64", "arm64" };
+        var folders = new[] { CreateFolder("x64"), CreateFolder("arm64") };
+
+        var errors = _service.Validate(manifests, arches, folders);
+
+        Assert.AreEqual(0, errors.Count);
+    }
+
+    #endregion
 }

--- a/src/winapp-CLI/WinApp.Cli.Tests/BundleValidationServiceTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/BundleValidationServiceTests.cs
@@ -1,0 +1,206 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using WinApp.Cli.Services;
+
+namespace WinApp.Cli.Tests;
+
+[TestClass]
+public class BundleValidationServiceTests
+{
+    private BundleValidationService _service = null!;
+    private DirectoryInfo _tempDir = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _service = new BundleValidationService();
+        _tempDir = new DirectoryInfo(Path.Combine(Path.GetTempPath(), $"BundleValidTest_{Guid.NewGuid():N}"));
+        _tempDir.Create();
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (_tempDir.Exists)
+        {
+            _tempDir.Delete(recursive: true);
+        }
+    }
+
+    private static AppxManifestDocument CreateManifest(
+        string name = "TestApp",
+        string publisher = "CN=TestPublisher",
+        string version = "1.0.0.0",
+        string arch = "x64",
+        string? capability = null)
+    {
+        var xml = $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<Package xmlns=""http://schemas.microsoft.com/appx/manifest/foundation/windows10""
+         xmlns:uap=""http://schemas.microsoft.com/appx/manifest/uap/windows10"">
+  <Identity Name=""{name}"" Publisher=""{publisher}"" Version=""{version}"" ProcessorArchitecture=""{arch}"" />
+  <Dependencies>
+    <TargetDeviceFamily Name=""Windows.Desktop"" MinVersion=""10.0.19041.0"" MaxVersionTested=""10.0.22621.0"" />
+  </Dependencies>
+  <Capabilities>
+    <Capability Name=""internetClient"" />{(capability != null ? $"\n    <Capability Name=\"{capability}\" />" : "")}
+  </Capabilities>
+  <Applications>
+    <Application Id=""App"" Executable=""MyApp.exe"" EntryPoint=""Windows.FullTrustApplication"">
+      <uap:VisualElements DisplayName=""TestApp"" Description=""Test"" Square150x150Logo=""logo.png"" Square44x44Logo=""logo.png"" BackgroundColor=""transparent"" />
+    </Application>
+  </Applications>
+</Package>";
+        return AppxManifestDocument.Parse(xml);
+    }
+
+    private DirectoryInfo CreateFolder(string name)
+    {
+        var dir = new DirectoryInfo(Path.Combine(_tempDir.FullName, name));
+        dir.Create();
+        return dir;
+    }
+
+    #region Architecture Validation
+
+    [TestMethod]
+    public void Validate_DuplicateArchitectures_ReturnsError()
+    {
+        var manifests = new[] { CreateManifest(arch: "x64"), CreateManifest(arch: "x64") };
+        var arches = new[] { "x64", "x64" };
+        var folders = new[] { CreateFolder("a"), CreateFolder("b") };
+
+        var errors = _service.Validate(manifests, arches, folders);
+
+        Assert.IsTrue(errors.Any(e => e.Field == "Architecture" && e.Message.Contains("Duplicate")));
+    }
+
+    [TestMethod]
+    public void Validate_AllNeutral_ReturnsError()
+    {
+        var manifests = new[] { CreateManifest(arch: "neutral"), CreateManifest(arch: "neutral") };
+        var arches = new[] { "neutral", "neutral" };
+        var folders = new[] { CreateFolder("a"), CreateFolder("b") };
+
+        var errors = _service.Validate(manifests, arches, folders);
+
+        Assert.IsTrue(errors.Any(e => e.Field == "Architecture" && e.Message.Contains("neutral")));
+    }
+
+    [TestMethod]
+    public void Validate_ValidArchitectures_NoErrors()
+    {
+        var manifests = new[] { CreateManifest(arch: "x64"), CreateManifest(arch: "arm64") };
+        var arches = new[] { "x64", "arm64" };
+        var folders = new[] { CreateFolder("x64"), CreateFolder("arm64") };
+
+        var errors = _service.Validate(manifests, arches, folders);
+
+        Assert.AreEqual(0, errors.Count);
+    }
+
+    #endregion
+
+    #region Identity Consistency
+
+    [TestMethod]
+    public void Validate_MismatchedVersion_ReturnsError()
+    {
+        var manifests = new[] { CreateManifest(version: "1.0.0.0"), CreateManifest(version: "2.0.0.0") };
+        var arches = new[] { "x64", "arm64" };
+        var folders = new[] { CreateFolder("x64"), CreateFolder("arm64") };
+
+        var errors = _service.Validate(manifests, arches, folders);
+
+        Assert.IsTrue(errors.Any(e => e.Field == "Identity/@Version"));
+    }
+
+    [TestMethod]
+    public void Validate_MismatchedName_ReturnsError()
+    {
+        var manifests = new[] { CreateManifest(name: "AppA"), CreateManifest(name: "AppB") };
+        var arches = new[] { "x64", "arm64" };
+        var folders = new[] { CreateFolder("x64"), CreateFolder("arm64") };
+
+        var errors = _service.Validate(manifests, arches, folders);
+
+        Assert.IsTrue(errors.Any(e => e.Field == "Identity/@Name"));
+    }
+
+    [TestMethod]
+    public void Validate_MismatchedPublisher_ReturnsError()
+    {
+        var manifests = new[] { CreateManifest(publisher: "CN=A"), CreateManifest(publisher: "CN=B") };
+        var arches = new[] { "x64", "arm64" };
+        var folders = new[] { CreateFolder("x64"), CreateFolder("arm64") };
+
+        var errors = _service.Validate(manifests, arches, folders);
+
+        Assert.IsTrue(errors.Any(e => e.Field == "Identity/@Publisher"));
+    }
+
+    [TestMethod]
+    public void Validate_MatchingIdentity_NoErrors()
+    {
+        var manifests = new[] { CreateManifest(), CreateManifest() };
+        var arches = new[] { "x64", "arm64" };
+        var folders = new[] { CreateFolder("x64"), CreateFolder("arm64") };
+
+        var errors = _service.Validate(manifests, arches, folders);
+
+        Assert.AreEqual(0, errors.Count);
+    }
+
+    #endregion
+
+    #region Capabilities Consistency
+
+    [TestMethod]
+    public void Validate_MismatchedCapabilities_ReturnsError()
+    {
+        var manifests = new[]
+        {
+            CreateManifest(capability: "microphone"),
+            CreateManifest() // only internetClient
+        };
+        var arches = new[] { "x64", "arm64" };
+        var folders = new[] { CreateFolder("x64"), CreateFolder("arm64") };
+
+        var errors = _service.Validate(manifests, arches, folders);
+
+        Assert.IsTrue(errors.Any(e => e.Field == "Capabilities"));
+    }
+
+    #endregion
+
+    #region Applications Consistency
+
+    [TestMethod]
+    public void Validate_DifferentAppId_ReturnsError()
+    {
+        var xml1 = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<Package xmlns=""http://schemas.microsoft.com/appx/manifest/foundation/windows10"">
+  <Identity Name=""App"" Publisher=""CN=Test"" Version=""1.0.0.0"" ProcessorArchitecture=""x64"" />
+  <Applications>
+    <Application Id=""App1"" Executable=""a.exe"" EntryPoint=""Windows.FullTrustApplication"" />
+  </Applications>
+</Package>";
+        var xml2 = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<Package xmlns=""http://schemas.microsoft.com/appx/manifest/foundation/windows10"">
+  <Identity Name=""App"" Publisher=""CN=Test"" Version=""1.0.0.0"" ProcessorArchitecture=""arm64"" />
+  <Applications>
+    <Application Id=""App2"" Executable=""a.exe"" EntryPoint=""Windows.FullTrustApplication"" />
+  </Applications>
+</Package>";
+
+        var manifests = new[] { AppxManifestDocument.Parse(xml1), AppxManifestDocument.Parse(xml2) };
+        var arches = new[] { "x64", "arm64" };
+        var folders = new[] { CreateFolder("x64"), CreateFolder("arm64") };
+
+        var errors = _service.Validate(manifests, arches, folders);
+
+        Assert.IsTrue(errors.Any(e => e.Field == "Applications"));
+    }
+
+    #endregion
+}

--- a/src/winapp-CLI/WinApp.Cli.Tests/EndToEndTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/EndToEndTests.cs
@@ -559,7 +559,7 @@ public class EndToEndTests : BaseCommandTests
         Assert.AreNotEqual(0, result.ExitCode, "Command should fail for non-existent package input folder.");
         var combinedOutput = $"{result.Output}\n{result.Error}";
         Assert.IsTrue(
-            combinedOutput.Contains("Input folder not found", StringComparison.OrdinalIgnoreCase)
+            combinedOutput.Contains("Input folder(s) not found:", StringComparison.OrdinalIgnoreCase)
                 || combinedOutput.Contains("Directory does not exist", StringComparison.OrdinalIgnoreCase),
             $"Expected package missing-folder error to be surfaced. Output: {combinedOutput}");
     }

--- a/src/winapp-CLI/WinApp.Cli.Tests/FakeMsixService.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/FakeMsixService.cs
@@ -63,4 +63,24 @@ internal class FakeMsixService : IMsixService
     {
         return Task.FromResult(new CreateMsixPackageResult(new FileInfo("fake.msix"), false));
     }
+
+    public Task<CreateMsixBundleResult> CreateMsixBundleAsync(
+        DirectoryInfo[] inputFolders,
+        FileSystemInfo? outputPath,
+        TaskContext taskContext,
+        string? packageName = null,
+        bool skipPri = false,
+        bool autoSign = false,
+        FileInfo? certificatePath = null,
+        string certificatePassword = "password",
+        bool generateDevCert = false,
+        bool installDevCert = false,
+        string? publisher = null,
+        FileInfo? manifestPath = null,
+        bool selfContained = false,
+        string? executable = null,
+        CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(new CreateMsixBundleResult(new FileInfo("fake.msixbundle"), false, []));
+    }
 }

--- a/src/winapp-CLI/WinApp.Cli.Tests/MsixServiceBundleOrchestrationTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/MsixServiceBundleOrchestrationTests.cs
@@ -76,12 +76,16 @@ internal sealed class FakeBuildToolsService : IBuildToolsService
     {
         Invocations.Add((tool.ExecutableName, arguments));
 
-        var match = OutputPathRegex.Match(arguments);
-        if (match.Success)
+        // Only create fake output files for makeappx (not signtool or other tools)
+        if (tool.ExecutableName.Contains("makeappx", StringComparison.OrdinalIgnoreCase))
         {
-            var outputPath = NormalizeLongPath(match.Groups["path"].Value);
-            Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
-            File.WriteAllText(outputPath, $"fake {tool.ExecutableName} output");
+            var match = OutputPathRegex.Match(arguments);
+            if (match.Success)
+            {
+                var outputPath = NormalizeLongPath(match.Groups["path"].Value);
+                Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+                File.WriteAllText(outputPath, $"fake {tool.ExecutableName} output");
+            }
         }
 
         return Task.FromResult<(string stdout, string stderr)>((string.Empty, string.Empty));
@@ -400,6 +404,87 @@ public class MsixServiceBundleOrchestrationTests : BaseCommandTests
         return folder;
     }
 
+    [TestMethod]
+    public async Task CreateMsixBundleAsync_NeutralArchWithSelfContained_ThrowsWithClearError()
+    {
+        // Arrange - create folders with neutral PE (AnyCPU managed IL)
+        var neutralFolder = _tempDirectory.CreateSubdirectory("neutral-slice");
+        File.WriteAllBytes(Path.Combine(neutralFolder.FullName, "TestApp.exe"), BuildManagedAnyCpuPe());
+        File.WriteAllBytes(Path.Combine(neutralFolder.FullName, "logo.png"), []);
+        File.WriteAllText(Path.Combine(neutralFolder.FullName, "Package.appxmanifest"), CreateManifestContent("neutral"));
+
+        var x64Folder = CreateSliceFolder("slice-x64-sc", 0x8664, "x64");
+
+        // Act & Assert
+        var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
+            _msixService.CreateMsixBundleAsync(
+                [neutralFolder, x64Folder],
+                outputPath: null,
+                TestTaskContext,
+                skipPri: true,
+                selfContained: true,
+                cancellationToken: TestContext.CancellationToken));
+
+        StringAssert.Contains(ex.Message, "Cannot use --self-contained with architecture-neutral slices");
+    }
+
+    [TestMethod]
+    public async Task CreateMsixBundleAsync_WithAutoSign_InvokesBundleServiceThenSigns()
+    {
+        // Arrange
+        var x64Folder = CreateSliceFolder("sign-x64", 0x8664, "x64");
+        var arm64Folder = CreateSliceFolder("sign-arm64", 0xAA64, "arm64");
+        var certPath = new FileInfo(Path.Combine(_tempDirectory.FullName, "test.pfx"));
+        const string password = "password";
+
+        // Generate a real self-signed certificate matching the test manifest publisher
+        using var rsa = System.Security.Cryptography.RSA.Create(2048);
+        var req = new System.Security.Cryptography.X509Certificates.CertificateRequest(
+            "CN=TestPublisher", rsa, System.Security.Cryptography.HashAlgorithmName.SHA256,
+            System.Security.Cryptography.RSASignaturePadding.Pkcs1);
+        using var cert = req.CreateSelfSigned(DateTimeOffset.Now, DateTimeOffset.Now.AddDays(1));
+        var pfxBytes = cert.Export(System.Security.Cryptography.X509Certificates.X509ContentType.Pfx, password);
+        File.WriteAllBytes(certPath.FullName, pfxBytes);
+
+        // Act
+        var result = await _msixService.CreateMsixBundleAsync(
+            [x64Folder, arm64Folder],
+            outputPath: null,
+            TestTaskContext,
+            skipPri: true,
+            autoSign: true,
+            certificatePath: certPath,
+            certificatePassword: password,
+            cancellationToken: TestContext.CancellationToken);
+
+        // Assert - bundle was created
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result.Signed);
+        Assert.AreEqual(1, _fakeBundleService.CallCount);
+        // Signing invokes signtool
+        Assert.IsTrue(_fakeBuildToolsService.Invocations.Any(i =>
+            i.ToolName.Contains("signtool", StringComparison.OrdinalIgnoreCase)),
+            "Expected signtool invocation for bundle signing");
+    }
+
+    [TestMethod]
+    public async Task PackageCommand_MultipleFolders_SuccessfullyCreatesBundleViaCommand()
+    {
+        // Arrange - two valid folders, invoke through PackageCommand
+        var x64Folder = CreateSliceFolder("cmd-x64", 0x8664, "x64");
+        var arm64Folder = CreateSliceFolder("cmd-arm64", 0xAA64, "arm64");
+        var packageCommand = GetRequiredService<PackageCommand>();
+        var args = new[] { x64Folder.FullName, arm64Folder.FullName, "--skip-pri" };
+
+        // Act
+        var exitCode = await ParseAndInvokeWithCaptureAsync(packageCommand, args);
+
+        // Assert
+        Assert.AreEqual(0, exitCode, $"Expected success. Stderr: {ConsoleStdErr}");
+        Assert.AreEqual(1, _fakeBundleService.CallCount, "Bundle service should be called exactly once");
+        Assert.AreEqual(2, _fakeBundleService.LastMsixFiles!.Count, "Should produce two intermediate MSIX files");
+    }
+
     private static string CreateManifestContent(string processorArchitecture)
     {
         return $$"""
@@ -443,5 +528,17 @@ public class MsixServiceBundleOrchestrationTests : BaseCommandTests
         BitConverter.GetBytes(optionalHeaderMagic).CopyTo(peBytes, coffHeaderOffset + 20);
 
         return peBytes;
+    }
+
+    /// <summary>
+    /// Builds a minimal managed AnyCPU PE that PeHelper.DetectPeArchitecture returns "neutral" for.
+    /// Uses the test assembly itself as a source of a valid IL-only binary.
+    /// </summary>
+    private static byte[] BuildManagedAnyCpuPe()
+    {
+        // Use the test assembly's DLL as source — it's a valid IL-only managed assembly.
+        // Read it and return its bytes. The test project targets AnyCPU (arm64 runtime but IL-only).
+        var assemblyPath = typeof(MsixServiceBundleOrchestrationTests).Assembly.Location;
+        return File.ReadAllBytes(assemblyPath);
     }
 }

--- a/src/winapp-CLI/WinApp.Cli.Tests/MsixServiceBundleOrchestrationTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/MsixServiceBundleOrchestrationTests.cs
@@ -1,0 +1,286 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.DependencyInjection;
+using WinApp.Cli.ConsoleTasks;
+using WinApp.Cli.Models;
+using WinApp.Cli.Services;
+using WinApp.Cli.Tools;
+
+namespace WinApp.Cli.Tests;
+
+internal sealed class FakeBundleService : IBundleService
+{
+    public int CallCount { get; private set; }
+    public IReadOnlyList<FileInfo>? LastMsixFiles { get; private set; }
+    public FileInfo? LastOutput { get; private set; }
+
+    public Task CreateBundleAsync(IReadOnlyList<FileInfo> msixFiles, FileInfo output, TaskContext taskContext, CancellationToken cancellationToken = default)
+    {
+        CallCount++;
+        LastMsixFiles = msixFiles.ToList();
+        LastOutput = output;
+
+        output.Directory?.Create();
+        File.WriteAllText(output.FullName, "fake bundle");
+
+        return Task.CompletedTask;
+    }
+}
+
+internal sealed class FakeBundleValidationService : IBundleValidationService
+{
+    public int CallCount { get; private set; }
+    public IReadOnlyList<AppxManifestDocument>? LastSliceManifests { get; private set; }
+    public IReadOnlyList<string>? LastDetectedArchitectures { get; private set; }
+    public IReadOnlyList<DirectoryInfo>? LastInputFolders { get; private set; }
+    public IReadOnlyList<BundleValidationError> ErrorsToReturn { get; set; } = [];
+
+    public IReadOnlyList<BundleValidationError> Validate(
+        IReadOnlyList<AppxManifestDocument> sliceManifests,
+        IReadOnlyList<string> detectedArchitectures,
+        IReadOnlyList<DirectoryInfo> inputFolders)
+    {
+        CallCount++;
+        LastSliceManifests = sliceManifests.ToList();
+        LastDetectedArchitectures = detectedArchitectures.ToList();
+        LastInputFolders = inputFolders.ToList();
+        return ErrorsToReturn;
+    }
+}
+
+internal sealed class FakeBuildToolsService : IBuildToolsService
+{
+    private static readonly Regex OutputPathRegex = new("(?:^|\\s)/p\\s+\"(?<path>[^\"]+)\"", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    public List<(string ToolName, string Arguments)> Invocations { get; } = [];
+
+    public FileInfo? GetBuildToolPath(string toolName)
+    {
+        return new FileInfo(Path.Combine(Path.GetTempPath(), toolName));
+    }
+
+    public Task<FileInfo> EnsureBuildToolAvailableAsync(string toolName, TaskContext taskContext, CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(new FileInfo(Path.Combine(Path.GetTempPath(), toolName)));
+    }
+
+    public Task<DirectoryInfo?> EnsureBuildToolsAsync(TaskContext taskContext, bool forceLatest = false, CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult<DirectoryInfo?>(null);
+    }
+
+    public Task<(string stdout, string stderr)> RunBuildToolAsync(Tool tool, string arguments, TaskContext taskContext, bool printErrors = true, CancellationToken cancellationToken = default)
+    {
+        Invocations.Add((tool.ExecutableName, arguments));
+
+        var match = OutputPathRegex.Match(arguments);
+        if (match.Success)
+        {
+            var outputPath = NormalizeLongPath(match.Groups["path"].Value);
+            Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+            File.WriteAllText(outputPath, $"fake {tool.ExecutableName} output");
+        }
+
+        return Task.FromResult<(string stdout, string stderr)>((string.Empty, string.Empty));
+    }
+
+    private static string NormalizeLongPath(string path)
+    {
+        return path.StartsWith(@"\\?\", StringComparison.Ordinal) ? path[4..] : path;
+    }
+}
+
+[TestClass]
+public class MsixServiceBundleOrchestrationTests : BaseCommandTests
+{
+    private static readonly string[] ExpectedArchitectures = ["x64", "arm64"];
+    private static readonly string[] ExpectedPackageNames = ["TestApp", "TestApp"];
+
+    private MsixService _msixService = null!;
+    private FakeBundleService _fakeBundleService = null!;
+    private FakeBundleValidationService _fakeBundleValidationService = null!;
+    private FakeBuildToolsService _fakeBuildToolsService = null!;
+
+    protected override IServiceCollection ConfigureServices(IServiceCollection services)
+    {
+        _fakeBundleService = new FakeBundleService();
+        _fakeBundleValidationService = new FakeBundleValidationService();
+        _fakeBuildToolsService = new FakeBuildToolsService();
+
+        return services
+            .AddSingleton<IBundleService>(_fakeBundleService)
+            .AddSingleton<IBundleValidationService>(_fakeBundleValidationService)
+            .AddSingleton<IBuildToolsService>(_fakeBuildToolsService)
+            .AddSingleton<INugetService, FakeNugetService>();
+    }
+
+    [TestInitialize]
+    public void SetupService()
+    {
+        _msixService = (MsixService)GetRequiredService<IMsixService>();
+    }
+
+    [TestMethod]
+    public async Task CreateMsixBundleAsync_ValidationFails_ThrowsWithValidationErrors()
+    {
+        // Arrange
+        var x64Folder = CreateSliceFolder("slice-x64", 0x8664, "x64");
+        var arm64Folder = CreateSliceFolder("slice-arm64", 0xAA64, "arm64");
+
+        _fakeBundleValidationService.ErrorsToReturn =
+        [
+            new BundleValidationError(
+                "Identity/@Version",
+                "Identity/@Version differs across slices. All slices in a bundle must have the same Identity/@Version.",
+                [
+                    $"{x64Folder.Name}: \"1.0.0.0\"",
+                    $"{arm64Folder.Name}: \"2.0.0.0\""
+                ])
+        ];
+
+        // Act
+        var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
+            _msixService.CreateMsixBundleAsync(
+                [x64Folder, arm64Folder],
+                outputPath: null,
+                TestTaskContext,
+                skipPri: true,
+                cancellationToken: TestContext.CancellationToken));
+
+        // Assert
+        StringAssert.Contains(ex.Message, "Bundle validation failed. The following inconsistencies were found across slices:");
+        StringAssert.Contains(ex.Message, "Identity/@Version: Identity/@Version differs across slices. All slices in a bundle must have the same Identity/@Version.");
+        StringAssert.Contains(ex.Message, $"• {x64Folder.Name}: \"1.0.0.0\"");
+        StringAssert.Contains(ex.Message, $"• {arm64Folder.Name}: \"2.0.0.0\"");
+        Assert.AreEqual(1, _fakeBundleValidationService.CallCount);
+        Assert.AreEqual(0, _fakeBundleService.CallCount);
+        Assert.AreEqual(0, _fakeBuildToolsService.Invocations.Count);
+    }
+
+    [TestMethod]
+    public async Task CreateMsixBundleAsync_MultipleFolders_InvokesValidationWithCorrectArchitectures()
+    {
+        // Arrange
+        var x64Folder = CreateSliceFolder("slice-x64", 0x8664, "x64");
+        var arm64Folder = CreateSliceFolder("slice-arm64", 0xAA64, "arm64");
+
+        // Act
+        var result = await _msixService.CreateMsixBundleAsync(
+            [x64Folder, arm64Folder],
+            outputPath: null,
+            TestTaskContext,
+            skipPri: true,
+            cancellationToken: TestContext.CancellationToken);
+
+        // Assert
+        Assert.AreEqual(1, _fakeBundleValidationService.CallCount);
+        CollectionAssert.AreEqual(ExpectedArchitectures, _fakeBundleValidationService.LastDetectedArchitectures!.ToArray());
+        CollectionAssert.AreEqual(new[] { x64Folder.FullName, arm64Folder.FullName }, _fakeBundleValidationService.LastInputFolders!.Select(folder => folder.FullName).ToArray());
+        CollectionAssert.AreEqual(ExpectedArchitectures, _fakeBundleValidationService.LastSliceManifests!.Select(manifest => manifest.IdentityProcessorArchitecture).ToArray());
+        CollectionAssert.AreEqual(ExpectedPackageNames, _fakeBundleValidationService.LastSliceManifests!.Select(manifest => manifest.IdentityName).ToArray());
+        Assert.AreEqual(2, result.Slices.Count);
+        Assert.AreEqual(2, _fakeBuildToolsService.Invocations.Count);
+        Assert.AreEqual(1, _fakeBundleService.CallCount);
+    }
+
+    [TestMethod]
+    public async Task CreateMsixBundleAsync_OutputNaming_UsesIdentityFromManifest()
+    {
+        // Arrange
+        var x64Folder = CreateSliceFolder("slice-x64", 0x8664, "x64");
+        var arm64Folder = CreateSliceFolder("slice-arm64", 0xAA64, "arm64");
+        var outputDirectory = _tempDirectory.CreateSubdirectory("bundle-output");
+
+        // Act
+        var result = await _msixService.CreateMsixBundleAsync(
+            [x64Folder, arm64Folder],
+            outputDirectory,
+            TestTaskContext,
+            skipPri: true,
+            cancellationToken: TestContext.CancellationToken);
+
+        // Assert
+        var expectedPath = Path.Combine(outputDirectory.FullName, "TestApp_1.0.0.0_arm64_x64.msixbundle");
+        Assert.AreEqual(expectedPath, result.BundlePath.FullName);
+        Assert.AreEqual(expectedPath, _fakeBundleService.LastOutput!.FullName);
+        Assert.IsTrue(result.BundlePath.Exists);
+    }
+
+    [TestMethod]
+    public async Task CreateMsixBundleAsync_OutputPathWithMsixBundleExtension_UsesExplicitBundleFilePath()
+    {
+        // Arrange
+        var x64Folder = CreateSliceFolder("slice-x64", 0x8664, "x64");
+        var arm64Folder = CreateSliceFolder("slice-arm64", 0xAA64, "arm64");
+        var explicitOutputPath = new FileInfo(Path.Combine(_tempDirectory.FullName, "custom-output.msixbundle"));
+
+        // Act
+        var result = await _msixService.CreateMsixBundleAsync(
+            [x64Folder, arm64Folder],
+            explicitOutputPath,
+            TestTaskContext,
+            skipPri: true,
+            cancellationToken: TestContext.CancellationToken);
+
+        // Assert
+        Assert.AreEqual(explicitOutputPath.FullName, result.BundlePath.FullName);
+        Assert.AreEqual(explicitOutputPath.FullName, _fakeBundleService.LastOutput!.FullName);
+        Assert.IsTrue(result.BundlePath.Exists);
+    }
+
+    private DirectoryInfo CreateSliceFolder(string folderName, ushort machineType, string manifestArchitecture)
+    {
+        var folder = _tempDirectory.CreateSubdirectory(folderName);
+        File.WriteAllBytes(Path.Combine(folder.FullName, "TestApp.exe"), BuildMinimalNativePe(machineType));
+        File.WriteAllBytes(Path.Combine(folder.FullName, "logo.png"), []);
+        File.WriteAllText(Path.Combine(folder.FullName, "Package.appxmanifest"), CreateManifestContent(manifestArchitecture));
+        return folder;
+    }
+
+    private static string CreateManifestContent(string processorArchitecture)
+    {
+        return $$"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+                     xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10">
+              <Identity Name="TestApp" Publisher="CN=TestPublisher" Version="1.0.0.0" ProcessorArchitecture="{{processorArchitecture}}" />
+              <Dependencies>
+                <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.19041.0" MaxVersionTested="10.0.22621.0" />
+              </Dependencies>
+              <Capabilities>
+                <Capability Name="internetClient" />
+              </Capabilities>
+              <Applications>
+                <Application Id="App" Executable="TestApp.exe" EntryPoint="Windows.FullTrustApplication">
+                  <uap:VisualElements DisplayName="TestApp" Description="Test" Square150x150Logo="logo.png" Square44x44Logo="logo.png" BackgroundColor="transparent" />
+                </Application>
+              </Applications>
+            </Package>
+            """;
+    }
+
+    private static byte[] BuildMinimalNativePe(ushort machineType)
+    {
+        bool is64Bit = machineType is 0x8664 or 0xAA64;
+        ushort optionalHeaderSize = is64Bit ? (ushort)0xF0 : (ushort)0xE0;
+        int coffHeaderOffset = 0x84;
+        var peBytes = new byte[coffHeaderOffset + 20 + optionalHeaderSize + 64];
+
+        peBytes[0] = 0x4D;
+        peBytes[1] = 0x5A;
+        BitConverter.GetBytes(0x80).CopyTo(peBytes, 0x3C);
+        peBytes[0x80] = 0x50;
+        peBytes[0x81] = 0x45;
+
+        BitConverter.GetBytes(machineType).CopyTo(peBytes, coffHeaderOffset);
+        BitConverter.GetBytes(optionalHeaderSize).CopyTo(peBytes, coffHeaderOffset + 16);
+        peBytes[coffHeaderOffset + 18] = 0x02;
+
+        ushort optionalHeaderMagic = is64Bit ? (ushort)0x20B : (ushort)0x10B;
+        BitConverter.GetBytes(optionalHeaderMagic).CopyTo(peBytes, coffHeaderOffset + 20);
+
+        return peBytes;
+    }
+}

--- a/src/winapp-CLI/WinApp.Cli.Tests/MsixServiceBundleOrchestrationTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/MsixServiceBundleOrchestrationTests.cs
@@ -3,6 +3,7 @@
 
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.DependencyInjection;
+using WinApp.Cli.Commands;
 using WinApp.Cli.ConsoleTasks;
 using WinApp.Cli.Models;
 using WinApp.Cli.Services;
@@ -123,6 +124,112 @@ public class MsixServiceBundleOrchestrationTests : BaseCommandTests
     }
 
     [TestMethod]
+    public async Task CreateMsixBundleAsync_NoExecutableInFolder_ThrowsWithClearError()
+    {
+        // Arrange - folder with no .exe
+        var folder = _tempDirectory.CreateSubdirectory("no-exe-folder");
+        File.WriteAllBytes(Path.Combine(folder.FullName, "logo.png"), []);
+        File.WriteAllText(Path.Combine(folder.FullName, "Package.appxmanifest"), CreateManifestContent("x64"));
+
+        // Act & Assert
+        var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
+            _msixService.CreateMsixBundleAsync(
+                [folder],
+                outputPath: null,
+                TestTaskContext,
+                skipPri: true,
+                cancellationToken: TestContext.CancellationToken));
+
+        StringAssert.Contains(ex.Message, "no executable found");
+        StringAssert.Contains(ex.Message, folder.FullName);
+    }
+
+    [TestMethod]
+    public async Task CreateMsixBundleAsync_NoManifestInFolder_ThrowsFileNotFoundException()
+    {
+        // Arrange - folder with exe but no manifest
+        var folder = _tempDirectory.CreateSubdirectory("no-manifest-folder");
+        File.WriteAllBytes(Path.Combine(folder.FullName, "TestApp.exe"), BuildMinimalNativePe(0x8664));
+
+        // Act & Assert
+        var ex = await Assert.ThrowsExactlyAsync<FileNotFoundException>(() =>
+            _msixService.CreateMsixBundleAsync(
+                [folder],
+                outputPath: null,
+                TestTaskContext,
+                skipPri: true,
+                cancellationToken: TestContext.CancellationToken));
+
+        StringAssert.Contains(ex.Message, "Manifest file not found");
+    }
+
+    [TestMethod]
+    public async Task CreateMsixBundleAsync_RuntimeToolExeIsSkippedInAutoDetection_UsesRealExe()
+    {
+        // Arrange - folder with createdump.exe (runtime tool) and the real app exe
+        var folder = _tempDirectory.CreateSubdirectory("runtime-tool-folder");
+        // Put createdump.exe first alphabetically (c < t) to verify it's skipped
+        File.WriteAllBytes(Path.Combine(folder.FullName, "createdump.exe"), BuildMinimalNativePe(0x8664));
+        File.WriteAllBytes(Path.Combine(folder.FullName, "TestApp.exe"), BuildMinimalNativePe(0x8664));
+        File.WriteAllBytes(Path.Combine(folder.FullName, "logo.png"), []);
+        File.WriteAllText(Path.Combine(folder.FullName, "Package.appxmanifest"), CreateManifestContent("x64"));
+
+        var arm64Folder = CreateSliceFolder("slice-arm64", 0xAA64, "arm64");
+
+        // Act - should succeed because manifest specifies executable, so runtime tool filter 
+        // only affects the "last resort" fallback
+        var result = await _msixService.CreateMsixBundleAsync(
+            [folder, arm64Folder],
+            outputPath: null,
+            TestTaskContext,
+            skipPri: true,
+            cancellationToken: TestContext.CancellationToken);
+
+        // Assert
+        Assert.IsNotNull(result);
+        Assert.AreEqual(2, result.Slices.Count);
+    }
+
+    [TestMethod]
+    public async Task CreateMsixBundleAsync_OnlyRuntimeToolExeInFolder_ThrowsNoExecutableFound()
+    {
+        // Arrange - folder with ONLY runtime tool executables (no manifest exe reference)
+        var folder = _tempDirectory.CreateSubdirectory("only-runtime-tools");
+        File.WriteAllBytes(Path.Combine(folder.FullName, "createdump.exe"), BuildMinimalNativePe(0x8664));
+        File.WriteAllBytes(Path.Combine(folder.FullName, "logo.png"), []);
+        // Manifest does NOT reference an executable that exists
+        File.WriteAllText(Path.Combine(folder.FullName, "Package.appxmanifest"), """
+            <?xml version="1.0" encoding="utf-8"?>
+            <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+                     xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10">
+              <Identity Name="TestApp" Publisher="CN=TestPublisher" Version="1.0.0.0" ProcessorArchitecture="x64" />
+              <Dependencies>
+                <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.19041.0" MaxVersionTested="10.0.22621.0" />
+              </Dependencies>
+              <Capabilities>
+                <Capability Name="internetClient" />
+              </Capabilities>
+              <Applications>
+                <Application Id="App" Executable="MissingApp.exe" EntryPoint="Windows.FullTrustApplication">
+                  <uap:VisualElements DisplayName="TestApp" Description="Test" Square150x150Logo="logo.png" Square44x44Logo="logo.png" BackgroundColor="transparent" />
+                </Application>
+              </Applications>
+            </Package>
+            """);
+
+        // Act & Assert
+        var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
+            _msixService.CreateMsixBundleAsync(
+                [folder],
+                outputPath: null,
+                TestTaskContext,
+                skipPri: true,
+                cancellationToken: TestContext.CancellationToken));
+
+        StringAssert.Contains(ex.Message, "no executable found");
+    }
+
+    [TestMethod]
     public async Task CreateMsixBundleAsync_ValidationFails_ThrowsWithValidationErrors()
     {
         // Arrange
@@ -228,6 +335,60 @@ public class MsixServiceBundleOrchestrationTests : BaseCommandTests
         Assert.AreEqual(explicitOutputPath.FullName, result.BundlePath.FullName);
         Assert.AreEqual(explicitOutputPath.FullName, _fakeBundleService.LastOutput!.FullName);
         Assert.IsTrue(result.BundlePath.Exists);
+    }
+
+    [TestMethod]
+    public async Task PackageCommand_DuplicateInputFolders_ReturnsNonZeroExitCode()
+    {
+        // Arrange
+        var folder = CreateSliceFolder("dupe-folder", 0x8664, "x64");
+        var packageCommand = GetRequiredService<PackageCommand>();
+        var args = new[] { folder.FullName, folder.FullName, "--skip-pri" };
+
+        // Act
+        var exitCode = await ParseAndInvokeWithCaptureAsync(packageCommand, args);
+
+        // Assert
+        Assert.AreNotEqual(0, exitCode, "Should fail for duplicate input folders");
+        var output = ConsoleStdErr!.ToString();
+        StringAssert.Contains(output, "Duplicate input folder");
+    }
+
+    [TestMethod]
+    public async Task PackageCommand_BundleWithMsixExtension_ReturnsNonZeroExitCode()
+    {
+        // Arrange - two folders + .msix output (should require .msixbundle)
+        var x64Folder = CreateSliceFolder("ext-x64", 0x8664, "x64");
+        var arm64Folder = CreateSliceFolder("ext-arm64", 0xAA64, "arm64");
+        var packageCommand = GetRequiredService<PackageCommand>();
+        var outputPath = Path.Combine(_tempDirectory.FullName, "output.msix");
+        var args = new[] { x64Folder.FullName, arm64Folder.FullName, "--output", outputPath, "--skip-pri" };
+
+        // Act
+        var exitCode = await ParseAndInvokeWithCaptureAsync(packageCommand, args);
+
+        // Assert
+        Assert.AreNotEqual(0, exitCode, "Should fail for .msix extension with bundle");
+        var output = ConsoleStdErr!.ToString();
+        StringAssert.Contains(output, "Cannot use .msix extension");
+    }
+
+    [TestMethod]
+    public async Task PackageCommand_SingleFolderWithMsixBundleExtension_ReturnsNonZeroExitCode()
+    {
+        // Arrange - one folder + .msixbundle output (should require .msix)
+        var folder = CreateSliceFolder("single-folder", 0x8664, "x64");
+        var packageCommand = GetRequiredService<PackageCommand>();
+        var outputPath = Path.Combine(_tempDirectory.FullName, "output.msixbundle");
+        var args = new[] { folder.FullName, "--output", outputPath, "--skip-pri" };
+
+        // Act
+        var exitCode = await ParseAndInvokeWithCaptureAsync(packageCommand, args);
+
+        // Assert
+        Assert.AreNotEqual(0, exitCode, "Should fail for .msixbundle extension with single package");
+        var output = ConsoleStdErr!.ToString();
+        StringAssert.Contains(output, "Cannot use .msixbundle extension");
     }
 
     private DirectoryInfo CreateSliceFolder(string folderName, ushort machineType, string manifestArchitecture)

--- a/src/winapp-CLI/WinApp.Cli.Tests/MsixServiceTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/MsixServiceTests.cs
@@ -1183,6 +1183,8 @@ public class MsixServiceTests
             null!,
             null!,
             null!,
+            null!,
+            null!,
             NullLogger<MsixService>.Instance,
             new CurrentDirectoryProvider(_tempDir.FullName));
     }
@@ -1427,6 +1429,7 @@ public class MsixServiceTests
         return new MsixService(
             null!, null!, null!, null!, null!, null!, null!, null!, null!, null!,
             prs,
+            null!, null!,
             NullLogger<MsixService>.Instance,
             new CurrentDirectoryProvider(cwd));
     }

--- a/src/winapp-CLI/WinApp.Cli/Commands/PackageCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/PackageCommand.cs
@@ -12,7 +12,7 @@ internal class PackageCommand : Command, IShortDescription
 {
     public string ShortDescription => "Create MSIX package";
 
-    public static Argument<DirectoryInfo> InputFolderArgument { get; }
+    public static Argument<DirectoryInfo[]> InputFolderArgument { get; }
     public static Option<FileInfo> OutputOption { get; }
     public static Option<string?> NameOption { get; }
     public static Option<bool> SkipPriOption { get; }
@@ -27,12 +27,11 @@ internal class PackageCommand : Command, IShortDescription
 
     static PackageCommand()
     {
-        InputFolderArgument = new Argument<DirectoryInfo>("input-folder")
+        InputFolderArgument = new Argument<DirectoryInfo[]>("input-folder")
         {
-            Description = "Input folder with package layout",
-            Arity = ArgumentArity.ExactlyOne
+            Description = "One or more input folders with package layout. Pass multiple folders to create an MSIX bundle (e.g., winapp pack ./publish/x64 ./publish/arm64).",
+            Arity = ArgumentArity.OneOrMore
         };
-        InputFolderArgument.AcceptExistingOnly();
         OutputOption = new Option<FileInfo>("--output")
         {
             Description = "Output msix file name for the generated package (defaults to <name>_<version>_<arch>.msix, falling back to <name>_<version>.msix, <name>_<arch>.msix, or <name>.msix when version/arch can't be determined)",
@@ -106,7 +105,7 @@ internal class PackageCommand : Command, IShortDescription
     {
         public override async Task<int> InvokeAsync(ParseResult parseResult, CancellationToken cancellationToken = default)
         {
-            var inputFolder = parseResult.GetRequiredValue(InputFolderArgument);
+            var inputFolders = parseResult.GetRequiredValue(InputFolderArgument);
             var output = parseResult.GetValue(OutputOption);
             var name = parseResult.GetValue(NameOption);
             var skipPri = parseResult.GetValue(SkipPriOption);
@@ -119,29 +118,99 @@ internal class PackageCommand : Command, IShortDescription
             var selfContained = parseResult.GetValue(SelfContainedOption);
             var executable = parseResult.GetValue(ExecutableOption);
 
-            return await statusService.ExecuteWithStatusAsync("Creating MSIX package...", async (taskContext, cancellationToken) =>
+            // Validate all input folders exist (report all missing at once)
+            var missingDirs = inputFolders.Where(d => !d.Exists).ToList();
+            if (missingDirs.Count > 0)
             {
-                try
+                var missingPaths = string.Join(Environment.NewLine, missingDirs.Select(d => $"  {d.FullName}"));
+                return await statusService.ExecuteWithStatusAsync("Validating input...", (taskContext, _) =>
                 {
-                    // Auto-sign if certificate is provided or if generate-cert is specified
-                    var autoSign = certPath != null || generateCert;
+                    return Task.FromResult((1, $"{UiSymbols.Error} Input folder(s) not found:{Environment.NewLine}{missingPaths}"));
+                }, cancellationToken);
+            }
 
-                    var result = await msixService.CreateMsixPackageAsync(inputFolder, output, taskContext, name, skipPri, autoSign, certPath, certPassword, generateCert, installCert, publisher, manifestPath, selfContained, executable, cancellationToken);
+            // Reject duplicate paths (normalize and compare)
+            var normalizedPaths = inputFolders.Select(d => Path.GetFullPath(d.FullName).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)).ToList();
+            var duplicates = normalizedPaths.GroupBy(p => p, StringComparer.OrdinalIgnoreCase).Where(g => g.Count() > 1).Select(g => g.Key).ToList();
+            if (duplicates.Count > 0)
+            {
+                var dupPaths = string.Join(Environment.NewLine, duplicates.Select(d => $"  {d}"));
+                return await statusService.ExecuteWithStatusAsync("Validating input...", (taskContext, _) =>
+                {
+                    return Task.FromResult((1, $"{UiSymbols.Error} Duplicate input folder(s):{Environment.NewLine}{dupPaths}"));
+                }, cancellationToken);
+            }
 
-                    taskContext.AddStatusMessage($"{UiSymbols.Package} Package: {result.MsixPath}");
-                    if (result.Signed)
+            // Validate --output extension for bundle mode
+            if (inputFolders.Length > 1 && output != null)
+            {
+                var ext = Path.GetExtension(output.Name);
+                if (string.Equals(ext, ".msix", StringComparison.OrdinalIgnoreCase))
+                {
+                    return await statusService.ExecuteWithStatusAsync("Validating input...", (taskContext, _) =>
                     {
-                        taskContext.AddStatusMessage($"{UiSymbols.Lock} Package has been signed");
-                    }
+                        return Task.FromResult((1, $"{UiSymbols.Error} Cannot use .msix extension for --output when creating a bundle from multiple folders. Use .msixbundle or omit the extension."));
+                    }, cancellationToken);
+                }
+            }
 
-                    return (0, "MSIX package creation completed.");
-                }
-                catch (Exception ex)
+            if (inputFolders.Length == 1)
+            {
+                // Single folder: existing behavior unchanged
+                var inputFolder = inputFolders[0];
+                return await statusService.ExecuteWithStatusAsync("Creating MSIX package...", async (taskContext, cancellationToken) =>
                 {
-                    taskContext.AddDebugMessage($"Stack Trace: {ex.StackTrace}");
-                    return (1, $"{UiSymbols.Error} Failed to create MSIX package: {ex.GetBaseException().Message}");
-                }
-            }, cancellationToken);
+                    try
+                    {
+                        var autoSign = certPath != null || generateCert;
+
+                        var result = await msixService.CreateMsixPackageAsync(inputFolder, output, taskContext, name, skipPri, autoSign, certPath, certPassword, generateCert, installCert, publisher, manifestPath, selfContained, executable, cancellationToken);
+
+                        taskContext.AddStatusMessage($"{UiSymbols.Package} Package: {result.MsixPath}");
+                        if (result.Signed)
+                        {
+                            taskContext.AddStatusMessage($"{UiSymbols.Lock} Package has been signed");
+                        }
+
+                        return (0, "MSIX package creation completed.");
+                    }
+                    catch (Exception ex)
+                    {
+                        taskContext.AddDebugMessage($"Stack Trace: {ex.StackTrace}");
+                        return (1, $"{UiSymbols.Error} Failed to create MSIX package: {ex.GetBaseException().Message}");
+                    }
+                }, cancellationToken);
+            }
+            else
+            {
+                // Multiple folders: create MSIX bundle
+                return await statusService.ExecuteWithStatusAsync("Creating MSIX bundle...", async (taskContext, cancellationToken) =>
+                {
+                    try
+                    {
+                        var autoSign = certPath != null || generateCert;
+
+                        var result = await msixService.CreateMsixBundleAsync(inputFolders, output, taskContext, name, skipPri, autoSign, certPath, certPassword, generateCert, installCert, publisher, manifestPath, selfContained, executable, cancellationToken);
+
+                        taskContext.AddStatusMessage($"{UiSymbols.Package} Bundle: {result.BundlePath}");
+                        if (result.Signed)
+                        {
+                            taskContext.AddStatusMessage($"{UiSymbols.Lock} Bundle has been signed");
+                        }
+                        else
+                        {
+                            taskContext.AddStatusMessage($"Bundle is unsigned. For Store submission, upload as-is. For sideload, run `winapp sign`.");
+                        }
+
+                        return (0, "MSIX bundle creation completed.");
+                    }
+                    catch (Exception ex)
+                    {
+                        taskContext.AddDebugMessage($"Stack Trace: {ex.StackTrace}");
+                        return (1, $"{UiSymbols.Error} Failed to create MSIX bundle: {ex.GetBaseException().Message}");
+                    }
+                }, cancellationToken);
+            }
         }
     }
 }

--- a/src/winapp-CLI/WinApp.Cli/Commands/PackageCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/PackageCommand.cs
@@ -10,7 +10,7 @@ namespace WinApp.Cli.Commands;
 
 internal class PackageCommand : Command, IShortDescription
 {
-    public string ShortDescription => "Create MSIX package";
+    public string ShortDescription => "Create MSIX package or bundle";
 
     public static Argument<DirectoryInfo[]> InputFolderArgument { get; }
     public static Option<FileInfo> OutputOption { get; }
@@ -34,7 +34,7 @@ internal class PackageCommand : Command, IShortDescription
         };
         OutputOption = new Option<FileInfo>("--output")
         {
-            Description = "Output msix file name for the generated package (defaults to <name>_<version>_<arch>.msix, falling back to <name>_<version>.msix, <name>_<arch>.msix, or <name>.msix when version/arch can't be determined)",
+            Description = "Output file name for the generated package (.msix) or bundle (.msixbundle). Defaults to <name>_<version>_<arch>.msix for single packages, or <name>_<version>_<arch1>_<arch2>.msixbundle for bundles.",
         };
 
         NameOption = new Option<string?>("--name")
@@ -150,6 +150,19 @@ internal class PackageCommand : Command, IShortDescription
                     return await statusService.ExecuteWithStatusAsync("Validating input...", (taskContext, _) =>
                     {
                         return Task.FromResult((1, $"{UiSymbols.Error} Cannot use .msix extension for --output when creating a bundle from multiple folders. Use .msixbundle or omit the extension."));
+                    }, cancellationToken);
+                }
+            }
+
+            // Validate --output extension for single-package mode
+            if (inputFolders.Length == 1 && output != null)
+            {
+                var ext = Path.GetExtension(output.Name);
+                if (string.Equals(ext, ".msixbundle", StringComparison.OrdinalIgnoreCase))
+                {
+                    return await statusService.ExecuteWithStatusAsync("Validating input...", (taskContext, _) =>
+                    {
+                        return Task.FromResult((1, $"{UiSymbols.Error} Cannot use .msixbundle extension for --output when creating a single package. Use .msix or omit the extension."));
                     }, cancellationToken);
                 }
             }

--- a/src/winapp-CLI/WinApp.Cli/Helpers/HostBuilderExtensions.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/HostBuilderExtensions.cs
@@ -28,6 +28,8 @@ internal static class StoreHostBuilderExtensions
             .AddSingleton<IManifestService, ManifestService>()
             .AddSingleton<IImageAssetService, ImageAssetService>()
             .AddSingleton<IMsixService, MsixService>()
+            .AddSingleton<IBundleService, BundleService>()
+            .AddSingleton<IBundleValidationService, BundleValidationService>()
             .AddSingleton<IPriService, PriService>()
             .AddSingleton<INugetService, NugetService>()
             .AddSingleton<IPackageInstallationService, PackageInstallationService>()

--- a/src/winapp-CLI/WinApp.Cli/Models/BundleSliceInfo.cs
+++ b/src/winapp-CLI/WinApp.Cli/Models/BundleSliceInfo.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+namespace WinApp.Cli.Models;
+
+/// <summary>
+/// Metadata about a single architecture slice within a bundle.
+/// </summary>
+internal record BundleSliceInfo(DirectoryInfo InputFolder, string Architecture, FileInfo IntermediateMsixPath);

--- a/src/winapp-CLI/WinApp.Cli/Models/CreateMsixBundleResult.cs
+++ b/src/winapp-CLI/WinApp.Cli/Models/CreateMsixBundleResult.cs
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+namespace WinApp.Cli.Models;
+
+internal record CreateMsixBundleResult(FileInfo BundlePath, bool Signed, IReadOnlyList<BundleSliceInfo> Slices);

--- a/src/winapp-CLI/WinApp.Cli/Services/BundleService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/BundleService.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.Logging;
+using WinApp.Cli.ConsoleTasks;
+using WinApp.Cli.Helpers;
+using WinApp.Cli.Tools;
+
+namespace WinApp.Cli.Services;
+
+internal class BundleService(
+    IBuildToolsService buildToolsService,
+    ILogger<BundleService> logger) : IBundleService
+{
+    public async Task CreateBundleAsync(IReadOnlyList<FileInfo> msixFiles, FileInfo output, TaskContext taskContext, CancellationToken cancellationToken = default)
+    {
+        if (msixFiles.Count == 0)
+        {
+            throw new ArgumentException("At least one .msix file is required to create a bundle.", nameof(msixFiles));
+        }
+
+        // Create a fresh dedicated directory containing only the .msix files for bundling.
+        // This avoids stale files or naming collisions affecting the bundle.
+        var bundleStagingDir = new DirectoryInfo(Path.Combine(Path.GetTempPath(), "winapp", $"bundle-{Guid.NewGuid():N}"));
+        bundleStagingDir.Create();
+
+        try
+        {
+            // Copy all intermediate .msix files into the staging directory
+            foreach (var msixFile in msixFiles)
+            {
+                var destPath = Path.Combine(bundleStagingDir.FullName, msixFile.Name);
+                msixFile.CopyTo(destPath, overwrite: true);
+                taskContext.AddDebugMessage($"Staged for bundle: {msixFile.Name}");
+            }
+
+            // Ensure output directory exists
+            output.Directory?.Create();
+
+            var inputPath = LongPathHelper.EnsureExtendedLengthPrefix(Path.TrimEndingDirectorySeparator(bundleStagingDir.FullName));
+            var outputPath = LongPathHelper.EnsureExtendedLengthPrefix(output.FullName);
+            var makeappxArguments = $@"bundle /o /d ""{inputPath}"" /p ""{outputPath}""";
+
+            taskContext.AddDebugMessage($"Creating MSIX bundle with {msixFiles.Count} package(s)...");
+            logger.LogDebug("Running makeappx bundle: {Arguments}", makeappxArguments);
+
+            await buildToolsService.RunBuildToolAsync(new MakeAppxTool(), makeappxArguments, taskContext, cancellationToken: cancellationToken);
+
+            taskContext.AddDebugMessage($"Bundle created: {output.FullName}");
+        }
+        finally
+        {
+            // Clean up bundle staging directory
+            try
+            {
+                if (bundleStagingDir.Exists)
+                {
+                    bundleStagingDir.Delete(recursive: true);
+                }
+            }
+            catch
+            {
+                taskContext.AddDebugMessage($"{UiSymbols.Warning} Could not clean up bundle staging directory: {bundleStagingDir.FullName}");
+            }
+        }
+    }
+}

--- a/src/winapp-CLI/WinApp.Cli/Services/BundleValidationService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/BundleValidationService.cs
@@ -1,0 +1,235 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Xml.Linq;
+
+namespace WinApp.Cli.Services;
+
+internal class BundleValidationService : IBundleValidationService
+{
+    public IReadOnlyList<BundleValidationError> Validate(
+        IReadOnlyList<AppxManifestDocument> sliceManifests,
+        IReadOnlyList<string> detectedArchitectures,
+        IReadOnlyList<DirectoryInfo> inputFolders)
+    {
+        var errors = new List<BundleValidationError>();
+
+        // Architecture validation
+        ValidateArchitectures(detectedArchitectures, inputFolders, errors);
+
+        // Cross-slice manifest consistency
+        if (sliceManifests.Count > 1)
+        {
+            ValidateIdentityConsistency(sliceManifests, inputFolders, errors);
+            ValidateCapabilitiesConsistency(sliceManifests, inputFolders, errors);
+            ValidateDependenciesConsistency(sliceManifests, inputFolders, errors);
+            ValidateApplicationsConsistency(sliceManifests, inputFolders, errors);
+        }
+
+        return errors;
+    }
+
+    private static void ValidateArchitectures(
+        IReadOnlyList<string> architectures,
+        IReadOnlyList<DirectoryInfo> inputFolders,
+        List<BundleValidationError> errors)
+    {
+        // Check for duplicates
+        var archGroups = architectures
+            .Select((arch, index) => (arch, folder: inputFolders[index]))
+            .GroupBy(x => x.arch, StringComparer.OrdinalIgnoreCase)
+            .Where(g => g.Count() > 1)
+            .ToList();
+
+        foreach (var group in archGroups)
+        {
+            var folders = group.Select(x => x.folder.FullName).ToList();
+            errors.Add(new BundleValidationError(
+                "Architecture",
+                $"Duplicate architecture '{group.Key}' detected in multiple input folders.",
+                folders));
+        }
+
+        // Check for all-neutral
+        if (architectures.All(a => string.Equals(a, "neutral", StringComparison.OrdinalIgnoreCase)))
+        {
+            errors.Add(new BundleValidationError(
+                "Architecture",
+                "All input folders contain architecture-neutral binaries. A bundle requires at least one architecture-specific slice.",
+                architectures.ToList()));
+        }
+    }
+
+    private static void ValidateIdentityConsistency(
+        IReadOnlyList<AppxManifestDocument> manifests,
+        IReadOnlyList<DirectoryInfo> inputFolders,
+        List<BundleValidationError> errors)
+    {
+        ValidateFieldConsistency(manifests, inputFolders, errors, "Identity/@Name",
+            m => m.IdentityName ?? string.Empty);
+        ValidateFieldConsistency(manifests, inputFolders, errors, "Identity/@Publisher",
+            m => m.IdentityPublisher ?? string.Empty);
+        ValidateFieldConsistency(manifests, inputFolders, errors, "Identity/@Version",
+            m => m.IdentityVersion ?? string.Empty);
+    }
+
+    private static void ValidateCapabilitiesConsistency(
+        IReadOnlyList<AppxManifestDocument> manifests,
+        IReadOnlyList<DirectoryInfo> inputFolders,
+        List<BundleValidationError> errors)
+    {
+        var capSets = manifests.Select(m => GetCanonicalCapabilities(m)).ToList();
+        var reference = capSets[0];
+
+        for (int i = 1; i < capSets.Count; i++)
+        {
+            if (!reference.SetEquals(capSets[i]))
+            {
+                var sliceValues = capSets.Select((caps, idx) =>
+                    $"{inputFolders[idx].Name}: [{string.Join(", ", caps.OrderBy(c => c))}]").ToList();
+                errors.Add(new BundleValidationError(
+                    "Capabilities",
+                    "Capabilities differ across slices. All slices in a bundle must declare the same capabilities.",
+                    sliceValues));
+                break;
+            }
+        }
+    }
+
+    private static void ValidateDependenciesConsistency(
+        IReadOnlyList<AppxManifestDocument> manifests,
+        IReadOnlyList<DirectoryInfo> inputFolders,
+        List<BundleValidationError> errors)
+    {
+        // Validate PackageDependency (Name + MinVersion)
+        var depSets = manifests.Select(m => GetCanonicalPackageDependencies(m)).ToList();
+        var reference = depSets[0];
+
+        for (int i = 1; i < depSets.Count; i++)
+        {
+            if (!reference.SetEquals(depSets[i]))
+            {
+                var sliceValues = depSets.Select((deps, idx) =>
+                    $"{inputFolders[idx].Name}: [{string.Join(", ", deps.OrderBy(d => d))}]").ToList();
+                errors.Add(new BundleValidationError(
+                    "Dependencies/PackageDependency",
+                    "Package dependencies differ across slices. Ensure all slices use the same dependency versions (especially Windows App SDK runtime version for --self-contained).",
+                    sliceValues));
+                break;
+            }
+        }
+
+        // Validate TargetDeviceFamily (MinVersion + MaxVersionTested)
+        var tdfSets = manifests.Select(m => GetCanonicalTargetDeviceFamilies(m)).ToList();
+        var tdfReference = tdfSets[0];
+
+        for (int i = 1; i < tdfSets.Count; i++)
+        {
+            if (!tdfReference.SetEquals(tdfSets[i]))
+            {
+                var sliceValues = tdfSets.Select((tdfs, idx) =>
+                    $"{inputFolders[idx].Name}: [{string.Join(", ", tdfs.OrderBy(t => t))}]").ToList();
+                errors.Add(new BundleValidationError(
+                    "Dependencies/TargetDeviceFamily",
+                    "TargetDeviceFamily declarations differ across slices.",
+                    sliceValues));
+                break;
+            }
+        }
+    }
+
+    private static void ValidateApplicationsConsistency(
+        IReadOnlyList<AppxManifestDocument> manifests,
+        IReadOnlyList<DirectoryInfo> inputFolders,
+        List<BundleValidationError> errors)
+    {
+        var appSets = manifests.Select(m => GetCanonicalApplicationIds(m)).ToList();
+        var reference = appSets[0];
+
+        for (int i = 1; i < appSets.Count; i++)
+        {
+            if (!reference.SetEquals(appSets[i]))
+            {
+                var sliceValues = appSets.Select((apps, idx) =>
+                    $"{inputFolders[idx].Name}: [{string.Join(", ", apps.OrderBy(a => a))}]").ToList();
+                errors.Add(new BundleValidationError(
+                    "Applications",
+                    "Application declarations differ across slices. All slices must declare the same Application Ids.",
+                    sliceValues));
+                break;
+            }
+        }
+    }
+
+    private static void ValidateFieldConsistency(
+        IReadOnlyList<AppxManifestDocument> manifests,
+        IReadOnlyList<DirectoryInfo> inputFolders,
+        List<BundleValidationError> errors,
+        string fieldName,
+        Func<AppxManifestDocument, string> extractor)
+    {
+        var values = manifests.Select(extractor).ToList();
+        var distinct = values.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+
+        if (distinct.Count > 1)
+        {
+            var sliceValues = values.Select((v, idx) => $"{inputFolders[idx].Name}: \"{v}\"").ToList();
+            errors.Add(new BundleValidationError(
+                fieldName,
+                $"{fieldName} differs across slices. All slices in a bundle must have the same {fieldName}.",
+                sliceValues));
+        }
+    }
+
+    private static HashSet<string> GetCanonicalCapabilities(AppxManifestDocument manifest)
+    {
+        var capsElement = manifest.GetCapabilitiesElement();
+        if (capsElement == null)
+        {
+            return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        return capsElement.Elements()
+            .Select(e => $"{e.Name.LocalName}:{e.Attribute("Name")?.Value ?? e.Name.LocalName}")
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static HashSet<string> GetCanonicalPackageDependencies(AppxManifestDocument manifest)
+    {
+        var depsElement = manifest.GetDependenciesElement();
+        if (depsElement == null)
+        {
+            return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        return depsElement.Elements(AppxManifestDocument.DefaultNs + "PackageDependency")
+            .Select(e => $"{e.Attribute("Name")?.Value}@{e.Attribute("MinVersion")?.Value}")
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static HashSet<string> GetCanonicalTargetDeviceFamilies(AppxManifestDocument manifest)
+    {
+        var depsElement = manifest.GetDependenciesElement();
+        if (depsElement == null)
+        {
+            return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        return depsElement.Elements(AppxManifestDocument.DefaultNs + "TargetDeviceFamily")
+            .Select(e => $"{e.Attribute("Name")?.Value}|{e.Attribute("MinVersion")?.Value}|{e.Attribute("MaxVersionTested")?.Value}")
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static HashSet<string> GetCanonicalApplicationIds(AppxManifestDocument manifest)
+    {
+        var appsElement = manifest.Document.Root?.Element(AppxManifestDocument.DefaultNs + "Applications");
+        if (appsElement == null)
+        {
+            return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        return appsElement.Elements(AppxManifestDocument.DefaultNs + "Application")
+            .Select(e => e.Attribute("Id")?.Value ?? string.Empty)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+    }
+}

--- a/src/winapp-CLI/WinApp.Cli/Services/BundleValidationService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/BundleValidationService.cs
@@ -56,7 +56,7 @@ internal class BundleValidationService : IBundleValidationService
             errors.Add(new BundleValidationError(
                 "Architecture",
                 "All input folders contain architecture-neutral binaries. A bundle requires at least one architecture-specific slice.",
-                architectures.ToList()));
+                inputFolders.Select((f, i) => $"{f.Name}: {architectures[i]}").ToList()));
         }
     }
 

--- a/src/winapp-CLI/WinApp.Cli/Services/IBundleService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/IBundleService.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using WinApp.Cli.ConsoleTasks;
+
+namespace WinApp.Cli.Services;
+
+internal interface IBundleService
+{
+    /// <summary>
+    /// Creates an MSIX bundle from a list of intermediate .msix files using makeappx bundle.
+    /// </summary>
+    /// <param name="msixFiles">The intermediate .msix files to include in the bundle.</param>
+    /// <param name="output">The output .msixbundle file path.</param>
+    /// <param name="taskContext">Task context for logging.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task CreateBundleAsync(IReadOnlyList<FileInfo> msixFiles, FileInfo output, TaskContext taskContext, CancellationToken cancellationToken = default);
+}

--- a/src/winapp-CLI/WinApp.Cli/Services/IBundleValidationService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/IBundleValidationService.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+namespace WinApp.Cli.Services;
+
+internal interface IBundleValidationService
+{
+    /// <summary>
+    /// Validates consistency across multiple bundle slices. Checks that Identity (excluding arch),
+    /// Capabilities, Dependencies, and Applications are consistent across all slices.
+    /// Also validates architecture constraints (no duplicates, no all-neutral, no unknown).
+    /// </summary>
+    /// <param name="sliceManifests">Finalized manifest documents per slice.</param>
+    /// <param name="detectedArchitectures">Detected architecture per slice (parallel to sliceManifests).</param>
+    /// <param name="inputFolders">Input folders per slice (for error messages).</param>
+    /// <returns>A list of validation errors. Empty list means validation passed.</returns>
+    IReadOnlyList<BundleValidationError> Validate(
+        IReadOnlyList<AppxManifestDocument> sliceManifests,
+        IReadOnlyList<string> detectedArchitectures,
+        IReadOnlyList<DirectoryInfo> inputFolders);
+}
+
+/// <summary>
+/// Represents a single cross-slice validation error.
+/// </summary>
+internal record BundleValidationError(string Field, string Message, IReadOnlyList<string> SliceValues);

--- a/src/winapp-CLI/WinApp.Cli/Services/IMsixService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/IMsixService.cs
@@ -25,6 +25,23 @@ internal interface IMsixService
         string? executable = null,
         CancellationToken cancellationToken = default);
 
+    public Task<CreateMsixBundleResult> CreateMsixBundleAsync(
+        DirectoryInfo[] inputFolders,
+        FileSystemInfo? outputPath,
+        TaskContext taskContext,
+        string? packageName = null,
+        bool skipPri = false,
+        bool autoSign = false,
+        FileInfo? certificatePath = null,
+        string certificatePassword = "password",
+        bool generateDevCert = false,
+        bool installDevCert = false,
+        string? publisher = null,
+        FileInfo? manifestPath = null,
+        bool selfContained = false,
+        string? executable = null,
+        CancellationToken cancellationToken = default);
+
     public Task<MsixIdentityResult> AddSparseIdentityAsync(
         string? entryPointPath,
         FileInfo appxManifestPath,

--- a/src/winapp-CLI/WinApp.Cli/Services/MsixService.Bundle.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/MsixService.Bundle.cs
@@ -1,0 +1,388 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text;
+using WinApp.Cli.ConsoleTasks;
+using WinApp.Cli.Helpers;
+using WinApp.Cli.Models;
+
+namespace WinApp.Cli.Services;
+
+internal partial class MsixService
+{
+    public async Task<CreateMsixBundleResult> CreateMsixBundleAsync(
+        DirectoryInfo[] inputFolders,
+        FileSystemInfo? outputPath,
+        TaskContext taskContext,
+        string? packageName = null,
+        bool skipPri = false,
+        bool autoSign = false,
+        FileInfo? certificatePath = null,
+        string certificatePassword = "password",
+        bool generateDevCert = false,
+        bool installDevCert = false,
+        string? publisher = null,
+        FileInfo? manifestPath = null,
+        bool selfContained = false,
+        string? executable = null,
+        CancellationToken cancellationToken = default)
+    {
+        // Stage intermediates under a short-path temp dir to avoid MAX_PATH issues
+        var guidSuffix = Guid.NewGuid().ToString("N")[..8];
+        var bundleTempDir = new DirectoryInfo(Path.Combine(Path.GetTempPath(), "winapp", $"b-{guidSuffix}"));
+        bundleTempDir.Create();
+
+        try
+        {
+            // --- Step 1: Detect architecture per folder ---
+            var sliceInfos = new List<(DirectoryInfo Folder, string Arch, string? ExePath)>();
+
+            for (int i = 0; i < inputFolders.Length; i++)
+            {
+                var folder = inputFolders[i];
+                var exePath = ResolveExecutableForFolder(folder, executable, taskContext);
+
+                if (exePath == null)
+                {
+                    throw new InvalidOperationException(
+                        $"Cannot detect architecture for '{folder.FullName}': no executable found. " +
+                        (executable != null ? $"The specified --executable '{executable}' was not found in this folder." : "Provide --executable or ensure the manifest references an executable that exists in each input folder."));
+                }
+
+                var detectedArch = PeHelper.DetectPeArchitecture(exePath);
+                if (detectedArch == null)
+                {
+                    throw new InvalidOperationException(
+                        $"Cannot detect architecture from '{exePath}': unrecognized PE format or not a valid executable.");
+                }
+
+                taskContext.AddDebugMessage($"[{i + 1}/{inputFolders.Length}] {folder.Name} → {detectedArch}");
+                sliceInfos.Add((folder, detectedArch, exePath));
+            }
+
+            var detectedArchitectures = sliceInfos.Select(s => s.Arch).ToList();
+
+            // --- Step 2: Resolve manifest per folder and finalize ---
+            var finalizedManifests = new List<(string Content, AppxManifestDocument Doc)>();
+            var dotNetPackageList = await FetchDotNetPackageListAsync(cancellationToken);
+
+            for (int i = 0; i < sliceInfos.Count; i++)
+            {
+                var (folder, arch, exePath) = sliceInfos[i];
+
+                // Resolve manifest for this slice
+                string manifestContent;
+                FileInfo resolvedManifestPath;
+
+                if (manifestPath != null)
+                {
+                    resolvedManifestPath = manifestPath;
+                }
+                else
+                {
+                    var resolved = FindManifestInDirectory(folder)
+                        ?? FindManifestInDirectory(new DirectoryInfo(currentDirectoryProvider.GetCurrentDirectory()));
+
+                    if (resolved == null)
+                    {
+                        throw new FileNotFoundException(
+                            $"Manifest file not found for '{folder.FullName}'. Searched for Package.appxmanifest, then appxmanifest.xml in: input folder, current directory. Use --manifest to specify explicitly.");
+                    }
+                    resolvedManifestPath = resolved;
+                }
+
+                manifestContent = await File.ReadAllTextAsync(resolvedManifestPath.FullName, Encoding.UTF8, cancellationToken);
+                manifestContent = ResolveManifestPlaceholders(manifestContent, executable, folder, taskContext);
+                manifestContent = await ResolveResourceLanguageXGenerateAsync(manifestContent, folder, taskContext, cancellationToken);
+
+                // Update manifest (deps, build metadata, arch detection)
+                (manifestContent, _) = await UpdateAppxManifestContentAsync(
+                    manifestContent, null, null, exePath,
+                    sparse: false, selfContained: selfContained, dotNetPackageList,
+                    taskContext, cancellationToken);
+
+                // Force-stamp the detected architecture (overrides whatever UpdateAppxManifestContentAsync detected)
+                var doc = AppxManifestDocument.Parse(manifestContent);
+                doc.IdentityProcessorArchitecture = arch;
+                manifestContent = doc.ToXml();
+                doc = AppxManifestDocument.Parse(manifestContent);
+
+                finalizedManifests.Add((manifestContent, doc));
+            }
+
+            // --- Step 3: Cross-slice validation (BEFORE packing) ---
+            var manifests = finalizedManifests.Select(m => m.Doc).ToList();
+            var folders = sliceInfos.Select(s => s.Folder).ToList();
+
+            var validationErrors = bundleValidationService.Validate(manifests, detectedArchitectures, folders);
+            if (validationErrors.Count > 0)
+            {
+                var errorBuilder = new StringBuilder();
+                errorBuilder.AppendLine("Bundle validation failed. The following inconsistencies were found across slices:");
+                errorBuilder.AppendLine();
+                foreach (var error in validationErrors)
+                {
+                    errorBuilder.AppendLine($"  {error.Field}: {error.Message}");
+                    foreach (var sliceValue in error.SliceValues)
+                    {
+                        errorBuilder.AppendLine($"    • {sliceValue}");
+                    }
+                    errorBuilder.AppendLine();
+                }
+                throw new InvalidOperationException(errorBuilder.ToString());
+            }
+
+            taskContext.AddDebugMessage("Cross-slice validation passed.");
+
+            // --- Step 4: Resolve identity for output naming ---
+            var referenceDoc = finalizedManifests[0].Doc;
+            var finalPackageName = packageName ?? referenceDoc.IdentityName ?? "Package";
+            finalPackageName = ManifestService.CleanPackageName(finalPackageName);
+            var extractedVersion = referenceDoc.IdentityVersion;
+            var extractedPublisher = publisher ?? referenceDoc.IdentityPublisher;
+
+            // Compose output filename: <Name>_<Version>_<arch1>_<arch2>.msixbundle (arches sorted)
+            var sortedArches = detectedArchitectures.OrderBy(a => a, StringComparer.OrdinalIgnoreCase).ToList();
+            var archSuffix = string.Join("_", sortedArches);
+
+            var defaultBundleFileName = !string.IsNullOrWhiteSpace(extractedVersion)
+                ? $"{finalPackageName}_{extractedVersion}_{archSuffix}.msixbundle"
+                : $"{finalPackageName}_{archSuffix}.msixbundle";
+
+            FileInfo outputBundlePath;
+            DirectoryInfo outputFolder;
+            if (outputPath == null)
+            {
+                outputFolder = currentDirectoryProvider.GetCurrentDirectoryInfo();
+                outputBundlePath = new FileInfo(Path.Combine(outputFolder.FullName, defaultBundleFileName));
+            }
+            else
+            {
+                var ext = Path.GetExtension(outputPath.Name);
+                if (string.Equals(ext, ".msixbundle", StringComparison.OrdinalIgnoreCase))
+                {
+                    outputBundlePath = new FileInfo(outputPath.FullName);
+                    outputFolder = outputBundlePath.Directory!;
+                }
+                else
+                {
+                    // Treat as directory (preserve existing semantics)
+                    outputFolder = new DirectoryInfo(outputPath.FullName);
+                    outputBundlePath = new FileInfo(Path.Combine(outputPath.FullName, defaultBundleFileName));
+                }
+            }
+
+            if (!outputFolder.Exists)
+            {
+                outputFolder.Create();
+            }
+
+            // --- Step 5: Pack each slice serially ---
+            var intermediateFiles = new List<FileInfo>();
+            var sliceResults = new List<BundleSliceInfo>();
+
+            for (int i = 0; i < sliceInfos.Count; i++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var (folder, arch, exePath) = sliceInfos[i];
+                var (manifestContent, _) = finalizedManifests[i];
+
+                taskContext.AddStatusMessage($"[{i + 1}/{sliceInfos.Count}] Packing {arch}...");
+
+                // Each intermediate .msix goes into the bundle temp dir
+                var intermediateMsixName = $"{finalPackageName}_{arch}.msix";
+                var intermediateMsixPath = new FileInfo(Path.Combine(bundleTempDir.FullName, intermediateMsixName));
+
+                await PackSingleFolderToMsixAsync(
+                    folder, manifestContent, intermediateMsixPath,
+                    taskContext, selfContained, executable, arch,
+                    skipPri, dotNetPackageList, cancellationToken);
+
+                intermediateFiles.Add(intermediateMsixPath);
+                sliceResults.Add(new BundleSliceInfo(folder, arch, intermediateMsixPath));
+            }
+
+            // --- Step 6: Create the bundle ---
+            taskContext.AddStatusMessage("Creating bundle...");
+            await bundleService.CreateBundleAsync(intermediateFiles, outputBundlePath, taskContext, cancellationToken);
+
+            // --- Step 7: Sign if requested ---
+            if (autoSign)
+            {
+                var resolvedManifest = manifestPath ?? FindManifestInDirectory(inputFolders[0])
+                    ?? FindManifestInDirectory(new DirectoryInfo(currentDirectoryProvider.GetCurrentDirectory()))
+                    ?? throw new FileNotFoundException("Cannot find manifest for publisher validation during signing.");
+
+                await SignMsixPackageAsync(outputFolder, certificatePassword, generateDevCert, installDevCert,
+                    finalPackageName, extractedPublisher, outputBundlePath, certificatePath,
+                    resolvedManifest, taskContext, cancellationToken);
+            }
+
+            return new CreateMsixBundleResult(outputBundlePath, autoSign, sliceResults);
+        }
+        finally
+        {
+            // Clean up bundle temp directory
+            try
+            {
+                if (bundleTempDir.Exists)
+                {
+                    bundleTempDir.Delete(recursive: true);
+                    taskContext.AddDebugMessage($"Cleaned up bundle temp directory: {bundleTempDir.FullName}");
+                }
+            }
+            catch
+            {
+                taskContext.AddDebugMessage($"{UiSymbols.Warning} Could not clean up bundle temp directory: {bundleTempDir.FullName}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Resolves the executable path for arch detection within a given folder.
+    /// If --executable is specified, uses that relative path. Otherwise, reads
+    /// the manifest's Application/@Executable for the folder.
+    /// </summary>
+    private string? ResolveExecutableForFolder(DirectoryInfo folder, string? executableOption, TaskContext taskContext)
+    {
+        if (executableOption != null)
+        {
+            var fullPath = Path.Combine(folder.FullName, executableOption);
+            return File.Exists(fullPath) ? fullPath : null;
+        }
+
+        // Auto-detect: find manifest and read Application/@Executable
+        var manifest = FindManifestInDirectory(folder)
+            ?? FindManifestInDirectory(new DirectoryInfo(currentDirectoryProvider.GetCurrentDirectory()));
+
+        if (manifest != null)
+        {
+            try
+            {
+                var doc = AppxManifestDocument.Load(manifest.FullName);
+                var appExe = doc.ApplicationExecutable;
+                if (appExe != null)
+                {
+                    var fullPath = Path.Combine(folder.FullName, appExe);
+                    if (File.Exists(fullPath))
+                    {
+                        return fullPath;
+                    }
+                }
+            }
+            catch
+            {
+                // Fall through to EXE scan
+            }
+        }
+
+        // Last resort: find first .exe in the folder root
+        var firstExe = folder.EnumerateFiles("*.exe", SearchOption.TopDirectoryOnly).FirstOrDefault();
+        if (firstExe != null)
+        {
+            taskContext.AddDebugMessage($"Auto-detected executable: {firstExe.Name} in {folder.Name}");
+            return firstExe.FullName;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Packs a single folder into an unsigned .msix file. This is the core packing logic
+    /// extracted for reuse by both single-package and bundle workflows.
+    /// Does NOT sign, does NOT resolve the manifest, does NOT determine output naming.
+    /// </summary>
+    private async Task PackSingleFolderToMsixAsync(
+        DirectoryInfo inputFolder,
+        string manifestContent,
+        FileInfo outputMsixPath,
+        TaskContext taskContext,
+        bool selfContained,
+        string? executable,
+        string targetArch,
+        bool skipPri,
+        DotNetPackageListJson? dotNetPackageList,
+        CancellationToken cancellationToken)
+    {
+        // Create staging directory
+        var stagingDir = new DirectoryInfo(Path.Combine(Path.GetTempPath(), $"winapp-package-{Guid.NewGuid():N}"));
+        stagingDir.Create();
+
+        try
+        {
+            var manifestDoc = AppxManifestDocument.Parse(manifestContent);
+
+            // Check for MSBuild-generated manifest and recipe
+            var isMSBuildGenerated = manifestDoc.Document.Root?
+                .Element(AppxManifestDocument.BuildNs + "Metadata")?
+                .Elements(AppxManifestDocument.BuildNs + "Item")
+                .Any(e => string.Equals(e.Attribute("Name")?.Value, "makepri.exe", StringComparison.OrdinalIgnoreCase)) == true;
+
+            FileInfo? recipeFile = null;
+            if (isMSBuildGenerated)
+            {
+                recipeFile = inputFolder.EnumerateFiles("*.build.appxrecipe", SearchOption.TopDirectoryOnly).FirstOrDefault();
+            }
+
+            if (recipeFile != null)
+            {
+                taskContext.AddDebugMessage($"Using appxrecipe for staging: {recipeFile.Name}");
+                await CopyFilesFromRecipeAsync(recipeFile, stagingDir, taskContext, cancellationToken);
+            }
+            else
+            {
+                CopyDirectoryRecursive(inputFolder, stagingDir);
+            }
+
+            // Write finalized manifest into staging
+            var updatedManifestPath = Path.Combine(stagingDir.FullName, "appxmanifest.xml");
+            await File.WriteAllTextAsync(updatedManifestPath, manifestContent, Encoding.UTF8, cancellationToken);
+
+            // PRI generation
+            var existingPri = new FileInfo(Path.Combine(stagingDir.FullName, "resources.pri"));
+            if (!skipPri && !existingPri.Exists)
+            {
+                taskContext.AddDebugMessage("Generating PRI files...");
+                var stagingManifest = new FileInfo(Path.Combine(stagingDir.FullName, "appxmanifest.xml"));
+                var priExpandedFiles = MrtAssetHelper.GetExpandedManifestReferencedFiles(stagingManifest, taskContext);
+                var priResourceCandidates = priExpandedFiles.Select(file => file.RelativePath);
+                await priService.CreatePriConfigAsync(stagingDir, taskContext, precomputedPriResourceCandidates: priResourceCandidates, cancellationToken: cancellationToken);
+                await priService.GeneratePriFileAsync(stagingDir, taskContext, cancellationToken: cancellationToken);
+            }
+
+            // Self-contained runtime (arch-aware)
+            if (selfContained)
+            {
+                var applicationExecutable = manifestDoc.ApplicationExecutable;
+                FileInfo? executablePath = applicationExecutable != null ? new FileInfo(Path.Combine(stagingDir.FullName, applicationExecutable)) : null;
+
+                if (executablePath != null)
+                {
+                    taskContext.AddDebugMessage($"Preparing self-contained runtime for {targetArch}...");
+                    var winAppSDKDeploymentDir = await PrepareRuntimeForPackagingAsync(stagingDir, dotNetPackageList, taskContext, cancellationToken);
+                    var resolvedDeploymentDir = Path.Combine(winAppSDKDeploymentDir.FullName, "..", "extracted");
+                    var windowsAppSDKManifestPath = new FileInfo(Path.Combine(resolvedDeploymentDir, "AppxManifest.xml"));
+                    await EmbedActivationManifestToExeAsync(executablePath, winAppSDKDeploymentDir, windowsAppSDKManifestPath, dotNetPackageList, taskContext, cancellationToken);
+                }
+            }
+
+            // Pack
+            await CreateMsixPackageFromFolderAsync(stagingDir, outputMsixPath, taskContext, cancellationToken);
+        }
+        finally
+        {
+            try
+            {
+                if (stagingDir.Exists)
+                {
+                    stagingDir.Delete(recursive: true);
+                }
+            }
+            catch
+            {
+                taskContext.AddDebugMessage($"{UiSymbols.Warning} Could not clean up staging directory: {stagingDir.FullName}");
+            }
+        }
+    }
+}

--- a/src/winapp-CLI/WinApp.Cli/Services/MsixService.Bundle.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/MsixService.Bundle.cs
@@ -40,7 +40,7 @@ internal partial class MsixService
             for (int i = 0; i < inputFolders.Length; i++)
             {
                 var folder = inputFolders[i];
-                var exePath = ResolveExecutableForFolder(folder, executable, taskContext);
+                var exePath = ResolveExecutableForFolder(folder, executable, manifestPath, taskContext);
 
                 if (exePath == null)
                 {
@@ -258,16 +258,17 @@ internal partial class MsixService
     /// If --executable is specified, uses that relative path. Otherwise, reads
     /// the manifest's Application/@Executable for the folder.
     /// </summary>
-    private string? ResolveExecutableForFolder(DirectoryInfo folder, string? executableOption, TaskContext taskContext)
+    private string? ResolveExecutableForFolder(DirectoryInfo folder, string? executableOption, FileInfo? manifestPath, TaskContext taskContext)
     {
         if (executableOption != null)
         {
-            var fullPath = Path.Combine(folder.FullName, executableOption);
-            return File.Exists(fullPath) ? fullPath : null;
+            var fullPath = ResolveAndValidatePathUnderFolder(folder, executableOption);
+            return fullPath != null && File.Exists(fullPath) ? fullPath : null;
         }
 
-        // Auto-detect: find manifest and read Application/@Executable
-        var manifest = FindManifestInDirectory(folder)
+        // Auto-detect: prefer explicit --manifest, then folder-local, then cwd
+        var manifest = manifestPath
+            ?? FindManifestInDirectory(folder)
             ?? FindManifestInDirectory(new DirectoryInfo(currentDirectoryProvider.GetCurrentDirectory()));
 
         if (manifest != null)
@@ -278,8 +279,8 @@ internal partial class MsixService
                 var appExe = doc.ApplicationExecutable;
                 if (appExe != null)
                 {
-                    var fullPath = Path.Combine(folder.FullName, appExe);
-                    if (File.Exists(fullPath))
+                    var fullPath = ResolveAndValidatePathUnderFolder(folder, appExe);
+                    if (fullPath != null && File.Exists(fullPath))
                     {
                         return fullPath;
                     }
@@ -302,6 +303,33 @@ internal partial class MsixService
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Resolves a relative path under a base folder, rejecting rooted paths and path traversal.
+    /// Returns the full path if valid and contained within the folder, or null otherwise.
+    /// </summary>
+    private static string? ResolveAndValidatePathUnderFolder(DirectoryInfo folder, string relativePath)
+    {
+        if (Path.IsPathRooted(relativePath))
+        {
+            return null;
+        }
+
+        if (relativePath.Contains("..", StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        var fullPath = Path.GetFullPath(Path.Combine(folder.FullName, relativePath));
+        var folderPrefix = folder.FullName.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+
+        if (!fullPath.StartsWith(folderPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        return fullPath;
     }
 
     /// <summary>
@@ -386,7 +414,10 @@ internal partial class MsixService
             if (selfContained)
             {
                 var applicationExecutable = manifestDoc.ApplicationExecutable;
-                FileInfo? executablePath = applicationExecutable != null ? new FileInfo(Path.Combine(stagingDir.FullName, applicationExecutable)) : null;
+                var validatedExePath = applicationExecutable != null
+                    ? ResolveAndValidatePathUnderFolder(stagingDir, applicationExecutable)
+                    : null;
+                FileInfo? executablePath = validatedExePath != null ? new FileInfo(validatedExePath) : null;
 
                 if (executablePath != null)
                 {

--- a/src/winapp-CLI/WinApp.Cli/Services/MsixService.Bundle.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/MsixService.Bundle.cs
@@ -63,7 +63,7 @@ internal partial class MsixService
             var detectedArchitectures = sliceInfos.Select(s => s.Arch).ToList();
 
             // --- Step 2: Resolve manifest per folder and finalize ---
-            var finalizedManifests = new List<(string Content, AppxManifestDocument Doc)>();
+            var finalizedManifests = new List<(string Content, AppxManifestDocument Doc, FileInfo ResolvedManifestPath)>();
             var dotNetPackageList = await FetchDotNetPackageListAsync(cancellationToken);
 
             for (int i = 0; i < sliceInfos.Count; i++)
@@ -107,7 +107,7 @@ internal partial class MsixService
                 manifestContent = doc.ToXml();
                 doc = AppxManifestDocument.Parse(manifestContent);
 
-                finalizedManifests.Add((manifestContent, doc));
+                finalizedManifests.Add((manifestContent, doc, resolvedManifestPath));
             }
 
             // --- Step 3: Cross-slice validation (BEFORE packing) ---
@@ -186,7 +186,7 @@ internal partial class MsixService
                 cancellationToken.ThrowIfCancellationRequested();
 
                 var (folder, arch, exePath) = sliceInfos[i];
-                var (manifestContent, _) = finalizedManifests[i];
+                var (manifestContent, _, sliceManifestPath) = finalizedManifests[i];
 
                 taskContext.AddStatusMessage($"[{i + 1}/{sliceInfos.Count}] Packing {arch}...");
 
@@ -195,7 +195,7 @@ internal partial class MsixService
                 var intermediateMsixPath = new FileInfo(Path.Combine(bundleTempDir.FullName, intermediateMsixName));
 
                 await PackSingleFolderToMsixAsync(
-                    folder, manifestContent, intermediateMsixPath,
+                    folder, manifestContent, sliceManifestPath, intermediateMsixPath,
                     taskContext, selfContained, executable, arch,
                     skipPri, dotNetPackageList, cancellationToken);
 
@@ -296,6 +296,7 @@ internal partial class MsixService
     private async Task PackSingleFolderToMsixAsync(
         DirectoryInfo inputFolder,
         string manifestContent,
+        FileInfo resolvedManifestPath,
         FileInfo outputMsixPath,
         TaskContext taskContext,
         bool selfContained,
@@ -339,6 +340,20 @@ internal partial class MsixService
             var updatedManifestPath = Path.Combine(stagingDir.FullName, "appxmanifest.xml");
             await File.WriteAllTextAsync(updatedManifestPath, manifestContent, Encoding.UTF8, cancellationToken);
 
+            // Copy external manifest-referenced assets if manifest lives outside the input folder
+            var manifestIsOutsideInputFolder = !inputFolder.FullName.TrimEnd(Path.DirectorySeparatorChar)
+                .Equals(resolvedManifestPath.Directory!.FullName.TrimEnd(Path.DirectorySeparatorChar), StringComparison.OrdinalIgnoreCase);
+
+            var allManifestReferences = ManifestFileReferenceHelper.ExtractAllFileReferencesFromManifest(manifestContent);
+
+            if (manifestIsOutsideInputFolder)
+            {
+                var externalAssets = MrtAssetHelper.GetExpandedManifestReferencedFiles(resolvedManifestPath, taskContext);
+                MrtAssetHelper.CopyAllAssets(externalAssets, stagingDir, taskContext);
+            }
+
+            CopyManifestReferencedFiles(allManifestReferences, resolvedManifestPath.Directory!, inputFolder, stagingDir, taskContext, cancellationToken);
+
             // PRI generation
             var existingPri = new FileInfo(Path.Combine(stagingDir.FullName, "resources.pri"));
             if (!skipPri && !existingPri.Exists)
@@ -360,7 +375,7 @@ internal partial class MsixService
                 if (executablePath != null)
                 {
                     taskContext.AddDebugMessage($"Preparing self-contained runtime for {targetArch}...");
-                    var winAppSDKDeploymentDir = await PrepareRuntimeForPackagingAsync(stagingDir, dotNetPackageList, taskContext, cancellationToken);
+                    var winAppSDKDeploymentDir = await PrepareRuntimeForPackagingAsync(stagingDir, dotNetPackageList, taskContext, cancellationToken, overrideArch: targetArch);
                     var resolvedDeploymentDir = Path.Combine(winAppSDKDeploymentDir.FullName, "..", "extracted");
                     var windowsAppSDKManifestPath = new FileInfo(Path.Combine(resolvedDeploymentDir, "AppxManifest.xml"));
                     await EmbedActivationManifestToExeAsync(executablePath, winAppSDKDeploymentDir, windowsAppSDKManifestPath, dotNetPackageList, taskContext, cancellationToken);

--- a/src/winapp-CLI/WinApp.Cli/Services/MsixService.Bundle.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/MsixService.Bundle.cs
@@ -177,6 +177,20 @@ internal partial class MsixService
                 outputFolder.Create();
             }
 
+            // --- Step 4b: Validate self-contained + neutral combination ---
+            if (selfContained)
+            {
+                var neutralSlices = sliceInfos.Where(s => string.Equals(s.Arch, "neutral", StringComparison.OrdinalIgnoreCase)).ToList();
+                if (neutralSlices.Count > 0)
+                {
+                    var neutralFolders = string.Join(", ", neutralSlices.Select(s => s.Folder.Name));
+                    throw new InvalidOperationException(
+                        $"Cannot use --self-contained with architecture-neutral slices ({neutralFolders}). " +
+                        "Self-contained runtime requires a specific architecture (x64, arm64, x86). " +
+                        "Either remove --self-contained or ensure all input folders contain architecture-specific binaries.");
+                }
+            }
+
             // --- Step 5: Pack each slice serially ---
             var intermediateFiles = new List<FileInfo>();
             var sliceResults = new List<BundleSliceInfo>();
@@ -277,8 +291,10 @@ internal partial class MsixService
             }
         }
 
-        // Last resort: find first .exe in the folder root
-        var firstExe = folder.EnumerateFiles("*.exe", SearchOption.TopDirectoryOnly).FirstOrDefault();
+        // Last resort: find first .exe in the folder root (excluding runtime tools)
+        var firstExe = folder.EnumerateFiles("*.exe", SearchOption.TopDirectoryOnly)
+            .Where(f => !IsRuntimeToolExecutable(f.Name))
+            .FirstOrDefault();
         if (firstExe != null)
         {
             taskContext.AddDebugMessage($"Auto-detected executable: {firstExe.Name} in {folder.Name}");

--- a/src/winapp-CLI/WinApp.Cli/Services/MsixService.Runtime.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/MsixService.Runtime.cs
@@ -846,9 +846,9 @@ internal partial class MsixService
     /// <param name="inputFolder">The folder where runtime files should be copied</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>The path to the self-contained deployment directory</returns>
-    private async Task<DirectoryInfo> PrepareRuntimeForPackagingAsync(DirectoryInfo inputFolder, DotNetPackageListJson? dotNetPackageList, TaskContext taskContext, CancellationToken cancellationToken)
+    private async Task<DirectoryInfo> PrepareRuntimeForPackagingAsync(DirectoryInfo inputFolder, DotNetPackageListJson? dotNetPackageList, TaskContext taskContext, CancellationToken cancellationToken, string? overrideArch = null)
     {
-        var arch = WorkspaceSetupService.GetSystemArchitecture();
+        var arch = overrideArch ?? WorkspaceSetupService.GetSystemArchitecture();
 
         var winappDir = winappDirectoryService.GetLocalWinappDirectory();
 

--- a/src/winapp-CLI/WinApp.Cli/Services/MsixService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/MsixService.cs
@@ -27,6 +27,8 @@ internal partial class MsixService(
     IWinmdService winmdService,
     IPriService priService,
     IPackageRegistrationService packageRegistrationService,
+    IBundleService bundleService,
+    IBundleValidationService bundleValidationService,
     ILogger<MsixService> logger,
     ICurrentDirectoryProvider currentDirectoryProvider) : IMsixService
 {

--- a/src/winapp-npm/scripts/generate-commands.mjs
+++ b/src/winapp-npm/scripts/generate-commands.mjs
@@ -128,6 +128,17 @@ function isBoolFlag(opt) {
   return tsType(opt.valueType, opt.helpName) === 'boolean';
 }
 
+/** Whether a positional argument is variadic (accepts multiple values). */
+function isVariadicArg(argDef) {
+  // Array types (e.g., DirectoryInfo[], String[])
+  if (argDef.valueType && argDef.valueType.endsWith('[]')) return true;
+  // Arity with no maximum or maximum > 1
+  const arity = argDef.arity;
+  if (arity && arity.maximum === undefined) return true;
+  if (arity && arity.maximum > 1) return true;
+  return false;
+}
+
 /**
  * Commands that act as pass-throughs (arbitrary extra args forwarded to
  * an underlying tool). We add a `string[]` property for the extra args.
@@ -284,8 +295,10 @@ function generate(schema) {
     // positional args first
     for (const arg of positionalArgs) {
       const required = arg.def.arity?.minimum >= 1;
+      const variadic = isVariadicArg(arg.def);
+      const type = variadic ? 'string | string[]' : tsType(arg.def.valueType);
       L(`  /** ${cleanDesc(arg.def.description)} */`);
-      L(`  ${arg.propName}${required ? '' : '?'}: ${tsType(arg.def.valueType)};`);
+      L(`  ${arg.propName}${required ? '' : '?'}: ${type};`);
     }
     // then named options
     for (const opt of opts) {
@@ -314,7 +327,18 @@ function generate(schema) {
     // Positional args
     for (const arg of positionalArgs) {
       const required = arg.def.arity?.minimum >= 1;
-      if (required) {
+      const variadic = isVariadicArg(arg.def);
+      if (variadic) {
+        if (required) {
+          L(`  const ${arg.propName}Arr = Array.isArray(options.${arg.propName}) ? options.${arg.propName} : [options.${arg.propName}];`);
+          L(`  args.push(...${arg.propName}Arr);`);
+        } else {
+          L(`  if (options.${arg.propName}) {`);
+          L(`    const ${arg.propName}Arr = Array.isArray(options.${arg.propName}) ? options.${arg.propName} : [options.${arg.propName}];`);
+          L(`    args.push(...${arg.propName}Arr);`);
+          L('  }');
+        }
+      } else if (required) {
         L(`  args.push(options.${arg.propName});`);
       } else {
         L(`  if (options.${arg.propName}) args.push(options.${arg.propName});`);

--- a/src/winapp-npm/src/winapp-commands.ts
+++ b/src/winapp-npm/src/winapp-commands.ts
@@ -249,6 +249,8 @@ export interface InitOptions extends CommonOptions {
   ignoreConfig?: boolean;
   /** Don't update .gitignore file */
   noGitignore?: boolean;
+  /** Search all directories, including commonly ignored ones like node_modules, bin, obj, etc. */
+  searchAll?: boolean;
   /** SDK installation mode: 'stable' (default), 'preview', 'experimental', or 'none' (skip SDK installation) */
   setupSdks?: SdkInstallMode;
   /** Do not prompt, and use default of all prompts */
@@ -265,6 +267,7 @@ export async function init(options: InitOptions = {}): Promise<WinappResult> {
   if (options.configOnly) args.push('--config-only');
   if (options.ignoreConfig) args.push('--ignore-config');
   if (options.noGitignore) args.push('--no-gitignore');
+  if (options.searchAll) args.push('--search-all');
   if (options.setupSdks) args.push('--setup-sdks', options.setupSdks);
   if (options.useDefaults) args.push('--use-defaults');
   return execCommand(args, options);
@@ -794,10 +797,8 @@ export interface UiScreenshotOptions extends CommonOptions {
   selector?: string;
   /** Target app (process name, window title, or PID). Lists windows if ambiguous. */
   app?: string;
-  /** Capture from screen DC via BitBlt (includes popups/overlays not owned by the target). Implies --focus. */
+  /** Capture from screen (includes popups/overlays) instead of window rendering. Brings window to foreground first. */
   captureScreen?: boolean;
-  /** Bring the target window to the foreground before capture. Already implied by --capture-screen. */
-  focus?: boolean;
   /** Format output as JSON */
   json?: boolean;
   /** Save output to file path (e.g., screenshot) */
@@ -814,7 +815,6 @@ export async function uiScreenshot(options: UiScreenshotOptions = {}): Promise<W
   if (options.selector) args.push(options.selector);
   if (options.app) args.push('--app', options.app);
   if (options.captureScreen) args.push('--capture-screen');
-  if (options.focus) args.push('--focus');
   if (options.json) args.push('--json');
   if (options.output) args.push('--output', options.output);
   if (options.window !== undefined) args.push('--window', options.window.toString());

--- a/src/winapp-npm/src/winapp-commands.ts
+++ b/src/winapp-npm/src/winapp-commands.ts
@@ -365,7 +365,7 @@ export async function manifestUpdateAssets(options: ManifestUpdateAssetsOptions)
 // ---------------------------------------------------------------------------
 
 export interface PackageOptions extends CommonOptions {
-  /** Input folder with package layout */
+  /** One or more input folders with package layout. Pass multiple folders to create an MSIX bundle (e.g., winapp pack ./publish/x64 ./publish/arm64). */
   inputFolder: string;
   /** Path to signing certificate (will auto-sign if provided) */
   cert?: string;
@@ -381,7 +381,7 @@ export interface PackageOptions extends CommonOptions {
   manifest?: string;
   /** Package name (default: from manifest) */
   name?: string;
-  /** Output msix file name for the generated package (defaults to <name>_<version>_<arch>.msix, falling back to <name>_<version>.msix, <name>_<arch>.msix, or <name>.msix when version/arch can't be determined) */
+  /** Output file name for the generated package (.msix) or bundle (.msixbundle). Defaults to <name>_<version>_<arch>.msix for single packages, or <name>_<version>_<arch1>_<arch2>.msixbundle for bundles. */
   output?: string;
   /** Publisher name for certificate generation */
   publisher?: string;

--- a/src/winapp-npm/src/winapp-commands.ts
+++ b/src/winapp-npm/src/winapp-commands.ts
@@ -249,8 +249,6 @@ export interface InitOptions extends CommonOptions {
   ignoreConfig?: boolean;
   /** Don't update .gitignore file */
   noGitignore?: boolean;
-  /** Search all directories, including commonly ignored ones like node_modules, bin, obj, etc. */
-  searchAll?: boolean;
   /** SDK installation mode: 'stable' (default), 'preview', 'experimental', or 'none' (skip SDK installation) */
   setupSdks?: SdkInstallMode;
   /** Do not prompt, and use default of all prompts */
@@ -267,7 +265,6 @@ export async function init(options: InitOptions = {}): Promise<WinappResult> {
   if (options.configOnly) args.push('--config-only');
   if (options.ignoreConfig) args.push('--ignore-config');
   if (options.noGitignore) args.push('--no-gitignore');
-  if (options.searchAll) args.push('--search-all');
   if (options.setupSdks) args.push('--setup-sdks', options.setupSdks);
   if (options.useDefaults) args.push('--use-defaults');
   return execCommand(args, options);
@@ -797,8 +794,10 @@ export interface UiScreenshotOptions extends CommonOptions {
   selector?: string;
   /** Target app (process name, window title, or PID). Lists windows if ambiguous. */
   app?: string;
-  /** Capture from screen (includes popups/overlays) instead of window rendering. Brings window to foreground first. */
+  /** Capture from screen DC via BitBlt (includes popups/overlays not owned by the target). Implies --focus. */
   captureScreen?: boolean;
+  /** Bring the target window to the foreground before capture. Already implied by --capture-screen. */
+  focus?: boolean;
   /** Format output as JSON */
   json?: boolean;
   /** Save output to file path (e.g., screenshot) */
@@ -815,6 +814,7 @@ export async function uiScreenshot(options: UiScreenshotOptions = {}): Promise<W
   if (options.selector) args.push(options.selector);
   if (options.app) args.push('--app', options.app);
   if (options.captureScreen) args.push('--capture-screen');
+  if (options.focus) args.push('--focus');
   if (options.json) args.push('--json');
   if (options.output) args.push('--output', options.output);
   if (options.window !== undefined) args.push('--window', options.window.toString());

--- a/src/winapp-npm/src/winapp-commands.ts
+++ b/src/winapp-npm/src/winapp-commands.ts
@@ -366,7 +366,7 @@ export async function manifestUpdateAssets(options: ManifestUpdateAssetsOptions)
 
 export interface PackageOptions extends CommonOptions {
   /** One or more input folders with package layout. Pass multiple folders to create an MSIX bundle (e.g., winapp pack ./publish/x64 ./publish/arm64). */
-  inputFolder: string;
+  inputFolder: string | string[];
   /** Path to signing certificate (will auto-sign if provided) */
   cert?: string;
   /** Certificate password (default: password) */
@@ -396,7 +396,8 @@ export interface PackageOptions extends CommonOptions {
  */
 export async function packageApp(options: PackageOptions): Promise<WinappResult> {
   const args: string[] = ['package'];
-  args.push(options.inputFolder);
+  const inputFolderArr = Array.isArray(options.inputFolder) ? options.inputFolder : [options.inputFolder];
+  args.push(...inputFolderArr);
   if (options.cert) args.push('--cert', options.cert);
   if (options.certPassword) args.push('--cert-password', options.certPassword);
   if (options.executable) args.push('--executable', options.executable);
@@ -440,7 +441,7 @@ export interface RunOptions extends CommonOptions {
   /** Input folder containing the app to run */
   inputFolder: string;
   /** Arguments to pass to the launched application. Provide after -- (e.g., winapp run . -- --flag value). */
-  appArgs?: string;
+  appArgs?: string | string[];
   /** Command-line arguments to pass to the application. Alternatively, use -- followed by arguments to avoid escaping (e.g., winapp run . -- --flag value). */
   args?: string;
   /** Remove the existing package's application data (LocalState, settings, etc.) before re-deploying. By default, application data is preserved across re-deployments. */
@@ -473,7 +474,10 @@ export interface RunOptions extends CommonOptions {
 export async function run(options: RunOptions): Promise<WinappResult> {
   const args: string[] = ['run'];
   args.push(options.inputFolder);
-  if (options.appArgs) args.push(options.appArgs);
+  if (options.appArgs) {
+    const appArgsArr = Array.isArray(options.appArgs) ? options.appArgs : [options.appArgs];
+    args.push(...appArgsArr);
+  }
   if (options.args) args.push('--args', options.args);
   if (options.clean) args.push('--clean');
   if (options.debugOutput) args.push('--debug-output');


### PR DESCRIPTION
Enabling creation of msixbundles via passing multiple output dirs to pack command
fixes #517 

## Decision tree

```
winapp pack <input-folder...> [options]
|
+-- N = 1 folder
|  +-- --output ends in .msixbundle? -> ERROR
|  +-- otherwise -> Single .msix package (existing behavior)
|
+-- N > 1 folders
   +-- --output ends in .msix? -> ERROR
   +-- otherwise -> .msixbundle
      |
      +-- Architecture detection (per folder)
      |  +-- PE header of --executable or auto-detected .exe
      |
      +-- Validation (cross-slice)
      |  +-- No duplicate architectures
      |  +-- Not all neutral
      |  +-- Identity (Name, Publisher, Version) must match
      |  +-- Capabilities must match
      |  +-- Applications (Id, EntryPoint) must match
      |  +-- PackageDependency must match
      |  +-- TargetDeviceFamily must match
      |
      +-- --self-contained
      |  +-- Downloads runtime per-slice using detected arch (not host arch)
      |
      +-- --manifest <path>
      |  +-- Shared across all slices (arch stamped per slice)
      |
      +-- --cert / --generate-cert
      |  +-- Signs the final .msixbundle
      |
      +-- Output naming (when --output omitted)
         +-- <name>_<version>_<arch1>_<arch2>.msixbundle
```

## Examples

```powershell
# Basic bundle
winapp pack ./publish/x64 ./publish/arm64

# With shared manifest + signing
winapp pack ./publish/x64 ./publish/arm64 --manifest ./appxmanifest.xml --generate-cert

# Self-contained (arch-aware runtime per slice)
winapp pack ./publish/x64 ./publish/arm64 --self-contained

# Custom output name
winapp pack ./publish/x64 ./publish/arm64 --output MyApp.msixbundle
```