### PR TITLE
Fix RCE via execution alias resolved against CWD/PATH

### DIFF
--- a/samples/cpp-app/test.Tests.ps1
+++ b/samples/cpp-app/test.Tests.ps1
@@ -100,6 +100,10 @@ add_executable(test-cpp-app main.cpp)
             Invoke-WinappCommand -Arguments "run build\Debug --unregister-on-exit"
         }
 
+        It "runs app via execution alias with winapp run --with-alias" -Skip:$script:skip {
+            Invoke-WinappCommand -Arguments "run build\Debug --with-alias --unregister-on-exit"
+        }
+
         It "CMake builds release successfully" -Skip:$script:skip {
             $output = cmake --build build --config Release 2>&1
             $LASTEXITCODE | Should -Be 0 -Because "CMake build failed: $output"

--- a/samples/rust-app/test.Tests.ps1
+++ b/samples/rust-app/test.Tests.ps1
@@ -83,6 +83,27 @@ Describe "Rust App Sample" {
             } finally { Pop-Location }
         }
 
+        It "Should reject hostile execution alias in manifest" -Skip:$script:skip {
+            # Regression test for MSRC RCE fix: a manifest containing a non-bare /
+            # path-traversal ExecutionAlias must be rejected by `winapp run --with-alias`
+            # before any process is launched.
+            Push-Location $script:rustProjectDir
+            try {
+                $manifestPath = Join-Path $script:rustProjectDir "Package.appxmanifest"
+                $original = Get-Content -Raw -Path $manifestPath
+                try {
+                    $hostile = $original -replace 'Alias="[^"]+"', 'Alias="..\evil.exe"'
+                    Set-Content -Path $manifestPath -Value $hostile -NoNewline
+
+                    $output = & winapp run .\target\debug --with-alias --unregister-on-exit 2>&1
+                    $LASTEXITCODE | Should -Not -Be 0 -Because "hostile alias must be rejected"
+                    ($output -join "`n") | Should -Match '(?i)alias' -Because "error should mention alias validation. Got: $output"
+                } finally {
+                    Set-Content -Path $manifestPath -Value $original -NoNewline
+                }
+            } finally { Pop-Location }
+        }
+
         It "Should build Rust app in release mode" -Skip:$script:skip {
             Push-Location $script:rustProjectDir
             try {

--- a/src/winapp-CLI/WinApp.Cli.Tests/ExecutionAliasResolverTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/ExecutionAliasResolverTests.cs
@@ -17,12 +17,21 @@ public class ExecutionAliasResolverTests
     [DataRow("my_app.exe", DisplayName = "underscore")]
     [DataRow("app123.exe", DisplayName = "digits")]
     [DataRow("a.exe", DisplayName = "single letter")]
-    [DataRow("notepad", DisplayName = "no extension still ok (resolver does not require .exe)")]
     [DataRow("file.with.dots.exe", DisplayName = "internal dots")]
     public void IsSafeAliasName_ValidBareFilename_ReturnsTrue(string alias)
     {
         Assert.IsTrue(ExecutionAliasResolver.IsSafeAliasName(alias),
             $"Expected '{alias}' to be accepted as a bare filename");
+    }
+
+    [TestMethod]
+    public void IsSafeAliasName_AtMaxLength_ReturnsTrue()
+    {
+        // 255 characters total (the boundary): 251 'a' + ".exe"
+        var alias = new string('a', 251) + ".exe";
+        Assert.AreEqual(255, alias.Length);
+        Assert.IsTrue(ExecutionAliasResolver.IsSafeAliasName(alias),
+            "Aliases exactly 255 characters long should be accepted");
     }
 
     // ---- IsSafeAliasName: reject empties / dot-names --------------------------
@@ -100,6 +109,52 @@ public class ExecutionAliasResolverTests
             "Aliases longer than 255 characters should be rejected");
     }
 
+    // ---- IsSafeAliasName: reject trailing dot/space (Win32 trims these) -------
+
+    [TestMethod]
+    [DataRow("evil.exe.", DisplayName = "trailing dot")]
+    [DataRow("evil.exe ", DisplayName = "trailing space")]
+    [DataRow("evil.exe..", DisplayName = "two trailing dots")]
+    [DataRow("evil.exe.  ", DisplayName = "trailing dot then spaces")]
+    public void IsSafeAliasName_TrailingDotOrSpace_ReturnsFalse(string alias)
+    {
+        Assert.IsFalse(ExecutionAliasResolver.IsSafeAliasName(alias),
+            $"Expected '{alias}' to be rejected — trailing dot/space is silently trimmed by Win32 path normalization");
+    }
+
+    // ---- IsSafeAliasName: require .exe suffix ---------------------------------
+
+    [TestMethod]
+    [DataRow("notepad", DisplayName = "no extension")]
+    [DataRow("myapp.com", DisplayName = ".com")]
+    [DataRow("myapp.bat", DisplayName = ".bat")]
+    [DataRow("myapp", DisplayName = "stem only")]
+    [DataRow("myapp.exetra", DisplayName = ".exe-like but not .exe")]
+    public void IsSafeAliasName_NonExeExtension_ReturnsFalse(string alias)
+    {
+        Assert.IsFalse(ExecutionAliasResolver.IsSafeAliasName(alias),
+            $"Expected '{alias}' to be rejected — Windows App Execution Aliases must end in .exe");
+    }
+
+    // ---- IsSafeAliasName: reject DOS reserved device names --------------------
+
+    [TestMethod]
+    [DataRow("CON.exe", DisplayName = "CON.exe")]
+    [DataRow("con.exe", DisplayName = "con.exe (lowercase)")]
+    [DataRow("PRN.exe", DisplayName = "PRN.exe")]
+    [DataRow("AUX.exe", DisplayName = "AUX.exe")]
+    [DataRow("NUL.exe", DisplayName = "NUL.exe")]
+    [DataRow("COM1.exe", DisplayName = "COM1.exe")]
+    [DataRow("COM9.exe", DisplayName = "COM9.exe")]
+    [DataRow("LPT1.exe", DisplayName = "LPT1.exe")]
+    [DataRow("LPT9.exe", DisplayName = "LPT9.exe")]
+    [DataRow("CON.txt.exe", DisplayName = "CON.txt.exe (stem still binds to CON)")]
+    public void IsSafeAliasName_ReservedDeviceNames_ReturnsFalse(string alias)
+    {
+        Assert.IsFalse(ExecutionAliasResolver.IsSafeAliasName(alias),
+            $"Expected '{alias}' to be rejected — reserved DOS device names bind to the device regardless of extension");
+    }
+
     // ---- ResolveAliasPath: success + base directory behaviour -----------------
 
     [TestMethod]
@@ -154,6 +209,24 @@ public class ExecutionAliasResolverTests
         Assert.IsNull(result,
             $"Hostile alias '{alias ?? "<null>"}' must not be resolved to a filesystem path");
     }
+
+    // ---- ResolveAliasPath: refuse non-rooted base directories -----------------
+
+    [TestMethod]
+    [DataRow("", DisplayName = "empty base directory")]
+    [DataRow("Microsoft\\WindowsApps", DisplayName = "relative base directory")]
+    [DataRow(".\\WindowsApps", DisplayName = "explicit-current-dir relative")]
+    public void ResolveAliasPath_NonRootedBaseDirectory_ReturnsNull(string baseDir)
+    {
+        // A non-rooted base directory would cause FileInfo to root the resulting
+        // path under the current working directory — reintroducing the very
+        // CWD-search RCE this resolver exists to prevent.
+        var result = ExecutionAliasResolver.ResolveAliasPath("myapp.exe", baseDir);
+
+        Assert.IsNull(result,
+            $"Resolver must refuse non-rooted base directory '{baseDir}' to avoid CWD-relative resolution");
+    }
+
 
     // ---- ResolveAliasPath: Exists reports filesystem state --------------------
 

--- a/src/winapp-CLI/WinApp.Cli.Tests/ExecutionAliasResolverTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/ExecutionAliasResolverTests.cs
@@ -1,0 +1,197 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using WinApp.Cli.Helpers;
+
+namespace WinApp.Cli.Tests;
+
+[TestClass]
+public class ExecutionAliasResolverTests
+{
+    // ---- IsSafeAliasName: accept bare filenames --------------------------------
+
+    [TestMethod]
+    [DataRow("myapp.exe", DisplayName = "simple .exe")]
+    [DataRow("MyApp.exe", DisplayName = "mixed case .exe")]
+    [DataRow("my-app.exe", DisplayName = "hyphen")]
+    [DataRow("my_app.exe", DisplayName = "underscore")]
+    [DataRow("app123.exe", DisplayName = "digits")]
+    [DataRow("a.exe", DisplayName = "single letter")]
+    [DataRow("notepad", DisplayName = "no extension still ok (resolver does not require .exe)")]
+    [DataRow("file.with.dots.exe", DisplayName = "internal dots")]
+    public void IsSafeAliasName_ValidBareFilename_ReturnsTrue(string alias)
+    {
+        Assert.IsTrue(ExecutionAliasResolver.IsSafeAliasName(alias),
+            $"Expected '{alias}' to be accepted as a bare filename");
+    }
+
+    // ---- IsSafeAliasName: reject empties / dot-names --------------------------
+
+    [TestMethod]
+    [DataRow(null, DisplayName = "null")]
+    [DataRow("", DisplayName = "empty")]
+    [DataRow("   ", DisplayName = "whitespace only")]
+    [DataRow("\t", DisplayName = "tab only")]
+    [DataRow(".", DisplayName = "single dot")]
+    [DataRow("..", DisplayName = "double dot (parent)")]
+    public void IsSafeAliasName_EmptyOrDotNames_ReturnsFalse(string? alias)
+    {
+        Assert.IsFalse(ExecutionAliasResolver.IsSafeAliasName(alias),
+            $"Expected '{alias ?? "<null>"}' to be rejected");
+    }
+
+    // ---- IsSafeAliasName: reject path separators ------------------------------
+
+    [TestMethod]
+    [DataRow("dir\\evil.exe", DisplayName = "backslash separator")]
+    [DataRow("dir/evil.exe", DisplayName = "forward slash separator")]
+    [DataRow("..\\evil.exe", DisplayName = "parent traversal with backslash")]
+    [DataRow("../evil.exe", DisplayName = "parent traversal with forward slash")]
+    [DataRow("a\\b\\c.exe", DisplayName = "nested backslash path")]
+    [DataRow("a/b/c.exe", DisplayName = "nested forward slash path")]
+    [DataRow("\\evil.exe", DisplayName = "leading backslash (rooted on current drive)")]
+    [DataRow("/evil.exe", DisplayName = "leading forward slash")]
+    public void IsSafeAliasName_PathSeparators_ReturnsFalse(string alias)
+    {
+        Assert.IsFalse(ExecutionAliasResolver.IsSafeAliasName(alias),
+            $"Expected '{alias}' to be rejected — contains a path separator");
+    }
+
+    // ---- IsSafeAliasName: reject rooted / absolute paths ----------------------
+
+    [TestMethod]
+    [DataRow("C:\\Windows\\System32\\calc.exe", DisplayName = "absolute path with drive")]
+    [DataRow("C:evil.exe", DisplayName = "drive-relative path")]
+    [DataRow("\\\\server\\share\\evil.exe", DisplayName = "UNC path")]
+    [DataRow("\\\\?\\C:\\evil.exe", DisplayName = "extended-length UNC")]
+    public void IsSafeAliasName_RootedPaths_ReturnsFalse(string alias)
+    {
+        Assert.IsFalse(ExecutionAliasResolver.IsSafeAliasName(alias),
+            $"Expected '{alias}' to be rejected — is a rooted / absolute path");
+    }
+
+    // ---- IsSafeAliasName: reject invalid filename characters ------------------
+
+    [TestMethod]
+    public void IsSafeAliasName_NullCharacter_ReturnsFalse()
+    {
+        Assert.IsFalse(ExecutionAliasResolver.IsSafeAliasName("evil\0.exe"));
+    }
+
+    [TestMethod]
+    [DataRow("evil*.exe", DisplayName = "asterisk")]
+    [DataRow("evil?.exe", DisplayName = "question mark")]
+    [DataRow("evil<.exe", DisplayName = "less than")]
+    [DataRow("evil>.exe", DisplayName = "greater than")]
+    [DataRow("evil|.exe", DisplayName = "pipe")]
+    [DataRow("evil\".exe", DisplayName = "quote")]
+    [DataRow("evil:test.exe", DisplayName = "colon (drive separator / ADS)")]
+    public void IsSafeAliasName_InvalidFilenameChars_ReturnsFalse(string alias)
+    {
+        Assert.IsFalse(ExecutionAliasResolver.IsSafeAliasName(alias),
+            $"Expected '{alias}' to be rejected — contains an invalid filename character");
+    }
+
+    [TestMethod]
+    public void IsSafeAliasName_TooLong_ReturnsFalse()
+    {
+        var alias = new string('a', 256) + ".exe";
+        Assert.IsFalse(ExecutionAliasResolver.IsSafeAliasName(alias),
+            "Aliases longer than 255 characters should be rejected");
+    }
+
+    // ---- ResolveAliasPath: success + base directory behaviour -----------------
+
+    [TestMethod]
+    public void ResolveAliasPath_ValidAlias_ReturnsAbsolutePathUnderBaseDirectory()
+    {
+        var baseDir = @"C:\Users\test\AppData\Local\Microsoft\WindowsApps";
+
+        var result = ExecutionAliasResolver.ResolveAliasPath("myapp.exe", baseDir);
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual(Path.Combine(baseDir, "myapp.exe"), result!.FullName);
+    }
+
+    [TestMethod]
+    public void ResolveAliasPath_DefaultBaseDirectory_UsesWindowsAppsLocation()
+    {
+        var result = ExecutionAliasResolver.ResolveAliasPath("myapp.exe");
+
+        Assert.IsNotNull(result);
+        var expectedBase = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "Microsoft",
+            "WindowsApps");
+        Assert.AreEqual(Path.Combine(expectedBase, "myapp.exe"), result!.FullName);
+    }
+
+    [TestMethod]
+    public void GetDefaultWindowsAppsDirectory_ReturnsExpectedPath()
+    {
+        var expected = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "Microsoft",
+            "WindowsApps");
+
+        Assert.AreEqual(expected, ExecutionAliasResolver.GetDefaultWindowsAppsDirectory());
+    }
+
+    // ---- ResolveAliasPath: refuse hostile inputs ------------------------------
+
+    [TestMethod]
+    [DataRow("..\\evil.exe", DisplayName = "parent traversal must not resolve")]
+    [DataRow("dir\\evil.exe", DisplayName = "path separator must not resolve")]
+    [DataRow("C:\\Windows\\System32\\calc.exe", DisplayName = "absolute path must not resolve")]
+    [DataRow("\\\\server\\share\\evil.exe", DisplayName = "UNC must not resolve")]
+    [DataRow("", DisplayName = "empty must not resolve")]
+    [DataRow(null, DisplayName = "null must not resolve")]
+    [DataRow("evil\0.exe", DisplayName = "NUL must not resolve")]
+    public void ResolveAliasPath_HostileAlias_ReturnsNull(string? alias)
+    {
+        var result = ExecutionAliasResolver.ResolveAliasPath(alias, @"C:\WindowsApps");
+
+        Assert.IsNull(result,
+            $"Hostile alias '{alias ?? "<null>"}' must not be resolved to a filesystem path");
+    }
+
+    // ---- ResolveAliasPath: Exists reports filesystem state --------------------
+
+    [TestMethod]
+    public void ResolveAliasPath_NonExistentFile_ReturnsFileInfoWithExistsFalse()
+    {
+        // Use a base directory and alias guaranteed not to exist on the test agent.
+        var baseDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var alias = $"winappcli-test-{Guid.NewGuid():N}.exe";
+
+        var result = ExecutionAliasResolver.ResolveAliasPath(alias, baseDir);
+
+        Assert.IsNotNull(result);
+        Assert.IsFalse(result!.Exists,
+            "ResolveAliasPath must not create the file; callers verify existence themselves");
+    }
+
+    [TestMethod]
+    public void ResolveAliasPath_ExistingFile_ReturnsFileInfoWithExistsTrue()
+    {
+        var baseDir = Path.Combine(Path.GetTempPath(), $"winappcli-resolver-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(baseDir);
+        try
+        {
+            var alias = "fake-alias.exe";
+            var fullPath = Path.Combine(baseDir, alias);
+            File.WriteAllText(fullPath, string.Empty);
+
+            var result = ExecutionAliasResolver.ResolveAliasPath(alias, baseDir);
+
+            Assert.IsNotNull(result);
+            Assert.IsTrue(result!.Exists,
+                "FileInfo.Exists should be true when the resolved file is present");
+            Assert.AreEqual(fullPath, result.FullName);
+        }
+        finally
+        {
+            Directory.Delete(baseDir, recursive: true);
+        }
+    }
+}

--- a/src/winapp-CLI/WinApp.Cli.Tests/ManifestAddAliasCommandTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/ManifestAddAliasCommandTests.cs
@@ -710,6 +710,36 @@ public class ManifestAddAliasCommandTests : BaseCommandTests
         Assert.AreEqual(originalContent, currentContent, "Manifest must not be modified when inferred alias is rejected");
     }
 
+    [TestMethod]
+    [DataRow("app\\my-app.exe", "my-app.exe", DisplayName = "backslash subdir (Electron pattern)")]
+    [DataRow("app/my-app.exe", "my-app.exe", DisplayName = "forward slash subdir")]
+    [DataRow("bin\\sub\\nested.exe", "nested.exe", DisplayName = "multi-segment subdir")]
+    public async Task AddAlias_PathPrefixedExecutable_InfersLeafFilenameAsAlias(string executable, string expectedAlias)
+    {
+        // The MSIX manifest's Application/@Executable is a package-relative path
+        // (e.g. "app\my-app.exe" — Electron guide). The inferred alias must be
+        // the leaf filename, not the full path.
+        var manifestPath = CreateManifest($"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+                     IgnorableNamespaces="">
+              <Identity Name="test-app" Publisher="CN=test" Version="1.0.0.0" />
+              <Applications>
+                <Application Id="testApp" Executable="{executable}" EntryPoint="Windows.FullTrustApplication">
+                </Application>
+              </Applications>
+            </Package>
+            """);
+
+        var command = GetRequiredService<ManifestAddAliasCommand>();
+
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["--manifest", manifestPath]);
+
+        Assert.AreEqual(0, exitCode, $"Command should succeed for Executable='{executable}'");
+        var content = await File.ReadAllTextAsync(manifestPath);
+        Assert.Contains($"Alias=\"{expectedAlias}\"", content, "Alias should be the leaf filename of Executable");
+    }
+
     #endregion
 
     #region Helper methods

--- a/src/winapp-CLI/WinApp.Cli.Tests/ManifestAddAliasCommandTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/ManifestAddAliasCommandTests.cs
@@ -648,6 +648,70 @@ public class ManifestAddAliasCommandTests : BaseCommandTests
 
     #endregion
 
+    #region Alias name validation tests
+
+    [TestMethod]
+    [DataRow("..\\evil.exe", DisplayName = "parent traversal")]
+    [DataRow("dir\\evil.exe", DisplayName = "path separator")]
+    [DataRow("C:\\Windows\\System32\\calc.exe", DisplayName = "absolute path")]
+    [DataRow("evil:test.exe", DisplayName = "colon / ADS")]
+    [DataRow("evil*.exe", DisplayName = "invalid char (asterisk)")]
+    [DataRow("CON.exe", DisplayName = "reserved DOS device name")]
+    [DataRow("NUL.exe", DisplayName = "reserved DOS device name (NUL)")]
+    [DataRow("COM1.exe", DisplayName = "reserved DOS device name (COM1)")]
+    public async Task AddAlias_UnsafeName_RejectsAndDoesNotModifyManifest(string unsafeAlias)
+    {
+        var manifestPath = CreateManifest("""
+            <?xml version="1.0" encoding="utf-8"?>
+            <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+                     IgnorableNamespaces="">
+              <Identity Name="test-app" Publisher="CN=test" Version="1.0.0.0" />
+              <Applications>
+                <Application Id="testApp" Executable="myapp.exe" EntryPoint="Windows.FullTrustApplication">
+                </Application>
+              </Applications>
+            </Package>
+            """);
+        var originalContent = await File.ReadAllTextAsync(manifestPath);
+
+        var command = GetRequiredService<ManifestAddAliasCommand>();
+
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["--manifest", manifestPath, "--name", unsafeAlias]);
+
+        Assert.AreEqual(1, exitCode, $"Command should fail for unsafe alias '{unsafeAlias}'");
+        var currentContent = await File.ReadAllTextAsync(manifestPath);
+        Assert.AreEqual(originalContent, currentContent, "Manifest must not be modified when alias is rejected");
+    }
+
+    [TestMethod]
+    public async Task AddAlias_UnsafeExecutableInferred_RejectsAndDoesNotModifyManifest()
+    {
+        // Executable attribute itself is the attack vector here — it gets used
+        // as the alias name when --name is not supplied.
+        var manifestPath = CreateManifest("""
+            <?xml version="1.0" encoding="utf-8"?>
+            <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+                     IgnorableNamespaces="">
+              <Identity Name="test-app" Publisher="CN=test" Version="1.0.0.0" />
+              <Applications>
+                <Application Id="testApp" Executable="..\evil.exe" EntryPoint="Windows.FullTrustApplication">
+                </Application>
+              </Applications>
+            </Package>
+            """);
+        var originalContent = await File.ReadAllTextAsync(manifestPath);
+
+        var command = GetRequiredService<ManifestAddAliasCommand>();
+
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["--manifest", manifestPath]);
+
+        Assert.AreEqual(1, exitCode, "Command should fail when inferred alias is unsafe");
+        var currentContent = await File.ReadAllTextAsync(manifestPath);
+        Assert.AreEqual(originalContent, currentContent, "Manifest must not be modified when inferred alias is rejected");
+    }
+
+    #endregion
+
     #region Helper methods
 
     private string CreateManifest(string content)

--- a/src/winapp-CLI/WinApp.Cli/Commands/ManifestAddAliasCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/ManifestAddAliasCommand.cs
@@ -95,6 +95,13 @@ internal class ManifestAddAliasCommand : Command, IShortDescription
                     logger.LogError("{UISymbol} Could not infer alias name from Executable attribute. Use --name to specify the alias.", UiSymbols.Error);
                     return 1;
 
+                case AddExecutionAliasStatus.InvalidAliasName:
+                    logger.LogError(
+                        "{UISymbol} Alias name '{Alias}' is not a valid bare .exe filename. Aliases must be a single .exe filename with no path separators, drive letters, '..' segments, trailing dots/spaces, or reserved device names (CON, NUL, COM1-9, LPT1-9).",
+                        UiSymbols.Error,
+                        result.AliasName);
+                    return 1;
+
                 case AddExecutionAliasStatus.ManifestParseError:
                     logger.LogError("{UISymbol} Failed to parse manifest: {Error}", UiSymbols.Error, result.ErrorMessage);
                     return 1;

--- a/src/winapp-CLI/WinApp.Cli/Commands/RunCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/RunCommand.cs
@@ -569,7 +569,7 @@ internal partial class RunCommand : Command, IShortDescription
             if (!ExecutionAliasResolver.IsSafeAliasName(alias))
             {
                 logger.LogError(
-                    "{UISymbol} Execution alias '{Alias}' is not a valid bare filename. Aliases must be a single .exe filename with no path separators, drive letters, or '..' segments. Fix the <uap5:ExecutionAlias> entry in the manifest.",
+                    "{UISymbol} Execution alias '{Alias}' is not a valid bare .exe filename. Aliases must be a single .exe filename with no path separators, drive letters, '..' segments, trailing dots/spaces, or reserved device names (CON, NUL, COM1-9, LPT1-9). Fix the <uap5:ExecutionAlias> entry in the manifest.",
                     UiSymbols.Error,
                     alias);
                 return 1;

--- a/src/winapp-CLI/WinApp.Cli/Commands/RunCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/RunCommand.cs
@@ -562,18 +562,47 @@ internal partial class RunCommand : Command, IShortDescription
                 return 1;
             }
 
+            // The alias value is attacker-controlled (it comes verbatim from the manifest,
+            // which may originate from an untrusted repo). Reject any alias that is not a
+            // bare filename before touching the filesystem.
             var alias = aliases[0]; // Use the first alias
+            if (!ExecutionAliasResolver.IsSafeAliasName(alias))
+            {
+                logger.LogError(
+                    "{UISymbol} Execution alias '{Alias}' is not a valid bare filename. Aliases must be a single .exe filename with no path separators, drive letters, or '..' segments. Fix the <uap5:ExecutionAlias> entry in the manifest.",
+                    UiSymbols.Error,
+                    alias);
+                return 1;
+            }
+
+            // Resolve the alias to the canonical Windows App Execution Alias proxy under
+            // %LOCALAPPDATA%\Microsoft\WindowsApps\. Using an absolute path here is the
+            // mitigation for the bare-filename CWD/PATH lookup that CreateProcess would
+            // otherwise perform — passing just "a.exe" would let an attacker-supplied
+            // a.exe in the project folder hijack the launch.
+            var aliasFile = ExecutionAliasResolver.ResolveAliasPath(alias);
+            if (aliasFile is null || !aliasFile.Exists)
+            {
+                logger.LogError(
+                    "{UISymbol} Execution alias proxy for '{Alias}' was not found at the expected location ('{ExpectedPath}'). Windows may not have registered the alias yet, or it has been removed. Try re-running 'winapp run' without --with-alias to launch via AUMID instead.",
+                    UiSymbols.Error,
+                    alias,
+                    aliasFile?.FullName ?? ExecutionAliasResolver.GetDefaultWindowsAppsDirectory());
+                return 1;
+            }
 
             // Build the ProcessStartInfo via a static helper so the argument-forwarding
-            // contract is unit-testable without spawning a real process.
-            var psi = BuildAliasProcessStartInfo(alias, appArgs);
+            // contract is unit-testable without spawning a real process. The FileName is
+            // the fully-qualified WindowsApps path so CreateProcess does not consult CWD
+            // or PATH when launching.
+            var psi = BuildAliasProcessStartInfo(aliasFile.FullName, appArgs);
 
             try
             {
                 using var process = Process.Start(psi);
                 if (process == null)
                 {
-                    logger.LogError("{UISymbol} Failed to start process via execution alias '{Alias}'.", UiSymbols.Error, alias);
+                    logger.LogError("{UISymbol} Failed to start process via execution alias '{Alias}' ({Path}).", UiSymbols.Error, alias, aliasFile.FullName);
                     return 1;
                 }
 
@@ -602,7 +631,7 @@ internal partial class RunCommand : Command, IShortDescription
             }
             catch (Exception ex)
             {
-                logger.LogError("{UISymbol} Failed to launch via execution alias '{Alias}': {Error}", UiSymbols.Error, alias, ex.Message);
+                logger.LogError("{UISymbol} Failed to launch via execution alias '{Alias}' ({Path}): {Error}", UiSymbols.Error, alias, aliasFile.FullName, ex.Message);
                 return 1;
             }
         }

--- a/src/winapp-CLI/WinApp.Cli/Helpers/ExecutionAliasResolver.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/ExecutionAliasResolver.cs
@@ -28,6 +28,16 @@ namespace WinApp.Cli.Helpers;
 /// </remarks>
 internal static class ExecutionAliasResolver
 {
+    // Windows reserved device basenames. The OS treats these specially in
+    // path resolution regardless of extension (e.g. "CON.exe" still binds
+    // to the CON device), so they must never appear as an alias filename.
+    private static readonly HashSet<string> ReservedDeviceNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "CON", "PRN", "AUX", "NUL",
+        "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
+        "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
+    };
+
     /// <summary>
     /// Returns true when <paramref name="alias"/> is a safe bare filename
     /// suitable for resolving under the WindowsApps alias directory.
@@ -39,7 +49,13 @@ internal static class ExecutionAliasResolver
     /// letters, UNC, leading separators), <c>..</c> path components, the bare
     /// dot/double-dot names, any character in
     /// <see cref="Path.GetInvalidFileNameChars"/> (which includes NUL and
-    /// other control chars on Windows), and names longer than 255 characters.
+    /// other control chars on Windows), names longer than 255 characters,
+    /// names without a <c>.exe</c> suffix (Windows App Execution Aliases are
+    /// always <c>.exe</c> proxies), names ending in a dot or space (Win32
+    /// silently strips these during path normalization, which would make the
+    /// validated string and the launched file diverge), and Windows reserved
+    /// device basenames such as <c>CON</c>, <c>NUL</c>, <c>COM1..9</c>,
+    /// <c>LPT1..9</c>, with or without an extension.
     /// </remarks>
     public static bool IsSafeAliasName(string? alias)
     {
@@ -85,6 +101,39 @@ internal static class ExecutionAliasResolver
             return false;
         }
 
+        // Windows path normalization silently trims trailing dots and spaces
+        // ("evil.exe." resolves to "evil.exe"), which would let an attacker
+        // construct an alias whose validated form differs from the file the
+        // OS actually opens. Reject any such name.
+        var lastChar = alias[^1];
+        if (lastChar == '.' || lastChar == ' ')
+        {
+            return false;
+        }
+
+        // Windows App Execution Aliases are .exe proxy stubs under
+        // %LOCALAPPDATA%\Microsoft\WindowsApps. Anything else cannot
+        // legitimately resolve to a registered alias.
+        if (!alias.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        // Reserved DOS device names are special-cased by Win32 regardless of
+        // extension or directory ("CON", "CON.exe", "CON.txt.exe" all bind
+        // to the CON device). Reject by checking the basename before the
+        // first '.'.
+        var stem = alias;
+        var firstDot = alias.IndexOf('.');
+        if (firstDot >= 0)
+        {
+            stem = alias[..firstDot];
+        }
+        if (ReservedDeviceNames.Contains(stem))
+        {
+            return false;
+        }
+
         return true;
     }
 
@@ -102,12 +151,21 @@ internal static class ExecutionAliasResolver
     /// Resolves <paramref name="alias"/> to an absolute <see cref="FileInfo"/>
     /// under the supplied <paramref name="baseDirectory"/> (or the default
     /// WindowsApps location when <paramref name="baseDirectory"/> is null).
-    /// Returns null when the alias is not a safe bare filename.
+    /// Returns null when the alias is not a safe bare filename, or when the
+    /// base directory is not a rooted absolute path.
     /// </summary>
     /// <remarks>
     /// The returned <see cref="FileInfo"/>'s <c>Exists</c> property indicates
     /// whether Windows has actually registered an alias proxy at that path —
     /// callers should check it before launching.
+    /// <para>
+    /// Refusing to resolve when <paramref name="baseDirectory"/> (or
+    /// <c>LocalApplicationData</c>) is empty/relative is critical: a
+    /// CWD-relative base would let <see cref="FileInfo.FullName"/> root the
+    /// resolved path under the (potentially hostile) current working
+    /// directory, reintroducing the very CWD-search RCE this resolver exists
+    /// to prevent.
+    /// </para>
     /// </remarks>
     public static FileInfo? ResolveAliasPath(string? alias, string? baseDirectory = null)
     {
@@ -117,6 +175,11 @@ internal static class ExecutionAliasResolver
         }
 
         var dir = baseDirectory ?? GetDefaultWindowsAppsDirectory();
+        if (string.IsNullOrEmpty(dir) || !Path.IsPathFullyQualified(dir))
+        {
+            return null;
+        }
+
         return new FileInfo(Path.Combine(dir, alias!));
     }
 }

--- a/src/winapp-CLI/WinApp.Cli/Helpers/ExecutionAliasResolver.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/ExecutionAliasResolver.cs
@@ -1,0 +1,122 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+namespace WinApp.Cli.Helpers;
+
+/// <summary>
+/// Validates execution alias names from AppX manifests and resolves them to the
+/// canonical Windows App Execution Alias location under
+/// <c>%LOCALAPPDATA%\Microsoft\WindowsApps</c>.
+/// </summary>
+/// <remarks>
+/// Manifest <c>&lt;uap5:ExecutionAlias Alias="..."/&gt;</c> values are
+/// attacker-controlled when the user runs <c>winapp run --with-alias</c> in an
+/// untrusted repository. Passing a bare filename like <c>"a.exe"</c> directly to
+/// <see cref="System.Diagnostics.Process.Start(System.Diagnostics.ProcessStartInfo)"/>
+/// with <c>UseShellExecute = false</c> dispatches to <c>CreateProcessW</c>,
+/// which resolves bare filenames against the current working directory first.
+/// An attacker who ships a hostile <c>a.exe</c> next to a malicious manifest
+/// would have it executed in place of the real Windows App Execution Alias
+/// proxy. This resolver:
+/// <list type="bullet">
+///   <item>Rejects any alias that is not a bare filename (path separators,
+///         <c>..</c>, drive letters, UNC paths, control chars).</item>
+///   <item>Returns the absolute path under the WindowsApps folder so callers
+///         can pass it to <c>ProcessStartInfo.FileName</c> directly. Absolute
+///         paths bypass <c>CreateProcess</c>'s CWD/PATH search.</item>
+/// </list>
+/// </remarks>
+internal static class ExecutionAliasResolver
+{
+    /// <summary>
+    /// Returns true when <paramref name="alias"/> is a safe bare filename
+    /// suitable for resolving under the WindowsApps alias directory.
+    /// </summary>
+    /// <remarks>
+    /// Rejects null/empty/whitespace, any path separator
+    /// (<see cref="Path.DirectorySeparatorChar"/> or
+    /// <see cref="Path.AltDirectorySeparatorChar"/>), rooted paths (drive
+    /// letters, UNC, leading separators), <c>..</c> path components, the bare
+    /// dot/double-dot names, any character in
+    /// <see cref="Path.GetInvalidFileNameChars"/> (which includes NUL and
+    /// other control chars on Windows), and names longer than 255 characters.
+    /// </remarks>
+    public static bool IsSafeAliasName(string? alias)
+    {
+        if (string.IsNullOrWhiteSpace(alias))
+        {
+            return false;
+        }
+
+        if (alias.Length > 255)
+        {
+            return false;
+        }
+
+        if (alias is "." or "..")
+        {
+            return false;
+        }
+
+        if (alias.Contains(Path.DirectorySeparatorChar)
+            || alias.Contains(Path.AltDirectorySeparatorChar))
+        {
+            return false;
+        }
+
+        if (Path.IsPathRooted(alias))
+        {
+            return false;
+        }
+
+        foreach (var invalid in Path.GetInvalidFileNameChars())
+        {
+            if (alias.Contains(invalid))
+            {
+                return false;
+            }
+        }
+
+        // Defence in depth: GetFileName strips any path components. If the
+        // result differs from the input, the input contained path-like content
+        // that the checks above missed (e.g. future platform differences).
+        if (!string.Equals(Path.GetFileName(alias), alias, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Returns the default Windows App Execution Alias base directory:
+    /// <c>%LOCALAPPDATA%\Microsoft\WindowsApps</c>.
+    /// </summary>
+    public static string GetDefaultWindowsAppsDirectory()
+        => Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "Microsoft",
+            "WindowsApps");
+
+    /// <summary>
+    /// Resolves <paramref name="alias"/> to an absolute <see cref="FileInfo"/>
+    /// under the supplied <paramref name="baseDirectory"/> (or the default
+    /// WindowsApps location when <paramref name="baseDirectory"/> is null).
+    /// Returns null when the alias is not a safe bare filename.
+    /// </summary>
+    /// <remarks>
+    /// The returned <see cref="FileInfo"/>'s <c>Exists</c> property indicates
+    /// whether Windows has actually registered an alias proxy at that path —
+    /// callers should check it before launching.
+    /// </remarks>
+    public static FileInfo? ResolveAliasPath(string? alias, string? baseDirectory = null)
+    {
+        if (!IsSafeAliasName(alias))
+        {
+            return null;
+        }
+
+        var dir = baseDirectory ?? GetDefaultWindowsAppsDirectory();
+        return new FileInfo(Path.Combine(dir, alias!));
+    }
+}

--- a/src/winapp-CLI/WinApp.Cli/Models/AddExecutionAliasResult.cs
+++ b/src/winapp-CLI/WinApp.Cli/Models/AddExecutionAliasResult.cs
@@ -11,6 +11,7 @@ internal enum AddExecutionAliasStatus
     NoApplicationElement,
     ApplicationIdNotFound,
     CouldNotInferAlias,
+    InvalidAliasName,
     ManifestParseError,
     ManifestEmpty,
 }

--- a/src/winapp-CLI/WinApp.Cli/Services/ManifestService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/ManifestService.cs
@@ -561,6 +561,15 @@ internal partial class ManifestService(
             aliasName += ".exe";
         }
 
+        // Validate the alias is a safe bare filename before writing it into
+        // the manifest. The same validator is used on the read side
+        // (RunCommand --with-alias) — see ExecutionAliasResolver for the
+        // RCE class this defends against.
+        if (!Helpers.ExecutionAliasResolver.IsSafeAliasName(aliasName))
+        {
+            return new AddExecutionAliasResult(AddExecutionAliasStatus.InvalidAliasName, AliasName: aliasName);
+        }
+
         // Check if the target Application already has any execution alias
         var targetExtensions = targetApp.Element(AppxManifestDocument.DefaultNs + "Extensions");
         if (targetExtensions != null)

--- a/src/winapp-CLI/WinApp.Cli/Services/ManifestService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/ManifestService.cs
@@ -540,14 +540,28 @@ internal partial class ManifestService(
             targetApp = applications[0];
         }
 
-        // Infer alias name from Executable attribute if not specified
+        // Infer alias name from Executable attribute if not specified.
+        // The MSIX manifest's Application/@Executable is a package-relative path
+        // (e.g. "app\my-app.exe" — see the Electron guide), so extract the leaf
+        // filename before using it as an alias. Still reject path-traversal
+        // segments defensively so a hostile manifest can't smuggle "..\evil.exe"
+        // through inference.
         var aliasName = options.AliasName;
         if (string.IsNullOrEmpty(aliasName))
         {
             var executable = targetApp.Attribute("Executable")?.Value;
             if (!string.IsNullOrEmpty(executable))
             {
-                aliasName = executable;
+                if (executable.Split('\\', '/').Any(seg => seg == ".."))
+                {
+                    return new AddExecutionAliasResult(AddExecutionAliasStatus.InvalidAliasName, AliasName: executable);
+                }
+
+                aliasName = Path.GetFileName(executable);
+                if (string.IsNullOrEmpty(aliasName))
+                {
+                    return new AddExecutionAliasResult(AddExecutionAliasStatus.CouldNotInferAlias);
+                }
             }
             else
             {


### PR DESCRIPTION
## Summary

Fixes an MSRC-reported RCE (case `bbe50a79-0358-f111-8ce8-000d3ac30a19`) in `winapp run --with-alias`.

`winapp run --with-alias` passed the alias from `<uap5:ExecutionAlias>` verbatim to `ProcessStartInfo.FileName` with `UseShellExecute = false`. .NET dispatches that through `CreateProcessW`, which resolves bare filenames against the **current working directory before PATH**. The Windows App Execution Alias proxy lives under `%LOCALAPPDATA%\Microsoft\WindowsApps\` (on PATH), but a hostile `a.exe` shipped alongside `Package.appxmanifest` in an untrusted repo would win the lookup and run in place of the registered alias — RCE with the developer's privileges from a clone-and-run flow.

## Fix

Add `Helpers/ExecutionAliasResolver.cs` with:

- `IsSafeAliasName(alias)` — validates the alias is a bare filename: rejects path separators (`\`, `/`), `..`, rooted paths (drive letters, UNC, leading separator), invalid filename chars (incl. NUL/control chars), oversized names, dot-names.
- `ResolveAliasPath(alias, baseDirectory?)` — combines the validated alias with the WindowsApps base directory and returns the absolute `FileInfo`. `baseDirectory` is parameterised for testability; production callers use `%LOCALAPPDATA%\Microsoft\WindowsApps`.

`RunCommand.LaunchViaExecutionAliasAsync` now:

1. Validates the extracted alias via `IsSafeAliasName`; rejects path-like values with a clear log message.
2. Resolves it to the absolute `%LOCALAPPDATA%\Microsoft\WindowsApps\<alias>` path.
3. Verifies the proxy file exists; if not, errors with a message pointing the user at AUMID launch (drop `--with-alias`).
4. Passes that **absolute path** to `ProcessStartInfo.FileName`. Absolute paths bypass `CreateProcess`'s CWD/PATH search entirely, so a hostile binary next to the manifest can no longer hijack the launch.

`MsixService.ExtractExecutionAliases` and `BuildAliasProcessStartInfo` keep their original semantics — validation/resolution is a launch concern, not a manifest-parsing one.

## Tests

New `ExecutionAliasResolverTests.cs` (31 tests):

- ✅ Accepted bare names: simple `.exe`, mixed case, hyphen/underscore/digits, single letter, no extension, internal dots
- ❌ Rejected: null/empty/whitespace/tab, `.`, `..`, all path separator variants, parent traversal (both slash flavours), nested paths, leading `/` and `\`, absolute paths with drive letters, drive-relative, UNC, extended-length UNC, NUL char, invalid filename chars (`* ? < > | " :`), names > 255 chars
- ✅ `ResolveAliasPath`: returns correct path under custom + default WindowsApps base; returns null for hostile aliases; `FileInfo.Exists` correctly reflects filesystem state for present/missing proxies

## Verification

- `dotnet build src/winapp-CLI/winapp.sln -c Debug` — clean (0 warnings, 0 errors)
- 1118 / 1118 unit tests pass (5 unrelated E2E failures need `npm run build` for the Node harness — not exercised by this change)
- `.\scripts\build-cli.ps1 -SkipMsix -SkipNpm -SkipTests` — full pipeline succeeds; auto-generated `docs/cli-schema.json` and skill docs unchanged (no user-facing option text changed)

## Notes

- The user-facing `--with-alias` option description is unchanged; this is an internal correctness/security fix, not an API change.
- `BuildAliasProcessStartInfo` is intentionally untouched — it just plumbs a string into `ProcessStartInfo`; the call site now passes a fully-qualified path.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>