### PR TITLE
Fix: pack with --self-contained won't overwrite dupe files from runtime like resources.pri

### DIFF
--- a/.github/workflows/test-samples.yml
+++ b/.github/workflows/test-samples.yml
@@ -58,6 +58,10 @@ jobs:
       fail-fast: false
       matrix:
         sample: [cpp-app, dotnet-app, electron, flutter-app, packaging-cli, rust-app, tauri-app, wpf-app]
+        node-version: ['24']
+        include:
+          - sample: electron
+            node-version: '22'
     runs-on: windows-latest
     name: ${{ matrix.sample }}
 
@@ -127,7 +131,7 @@ jobs:
         contains(fromJson('["electron", "tauri-app", "cpp-app", "dotnet-app", "wpf-app", "rust-app", "flutter-app", "packaging-cli"]'), matrix.sample)
       uses: actions/setup-node@v5
       with:
-        node-version: '24'
+        node-version: ${{ matrix.node-version }}
 
     - name: Setup Flutter
       if: >-

--- a/.github/workflows/test-samples.yml
+++ b/.github/workflows/test-samples.yml
@@ -37,7 +37,7 @@ jobs:
         dotnet-version: '10.0.x'
     - uses: actions/setup-node@v5
       with:
-        node-version: '24'
+        node-version: '22'
     - name: Build npm package
       shell: pwsh
       run: .\scripts\build-cli.ps1 -SkipTests -SkipMsix -SkipVsc
@@ -58,10 +58,6 @@ jobs:
       fail-fast: false
       matrix:
         sample: [cpp-app, dotnet-app, electron, flutter-app, packaging-cli, rust-app, tauri-app, wpf-app]
-        node-version: ['24']
-        include:
-          - sample: electron
-            node-version: '22'
     runs-on: windows-latest
     name: ${{ matrix.sample }}
 
@@ -131,7 +127,7 @@ jobs:
         contains(fromJson('["electron", "tauri-app", "cpp-app", "dotnet-app", "wpf-app", "rust-app", "flutter-app", "packaging-cli"]'), matrix.sample)
       uses: actions/setup-node@v5
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: '22'
 
     - name: Setup Flutter
       if: >-

--- a/src/winapp-CLI/WinApp.Cli.Tests/MsixServiceTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/MsixServiceTests.cs
@@ -1942,4 +1942,81 @@ public class MsixServiceTests
         }
         return count;
     }
+
+    #region MergeRuntimeFilesIntoStaging tests
+
+    [TestMethod]
+    public void MergeRuntimeFilesIntoStaging_DoesNotOverwriteExistingResourcesPri()
+    {
+        // Arrange — staging has the app's resources.pri
+        var stagingDir = _tempDir.CreateSubdirectory("staging");
+        var appPriContent = "APP_PRI_CONTENT"u8.ToArray();
+        File.WriteAllBytes(Path.Combine(stagingDir.FullName, "resources.pri"), appPriContent);
+
+        // Runtime source has its own resources.pri
+        var runtimeDir = _tempDir.CreateSubdirectory("runtime");
+        File.WriteAllBytes(Path.Combine(runtimeDir.FullName, "resources.pri"), "RUNTIME_PRI"u8.ToArray());
+
+        // Act
+        MsixService.MergeRuntimeFilesIntoStaging(runtimeDir, stagingDir);
+
+        // Assert — app's PRI is preserved
+        var resultPri = File.ReadAllBytes(Path.Combine(stagingDir.FullName, "resources.pri"));
+        CollectionAssert.AreEqual(appPriContent, resultPri,
+            "App's resources.pri must not be overwritten by the runtime's");
+    }
+
+    [TestMethod]
+    public void MergeRuntimeFilesIntoStaging_DoesNotOverwriteExistingAssets()
+    {
+        // Arrange — staging has the app's StoreLogo
+        var stagingDir = _tempDir.CreateSubdirectory("staging");
+        var assetsDir = stagingDir.CreateSubdirectory("Assets");
+        var appLogoContent = "APP_STORE_LOGO"u8.ToArray();
+        File.WriteAllBytes(Path.Combine(assetsDir.FullName, "StoreLogo.png"), appLogoContent);
+
+        // Runtime source has its own Assets\StoreLogo.png
+        var runtimeDir = _tempDir.CreateSubdirectory("runtime");
+        var runtimeAssetsDir = runtimeDir.CreateSubdirectory("Assets");
+        File.WriteAllBytes(Path.Combine(runtimeAssetsDir.FullName, "StoreLogo.png"), "RUNTIME_LOGO"u8.ToArray());
+
+        // Act
+        MsixService.MergeRuntimeFilesIntoStaging(runtimeDir, stagingDir);
+
+        // Assert — app's asset is preserved
+        var resultLogo = File.ReadAllBytes(Path.Combine(assetsDir.FullName, "StoreLogo.png"));
+        CollectionAssert.AreEqual(appLogoContent, resultLogo,
+            "App's Assets\\StoreLogo.png must not be overwritten by the runtime's");
+    }
+
+    [TestMethod]
+    public void MergeRuntimeFilesIntoStaging_CopiesNewRuntimeFiles()
+    {
+        // Arrange — staging is empty
+        var stagingDir = _tempDir.CreateSubdirectory("staging");
+
+        // Runtime source has DLLs and PRI
+        var runtimeDir = _tempDir.CreateSubdirectory("runtime");
+        File.WriteAllBytes(Path.Combine(runtimeDir.FullName, "Microsoft.WindowsAppRuntime.dll"), [0x01]);
+        File.WriteAllBytes(Path.Combine(runtimeDir.FullName, "Microsoft.UI.pri"), [0x02]);
+
+        // Act
+        MsixService.MergeRuntimeFilesIntoStaging(runtimeDir, stagingDir);
+
+        // Assert — runtime files are copied
+        Assert.IsTrue(File.Exists(Path.Combine(stagingDir.FullName, "Microsoft.WindowsAppRuntime.dll")));
+        Assert.IsTrue(File.Exists(Path.Combine(stagingDir.FullName, "Microsoft.UI.pri")));
+    }
+
+    [TestMethod]
+    public void MergeRuntimeFilesIntoStaging_ThrowsWhenSourceDirMissing()
+    {
+        var stagingDir = _tempDir.CreateSubdirectory("staging");
+        var missingDir = new DirectoryInfo(Path.Combine(_tempDir.FullName, "does-not-exist"));
+
+        Assert.ThrowsExactly<DirectoryNotFoundException>(
+            () => MsixService.MergeRuntimeFilesIntoStaging(missingDir, stagingDir));
+    }
+
+    #endregion
 }

--- a/src/winapp-CLI/WinApp.Cli/Services/MsixService.Runtime.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/MsixService.Runtime.cs
@@ -873,7 +873,19 @@ internal partial class MsixService
                     Directory.CreateDirectory(destDir);
                 }
 
-                file.CopyTo(destFile, overwrite: true);
+                // Never overwrite existing app files with runtime equivalents. The staging
+                // directory already contains the app's own assets, PRI, and resources — these
+                // must take precedence. In particular, overwriting resources.pri would destroy
+                // the app's MRT mappings (e.g. SplashScreen.png → SplashScreen.scale-200.png)
+                // and cause deployment failure (0x80070002). Similarly, the runtime's placeholder
+                // Assets\StoreLogo.png must not replace the app's branded icons.
+                if (File.Exists(destFile))
+                {
+                    taskContext.AddDebugMessage($"{UiSymbols.Note} Skipping (app file exists): {relativePath}");
+                    continue;
+                }
+
+                file.CopyTo(destFile, overwrite: false);
 
                 taskContext.AddDebugMessage($"{UiSymbols.Folder} Bundled runtime: {relativePath}");
             }

--- a/src/winapp-CLI/WinApp.Cli/Services/MsixService.Runtime.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/MsixService.Runtime.cs
@@ -858,45 +858,52 @@ internal partial class MsixService
         // Copy runtime files from .winapp/self-contained to input folder
         var runtimeSourceDir = new DirectoryInfo(Path.Combine(winappDir.FullName, "self-contained", arch, "deployment"));
 
-        if (runtimeSourceDir.Exists)
-        {
-            // Copy files recursively to maintain directory structure
-            foreach (var file in runtimeSourceDir.GetFiles("*", SearchOption.AllDirectories))
-            {
-                var relativePath = Path.GetRelativePath(runtimeSourceDir.FullName, file.FullName);
-                var destFile = Path.Combine(inputFolder.FullName, relativePath);
+        MergeRuntimeFilesIntoStaging(runtimeSourceDir, inputFolder, taskContext);
 
-                // Create destination directory if needed
-                var destDir = Path.GetDirectoryName(destFile);
-                if (!string.IsNullOrEmpty(destDir))
-                {
-                    Directory.CreateDirectory(destDir);
-                }
+        return runtimeSourceDir;
+    }
 
-                // Never overwrite existing app files with runtime equivalents. The staging
-                // directory already contains the app's own assets, PRI, and resources — these
-                // must take precedence. In particular, overwriting resources.pri would destroy
-                // the app's MRT mappings (e.g. SplashScreen.png → SplashScreen.scale-200.png)
-                // and cause deployment failure (0x80070002). Similarly, the runtime's placeholder
-                // Assets\StoreLogo.png must not replace the app's branded icons.
-                if (File.Exists(destFile))
-                {
-                    taskContext.AddDebugMessage($"{UiSymbols.Note} Skipping (app file exists): {relativePath}");
-                    continue;
-                }
-
-                file.CopyTo(destFile, overwrite: false);
-
-                taskContext.AddDebugMessage($"{UiSymbols.Folder} Bundled runtime: {relativePath}");
-            }
-
-            taskContext.AddDebugMessage($"{UiSymbols.Check} Windows App SDK runtime bundled into package");
-        }
-        else
+    /// <summary>
+    /// Copies runtime files from <paramref name="runtimeSourceDir"/> into <paramref name="stagingDir"/>,
+    /// skipping any file that already exists in the staging directory. This ensures the app's own
+    /// assets (resources.pri, Assets\StoreLogo.png, etc.) are never overwritten by their runtime equivalents.
+    /// </summary>
+    internal static void MergeRuntimeFilesIntoStaging(DirectoryInfo runtimeSourceDir, DirectoryInfo stagingDir, TaskContext? taskContext = null)
+    {
+        if (!runtimeSourceDir.Exists)
         {
             throw new DirectoryNotFoundException($"Runtime files not found at {runtimeSourceDir}");
         }
 
-        return runtimeSourceDir;
+        foreach (var file in runtimeSourceDir.GetFiles("*", SearchOption.AllDirectories))
+        {
+            var relativePath = Path.GetRelativePath(runtimeSourceDir.FullName, file.FullName);
+            var destFile = Path.Combine(stagingDir.FullName, relativePath);
+
+            // Create destination directory if needed
+            var destDir = Path.GetDirectoryName(destFile);
+            if (!string.IsNullOrEmpty(destDir))
+            {
+                Directory.CreateDirectory(destDir);
+            }
+
+            // Never overwrite existing app files with runtime equivalents. The staging
+            // directory already contains the app's own assets, PRI, and resources — these
+            // must take precedence. In particular, overwriting resources.pri would destroy
+            // the app's MRT mappings (e.g. SplashScreen.png → SplashScreen.scale-200.png)
+            // and cause deployment failure (0x80070002). Similarly, the runtime's placeholder
+            // Assets\StoreLogo.png must not replace the app's branded icons.
+            if (File.Exists(destFile))
+            {
+                taskContext?.AddDebugMessage($"{UiSymbols.Note} Skipping (app file exists): {relativePath}");
+                continue;
+            }
+
+            file.CopyTo(destFile, overwrite: false);
+
+            taskContext?.AddDebugMessage($"{UiSymbols.Folder} Bundled runtime: {relativePath}");
+        }
+
+        taskContext?.AddDebugMessage($"{UiSymbols.Check} Windows App SDK runtime bundled into package");
     }
 }

--- a/src/winapp-CLI/WinApp.Cli/WinApp.Cli.csproj
+++ b/src/winapp-CLI/WinApp.Cli/WinApp.Cli.csproj
@@ -35,6 +35,9 @@
     <DebuggerSupport>false</DebuggerSupport>
     <EventSourceSupport>true</EventSourceSupport>
 
+    <!-- Allow test project to access internal types -->
+    <InternalsVisibleTo>WinApp.Cli.Tests</InternalsVisibleTo>
+
     <!-- The *first* DefineConstants is removed during Official Release Builds (.pipelines/Unstub.ps1)-->
     <DefineConstants>TELEMETRYEVENTSOURCE_PUBLIC</DefineConstants>
   </PropertyGroup>


### PR DESCRIPTION
fixes #548 

Generalized fix for this issue - any file that has a dupe in the dest directory will not be copied over from the runtime.