### PR TITLE
fix(ui): report ambiguity on partial process name match

### DIFF
--- a/src/winapp-CLI/WinApp.Cli/Services/UiSessionService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/UiSessionService.cs
@@ -355,6 +355,19 @@ internal sealed class UiSessionService(
                     LogPartialMatch(app, result);
                     return result;
                 }
+
+                if (withWindow.Length > 1)
+                {
+                    var listing = string.Join("\n  ",
+                        withWindow.Select(p =>
+                        {
+                            try { return $"PID {p.Id} ({p.ProcessName}): \"{p.MainWindowTitle}\""; }
+                            catch { return $"PID {p.Id}"; }
+                        }));
+                    throw new InvalidOperationException(
+                        $"Multiple processes matching '{app}' found:\n  {listing}\n" +
+                        "Use --app with a PID or a more specific window title.");
+                }
             }
         }
         finally


### PR DESCRIPTION
When multiple processes match a partial `--app` query (e.g. `-a terminal` matching two `WindowsTerminal` instances) and all have visible windows, the code silently fell through to title search which then failed with a misleading *No running app found* error.

Now it throws a clear error listing the matching PIDs, process names, and window titles — consistent with the exact-name-match path:

```
Multiple processes matching 'terminal' found:
  PID 6816 (WindowsTerminal): ...
  PID 10516 (WindowsTerminal): Administrator: Windows PowerShell
Use --app with a PID or a more specific window title.
```