### PR TITLE
Minor cleanup in our manifest / template manifests

### DIFF
--- a/msix/appxmanifest.xml
+++ b/msix/appxmanifest.xml
@@ -34,7 +34,6 @@
   <Applications>
     <Application Id="winapp"
       Executable="winapp.exe"
-      EntryPoint="Windows.FullTrustApplication"
       uap10:RuntimeBehavior="packagedClassicApp"
       uap10:TrustLevel="mediumIL" >
       <uap:VisualElements

--- a/src/winapp-CLI/WinApp.Cli.Tests/ManifestCommandTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/ManifestCommandTests.cs
@@ -126,7 +126,7 @@ public class ManifestCommandTests : BaseCommandTests
         Assert.IsTrue(File.Exists(manifestPath), "Package.appxmanifest should be created");
         var manifestContent = await File.ReadAllTextAsync(manifestPath, TestContext.CancellationToken);
         Assert.Contains("uap10:AllowExternalContent", manifestContent, "Sparse manifest should contain AllowExternalContent");
-        Assert.Contains("packagedClassicApp", manifestContent, "Sparse manifest should contain packagedClassicApp");
+        Assert.Contains("EntryPoint=\"Windows.FullTrustApplication\"", manifestContent, "Sparse manifest should contain FullTrustApplication entry point");
     }
 
     [TestMethod]

--- a/src/winapp-CLI/WinApp.Cli/Templates/appxmanifest.packaged.xml
+++ b/src/winapp-CLI/WinApp.Cli/Templates/appxmanifest.packaged.xml
@@ -33,9 +33,7 @@
   <Applications>
     <Application Id="{ApplicationId}"
       Executable="$targetnametoken$.exe"
-      EntryPoint="Windows.FullTrustApplication"
-      uap10:TrustLevel="mediumIL"
-      uap10:RuntimeBehavior="packagedClassicApp">
+      EntryPoint="Windows.FullTrustApplication">
       <uap:VisualElements
         DisplayName="{PackageName}"
         Description="{Description}"

--- a/src/winapp-CLI/WinApp.Cli/Templates/appxmanifest.sparse.xml
+++ b/src/winapp-CLI/WinApp.Cli/Templates/appxmanifest.sparse.xml
@@ -35,8 +35,7 @@
   <Applications>
     <Application Id="{ApplicationId}"
       Executable="$targetnametoken$.exe"
-      uap10:TrustLevel="mediumIL"
-      uap10:RuntimeBehavior="packagedClassicApp">
+      EntryPoint="Windows.FullTrustApplication">
       <uap:VisualElements
         AppListEntry="none"
         DisplayName="{PackageName}"


### PR DESCRIPTION
Based on original feedback from #228

fixes #574 

 `msix/appxmanifest.xml` — Removed `EntryPoint="Windows.FullTrustApplication"` (redundant since MinVersion=10.0.19045.0 ≥ 20H1, and `uap10:TrustLevel`+`RuntimeBehavior` are already specified).

  `Templates/appxmanifest.packaged.xml` and `Templates/appxmanifest.sparse.xml` — Removed `uap10:TrustLevel="mediumIL"` and `uap10:RuntimeBehavior="packagedClassicApp"`, added `EntryPoint="Windows.FullTrustApplication"` instead. This ensures compatibility with systems back to MinVersion 10.0.18362.0 (pre-20H1) where uap10 attributes aren't available.