### PR TITLE
Screenshot command with an out directory that doesn't exist will create that directory instead of throwing an exception

### DIFF
--- a/src/winapp-CLI/WinApp.Cli/Commands/UiScreenshotCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/UiScreenshotCommand.cs
@@ -97,6 +97,11 @@ internal class UiScreenshotCommand : Command, IShortDescription
                 var pngBytes = EncodePng(pixels, w, h);
 
                 var filePath = output ?? "screenshot.png";
+                var dir = Path.GetDirectoryName(Path.GetFullPath(filePath));
+                if (dir is not null)
+                {
+                    Directory.CreateDirectory(dir);
+                }
                 await File.WriteAllBytesAsync(filePath, pngBytes, cancellationToken);
                 var absolutePath = Path.GetFullPath(filePath);
 
@@ -217,6 +222,11 @@ internal class UiScreenshotCommand : Command, IShortDescription
 
             // Compose all captures side-by-side into single image
             var pngBytes = ComposeSideBySide(captures);
+            var dir = Path.GetDirectoryName(Path.GetFullPath(filePath));
+            if (dir is not null)
+            {
+                Directory.CreateDirectory(dir);
+            }
             await File.WriteAllBytesAsync(filePath, pngBytes, ct);
             var absolutePath = Path.GetFullPath(filePath);
 


### PR DESCRIPTION
fixes #572 

If a user specifies an out path with `-o` that contains directory that doesn't exist, create it.