### PR TITLE
[ci] workaround MSVC 14.51 coroutine hard-error in flutter-app test

### DIFF
--- a/samples/flutter-app/test.Tests.ps1
+++ b/samples/flutter-app/test.Tests.ps1
@@ -79,6 +79,15 @@ Describe "flutter-app sample" {
 
         It "Should build Flutter app for Windows" {
             Set-Location $script:projectDir
+            # MSVC 14.51+ hard-errors on <experimental/coroutine>; suppress until Flutter updates its runner.
+            $cmakeFile = Join-Path $script:projectDir "windows\runner\CMakeLists.txt"
+            if (Test-Path $cmakeFile) {
+                $content = Get-Content $cmakeFile -Raw
+                if ($content -notlike '*_SILENCE_EXPERIMENTAL_COROUTINE*') {
+                    $content = $content -replace '(target_compile_definitions\(\$\{BINARY_NAME\} PRIVATE[^)]*)', "`$1`n  _SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS"
+                    Set-Content $cmakeFile $content -NoNewline
+                }
+            }
             flutter build windows
             $LASTEXITCODE | Should -Be 0
             $script:buildOutput = Join-Path $script:projectDir "build\windows\x64\runner\Release"
@@ -117,6 +126,16 @@ Describe "flutter-app sample" {
             if ($LASTEXITCODE -ne 0) { throw "flutter pub get failed" }
 
             Invoke-WinappCommand -Arguments "restore"
+
+            # MSVC 14.51+ hard-errors on <experimental/coroutine>; suppress until Flutter updates its runner.
+            $cmakeFile = Join-Path $script:sampleDir "windows\runner\CMakeLists.txt"
+            if (Test-Path $cmakeFile) {
+                $content = Get-Content $cmakeFile -Raw
+                if ($content -notlike '*_SILENCE_EXPERIMENTAL_COROUTINE*') {
+                    $content = $content -replace '(target_compile_definitions\(\$\{BINARY_NAME\} PRIVATE[^)]*)', "`$1`n  _SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS"
+                    Set-Content $cmakeFile $content -NoNewline
+                }
+            }
 
             flutter build windows
             if ($LASTEXITCODE -ne 0) { throw "flutter build windows failed" }

--- a/samples/flutter-app/test.Tests.ps1
+++ b/samples/flutter-app/test.Tests.ps1
@@ -151,6 +151,7 @@ Describe "flutter-app sample" {
                     Set-Content $cmakeFile $originalCmake -Encoding utf8
                 }
             }
+        }
 
         It "Should build flutter_app.exe" {
             Join-Path $script:sampleDir "build\windows\x64\runner\Release\flutter_app.exe" | Should -Exist

--- a/samples/flutter-app/test.Tests.ps1
+++ b/samples/flutter-app/test.Tests.ps1
@@ -129,17 +129,28 @@ Describe "flutter-app sample" {
 
             # MSVC 14.51+ hard-errors on <experimental/coroutine>; suppress until Flutter updates its runner.
             $cmakeFile = Join-Path $script:sampleDir "windows\runner\CMakeLists.txt"
-            if (Test-Path $cmakeFile) {
-                $content = Get-Content $cmakeFile -Raw
-                if ($content -notlike '*_SILENCE_EXPERIMENTAL_COROUTINE*') {
-                    $content = $content -replace '(target_compile_definitions\(\$\{BINARY_NAME\} PRIVATE[^)]*)', "`$1`n  _SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS"
-                    Set-Content $cmakeFile $content -NoNewline
+            $originalCmake = $null
+            $cmakePatched = $false
+            try {
+                if (Test-Path $cmakeFile) {
+                    $originalCmake = Get-Content $cmakeFile -Raw -Encoding utf8
+                    if ($originalCmake -notlike '*_SILENCE_EXPERIMENTAL_COROUTINE*') {
+                        $patched = $originalCmake -replace '(target_compile_definitions\(\$\{BINARY_NAME\} PRIVATE[^)]*)', "`$1`n  _SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS"
+                        if ($patched -ne $originalCmake) {
+                            Set-Content $cmakeFile $patched -Encoding utf8
+                            $cmakePatched = $true
+                        }
+                    }
+                }
+
+                flutter build windows
+                if ($LASTEXITCODE -ne 0) { throw "flutter build windows failed" }
+            }
+            finally {
+                if ($cmakePatched -and $null -ne $originalCmake) {
+                    Set-Content $cmakeFile $originalCmake -Encoding utf8
                 }
             }
-
-            flutter build windows
-            if ($LASTEXITCODE -ne 0) { throw "flutter build windows failed" }
-        }
 
         It "Should build flutter_app.exe" {
             Join-Path $script:sampleDir "build\windows\x64\runner\Release\flutter_app.exe" | Should -Exist


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does and why -->

## Usage Example

<!-- If this PR adds or changes commands, flags, or APIs, include a short code snippet -->
<!-- Example:
```bash
winapp store app list
```
-->

## Related Issue

<!-- Link to any related issues: Fixes #123, Closes #456, Related to #789 -->

## Type of Change

<!-- Keep the applicable line(s), delete the rest -->

- 🐛 Bug fix
- ✨ New feature
- 💥 Breaking change
- 📝 Documentation
- 🔧 Config/build
- ♻️ Refactoring
- 🧪 Test update

## Checklist
<!-- Delete the ones that do not apply to your changes -->

- [ ] New tests added for new functionality (if applicable)
- [ ] Tested locally on Windows
- [ ] Main [README.md](../README.md) updated (if applicable)
- [ ] [docs/usage.md](../docs/usage.md) updated (if CLI commands changed)
- [ ] [Language-specific guides](../docs/guides) updated (if applicable)
- [ ] [Sample projects updated](../samples) to reflect changes (if applicable)
- [ ] Agent skill templates updated in `docs/fragments/skills/` (if CLI commands/workflows changed)

## Screenshots / Demo

<!-- If applicable, add screenshots or GIFs demonstrating the changes -->

## Additional Notes

<!-- Any additional information that reviewers should know -->

## AI Description

<!-- ai-description-start -->
This pull request modifies the PowerShell test script for the Flutter app sample to address a hard error encountered with MSVC 14.51 related to ``. A workaround is implemented by temporarily modifying the CMake configuration to suppress deprecation warnings during the build process. 

```powershell
# MSVC 14.51+ hard-errors on ; suppress until Flutter updates its runner.
$cmakeFile = Join-Path $script:projectDir "windows\runner\CMakeLists.txt"
if (Test-Path $cmakeFile) {
    $content = Get-Content $cmakeFile -Raw
    if ($content -notlike '*_SILENCE_EXPERIMENTAL_COROUTINE*') {
        $content = $content -replace '(target_compile_definitions\(\$\{BINARY_NAME\} PRIVATE[^)]*)', "`$1`n  _SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS"
        Set-Content $cmakeFile $content -NoNewline
    }
}
```
<!-- ai-description-end -->
