### PR TITLE
Add "ui hover" command to allow capturing of tooltips/flyouts/etc

### DIFF
--- a/.claude/agents/winapp.md
+++ b/.claude/agents/winapp.md
@@ -210,6 +210,7 @@ Want to inspect or interact with a running app's UI?
 - `ui get-property <selector> -a <app> [-p <prop>]` — read UIA properties (including ToggleState, Value, IsSelected, ExpandCollapseState)
 - `ui screenshot -a <app> [--output file.png] [--json] [--focus] [--capture-screen]` — capture window as PNG. Default uses Windows.Graphics.Capture (composited surface — preserves rounded corners and works while occluded), with PrintWindow as fallback. Use `--focus` to bring the window to the foreground first; use `--capture-screen` for popup overlays not owned by the target window.
 - `ui invoke <selector> -a <app>` — activate element by slug or text search. Auto-walks to invokable ancestor for non-invokable elements.
+- `ui hover <selector> -a <app> [--dwell-time <ms>]` — move mouse to element center to trigger tooltips, flyouts, and hover states. Use with `ui screenshot --capture-screen` to capture the result.
 - `ui set-value <selector> "value" -a <app>` — set text or slider value
 - `ui focus <selector> -a <app>` — move keyboard focus
 - `ui scroll-into-view <selector> -a <app>` — scroll element visible

--- a/.claude/skills/winapp-ui-automation/SKILL.md
+++ b/.claude/skills/winapp-ui-automation/SKILL.md
@@ -104,8 +104,9 @@ winapp ui screenshot -a myapp --focus --output focused.png
 ```
 
 ### Hover (for tooltips, flyouts, hover states)
+`--dwell-time <ms>` sets how long to wait after hovering (default: 800, range: 0–10000).
 ```powershell
-# Hover to trigger tooltip, then capture it
+# Hover to trigger tooltip, then capture it (default 800ms dwell)
 winapp ui hover btn-info-a1b2 -a myapp; winapp ui screenshot -a myapp --capture-screen --output tooltip.png
 
 # Longer dwell for apps with slow tooltip timers

--- a/.claude/skills/winapp-ui-automation/SKILL.md
+++ b/.claude/skills/winapp-ui-automation/SKILL.md
@@ -103,6 +103,15 @@ winapp ui screenshot -a myapp --capture-screen --output with-popups.png
 winapp ui screenshot -a myapp --focus --output focused.png
 ```
 
+### Hover (for tooltips, flyouts, hover states)
+```powershell
+# Hover to trigger tooltip, then capture it
+winapp ui hover btn-info-a1b2 -a myapp; winapp ui screenshot -a myapp --capture-screen --output tooltip.png
+
+# Longer dwell for apps with slow tooltip timers
+winapp ui hover btn-info-a1b2 -a myapp --dwell-time 1200; winapp ui screenshot -a myapp --capture-screen
+```
+
 ### Read element state
 ```powershell
 # Read text/value content (works for RichEditBox, TextBox, ComboBox, Slider, labels)
@@ -152,6 +161,7 @@ winapp ui wait-for itm-status-c3d4 -a myapp --value "Complete" --timeout 5000
 - Use `get-property --property ToggleState` to verify checkbox/toggle state after invoke
 - `scroll` auto-finds the nearest scrollable parent
 - Use `--capture-screen` to capture popup overlays, dropdown menus, and flyouts (also brings the window to the foreground)
+- Use `hover` before `screenshot --capture-screen` to capture tooltips and hover-triggered UI
 - Use `--focus` to foreground the target window before capture without switching to screen-DC capture (default capture path uses Windows.Graphics.Capture and works while occluded)
 - Use `--hide-disabled` and `--hide-offscreen` to reduce noise
 

--- a/.github/plugin/agents/winapp.agent.md
+++ b/.github/plugin/agents/winapp.agent.md
@@ -211,6 +211,7 @@ Want to inspect or interact with a running app's UI?
 - `ui get-property <selector> -a <app> [-p <prop>]` — read UIA properties (including ToggleState, Value, IsSelected, ExpandCollapseState)
 - `ui screenshot -a <app> [--output file.png] [--json] [--focus] [--capture-screen]` — capture window as PNG. Default uses Windows.Graphics.Capture (composited surface — preserves rounded corners and works while occluded), with PrintWindow as fallback. Use `--focus` to bring the window to the foreground first; use `--capture-screen` for popup overlays not owned by the target window.
 - `ui invoke <selector> -a <app>` — activate element by slug or text search. Auto-walks to invokable ancestor for non-invokable elements.
+- `ui hover <selector> -a <app> [--dwell-time <ms>]` — move mouse to element center to trigger tooltips, flyouts, and hover states. Use with `ui screenshot --capture-screen` to capture the result.
 - `ui set-value <selector> "value" -a <app>` — set text or slider value
 - `ui focus <selector> -a <app>` — move keyboard focus
 - `ui scroll-into-view <selector> -a <app>` — scroll element visible

--- a/.github/plugin/skills/winapp-cli/ui-automation/SKILL.md
+++ b/.github/plugin/skills/winapp-cli/ui-automation/SKILL.md
@@ -104,8 +104,9 @@ winapp ui screenshot -a myapp --focus --output focused.png
 ```
 
 ### Hover (for tooltips, flyouts, hover states)
+`--dwell-time <ms>` sets how long to wait after hovering (default: 800, range: 0–10000).
 ```powershell
-# Hover to trigger tooltip, then capture it
+# Hover to trigger tooltip, then capture it (default 800ms dwell)
 winapp ui hover btn-info-a1b2 -a myapp; winapp ui screenshot -a myapp --capture-screen --output tooltip.png
 
 # Longer dwell for apps with slow tooltip timers

--- a/.github/plugin/skills/winapp-cli/ui-automation/SKILL.md
+++ b/.github/plugin/skills/winapp-cli/ui-automation/SKILL.md
@@ -103,6 +103,15 @@ winapp ui screenshot -a myapp --capture-screen --output with-popups.png
 winapp ui screenshot -a myapp --focus --output focused.png
 ```
 
+### Hover (for tooltips, flyouts, hover states)
+```powershell
+# Hover to trigger tooltip, then capture it
+winapp ui hover btn-info-a1b2 -a myapp; winapp ui screenshot -a myapp --capture-screen --output tooltip.png
+
+# Longer dwell for apps with slow tooltip timers
+winapp ui hover btn-info-a1b2 -a myapp --dwell-time 1200; winapp ui screenshot -a myapp --capture-screen
+```
+
 ### Read element state
 ```powershell
 # Read text/value content (works for RichEditBox, TextBox, ComboBox, Slider, labels)
@@ -152,6 +161,7 @@ winapp ui wait-for itm-status-c3d4 -a myapp --value "Complete" --timeout 5000
 - Use `get-property --property ToggleState` to verify checkbox/toggle state after invoke
 - `scroll` auto-finds the nearest scrollable parent
 - Use `--capture-screen` to capture popup overlays, dropdown menus, and flyouts (also brings the window to the foreground)
+- Use `hover` before `screenshot --capture-screen` to capture tooltips and hover-triggered UI
 - Use `--focus` to foreground the target window before capture without switching to screen-DC capture (default capture path uses Windows.Graphics.Capture and works while occluded)
 - Use `--hide-disabled` and `--hide-offscreen` to reduce noise
 

--- a/docs/cli-schema.json
+++ b/docs/cli-schema.json
@@ -2176,6 +2176,113 @@
             }
           }
         },
+        "hover": {
+          "description": "Move the mouse to an element's center to trigger hover effects (tooltips, flyouts, visual states). Uses SendInput for realistic mouse movement and waits for a configurable dwell time.",
+          "hidden": false,
+          "arguments": {
+            "selector": {
+              "description": "Semantic slug (e.g., btn-minimize-d1a0) or text to search by name/automationId",
+              "order": 0,
+              "hidden": false,
+              "valueType": "System.String",
+              "hasDefaultValue": false,
+              "arity": {
+                "minimum": 0,
+                "maximum": 1
+              }
+            }
+          },
+          "options": {
+            "--app": {
+              "description": "Target app (process name, window title, or PID). Lists windows if ambiguous.",
+              "hidden": false,
+              "aliases": [
+                "-a"
+              ],
+              "valueType": "System.String",
+              "hasDefaultValue": false,
+              "arity": {
+                "minimum": 1,
+                "maximum": 1
+              },
+              "required": false,
+              "recursive": false
+            },
+            "--dwell-time": {
+              "description": "Time in milliseconds to wait after hovering for hover effects to appear (default: 800)",
+              "hidden": false,
+              "valueType": "System.Int32",
+              "hasDefaultValue": true,
+              "defaultValue": 800,
+              "arity": {
+                "minimum": 1,
+                "maximum": 1
+              },
+              "required": false,
+              "recursive": false
+            },
+            "--json": {
+              "description": "Format output as JSON",
+              "hidden": false,
+              "valueType": "System.Boolean",
+              "hasDefaultValue": true,
+              "defaultValue": false,
+              "arity": {
+                "minimum": 0,
+                "maximum": 1
+              },
+              "required": false,
+              "recursive": false
+            },
+            "--quiet": {
+              "description": "Suppress progress messages",
+              "hidden": false,
+              "aliases": [
+                "-q"
+              ],
+              "valueType": "System.Boolean",
+              "hasDefaultValue": true,
+              "defaultValue": false,
+              "arity": {
+                "minimum": 0,
+                "maximum": 1
+              },
+              "required": false,
+              "recursive": false
+            },
+            "--verbose": {
+              "description": "Enable verbose output",
+              "hidden": false,
+              "aliases": [
+                "-v"
+              ],
+              "valueType": "System.Boolean",
+              "hasDefaultValue": true,
+              "defaultValue": false,
+              "arity": {
+                "minimum": 0,
+                "maximum": 1
+              },
+              "required": false,
+              "recursive": false
+            },
+            "--window": {
+              "description": "Target window by HWND (stable handle from list output). Takes precedence over --app.",
+              "hidden": false,
+              "aliases": [
+                "-w"
+              ],
+              "valueType": "System.Nullable<System.Int64>",
+              "hasDefaultValue": false,
+              "arity": {
+                "minimum": 1,
+                "maximum": 1
+              },
+              "required": false,
+              "recursive": false
+            }
+          }
+        },
         "inspect": {
           "description": "View the UI element tree with semantic slugs, element types, names, and bounds.",
           "hidden": false,

--- a/docs/fragments/skills/winapp-cli/ui-automation.md
+++ b/docs/fragments/skills/winapp-cli/ui-automation.md
@@ -99,8 +99,9 @@ winapp ui screenshot -a myapp --focus --output focused.png
 ```
 
 ### Hover (for tooltips, flyouts, hover states)
+`--dwell-time <ms>` sets how long to wait after hovering (default: 800, range: 0–10000).
 ```powershell
-# Hover to trigger tooltip, then capture it
+# Hover to trigger tooltip, then capture it (default 800ms dwell)
 winapp ui hover btn-info-a1b2 -a myapp; winapp ui screenshot -a myapp --capture-screen --output tooltip.png
 
 # Longer dwell for apps with slow tooltip timers

--- a/docs/fragments/skills/winapp-cli/ui-automation.md
+++ b/docs/fragments/skills/winapp-cli/ui-automation.md
@@ -98,6 +98,15 @@ winapp ui screenshot -a myapp --capture-screen --output with-popups.png
 winapp ui screenshot -a myapp --focus --output focused.png
 ```
 
+### Hover (for tooltips, flyouts, hover states)
+```powershell
+# Hover to trigger tooltip, then capture it
+winapp ui hover btn-info-a1b2 -a myapp; winapp ui screenshot -a myapp --capture-screen --output tooltip.png
+
+# Longer dwell for apps with slow tooltip timers
+winapp ui hover btn-info-a1b2 -a myapp --dwell-time 1200; winapp ui screenshot -a myapp --capture-screen
+```
+
 ### Read element state
 ```powershell
 # Read text/value content (works for RichEditBox, TextBox, ComboBox, Slider, labels)
@@ -147,6 +156,7 @@ winapp ui wait-for itm-status-c3d4 -a myapp --value "Complete" --timeout 5000
 - Use `get-property --property ToggleState` to verify checkbox/toggle state after invoke
 - `scroll` auto-finds the nearest scrollable parent
 - Use `--capture-screen` to capture popup overlays, dropdown menus, and flyouts (also brings the window to the foreground)
+- Use `hover` before `screenshot --capture-screen` to capture tooltips and hover-triggered UI
 - Use `--focus` to foreground the target window before capture without switching to screen-DC capture (default capture path uses Windows.Graphics.Capture and works while occluded)
 - Use `--hide-disabled` and `--hide-offscreen` to reduce noise
 

--- a/docs/npm-usage.md
+++ b/docs/npm-usage.md
@@ -520,6 +520,28 @@ function uiGetValue(options?: UiGetValueOptions): Promise<WinappResult>
 
 ---
 
+### `uiHover()`
+
+Move the mouse to an element's center to trigger hover effects (tooltips, flyouts, visual states). Uses SendInput for realistic mouse movement and waits for a configurable dwell time.
+
+```typescript
+function uiHover(options?: UiHoverOptions): Promise<WinappResult>
+```
+
+**Options:**
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `selector` | `string \| undefined` | No | Semantic slug (e.g., btn-minimize-d1a0) or text to search by name/automationId |
+| `app` | `string \| undefined` | No | Target app (process name, window title, or PID). Lists windows if ambiguous. |
+| `dwellTime` | `number \| undefined` | No | Time in milliseconds to wait after hovering for hover effects to appear (default: 800) |
+| `json` | `boolean \| undefined` | No | Format output as JSON |
+| `window` | `number \| undefined` | No | Target window by HWND (stable handle from list output). Takes precedence over --app. |
+
+*Also accepts [CommonOptions](#commonoptions) (`quiet`, `verbose`, `cwd`).*
+
+---
+
 ### `uiInspect()`
 
 View the UI element tree with semantic slugs, element types, names, and bounds.
@@ -1353,6 +1375,19 @@ type ManifestTemplates = "packaged" | "sparse"
 |----------|------|----------|-------------|
 | `selector` | `string \| undefined` | No | Semantic slug (e.g., btn-minimize-d1a0) or text to search by name/automationId |
 | `app` | `string \| undefined` | No | Target app (process name, window title, or PID). Lists windows if ambiguous. |
+| `json` | `boolean \| undefined` | No | Format output as JSON |
+| `window` | `number \| undefined` | No | Target window by HWND (stable handle from list output). Takes precedence over --app. |
+| `quiet` | `boolean \| undefined` | No | Suppress progress messages. |
+| `verbose` | `boolean \| undefined` | No | Enable verbose output. |
+| `cwd` | `string \| undefined` | No | Working directory for the CLI process (defaults to process.cwd()). |
+
+### `UiHoverOptions`
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `selector` | `string \| undefined` | No | Semantic slug (e.g., btn-minimize-d1a0) or text to search by name/automationId |
+| `app` | `string \| undefined` | No | Target app (process name, window title, or PID). Lists windows if ambiguous. |
+| `dwellTime` | `number \| undefined` | No | Time in milliseconds to wait after hovering for hover effects to appear (default: 800) |
 | `json` | `boolean \| undefined` | No | Format output as JSON |
 | `window` | `number \| undefined` | No | Target window by HWND (stable handle from list output). Takes precedence over --app. |
 | `quiet` | `boolean \| undefined` | No | Suppress progress messages. |

--- a/docs/ui-automation.md
+++ b/docs/ui-automation.md
@@ -265,6 +265,9 @@ winapp ui hover btn-info-a1b2 -a myapp --dwell-time 1200        # longer dwell f
 winapp ui hover btn-info-a1b2 -a myapp; winapp ui screenshot -a myapp --capture-screen  # hover then capture tooltip
 ```
 
+**Options:**
+- `--dwell-time <ms>` — Time in milliseconds to wait after hovering for effects to appear (default: 800, range: 0–10000)
+
 ### set-value
 Set a value on an editable element (text for TextBox/ComboBox, number for Slider).
 ```bash

--- a/docs/ui-automation.md
+++ b/docs/ui-automation.md
@@ -257,6 +257,14 @@ winapp ui click btn-column1-a3f2 -a myapp --double      # double-click
 winapp ui click btn-column1-a3f2 -a myapp --right       # right-click
 ```
 
+### hover
+Move the mouse to an element's center to trigger hover effects (tooltips, flyouts, visual states). Uses `SendInput` for realistic mouse movement with a small wiggle, then waits for a configurable dwell time.
+```bash
+winapp ui hover btn-info-a1b2 -a myapp                          # hover with default 800ms dwell
+winapp ui hover btn-info-a1b2 -a myapp --dwell-time 1200        # longer dwell for slow tooltips
+winapp ui hover btn-info-a1b2 -a myapp; winapp ui screenshot -a myapp --capture-screen  # hover then capture tooltip
+```
+
 ### set-value
 Set a value on an editable element (text for TextBox/ComboBox, number for Slider).
 ```bash

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1044,6 +1044,7 @@ winapp ui [command] [options]
 - `screenshot` - Capture window/element as PNG (auto-captures dialogs separately)
 - `invoke` - Activate element (click, toggle, expand)
 - `click` - Click element via mouse simulation (for controls that don't support invoke)
+- `hover` - Move mouse to element to trigger tooltips, flyouts, and hover states
 - `set-value` - Set value on editable element (text, number)
 - `focus` - Move keyboard focus
 - `scroll-into-view` - Scroll element visible

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1044,7 +1044,7 @@ winapp ui [command] [options]
 - `screenshot` - Capture window/element as PNG (auto-captures dialogs separately)
 - `invoke` - Activate element (click, toggle, expand)
 - `click` - Click element via mouse simulation (for controls that don't support invoke)
-- `hover` - Move mouse to element to trigger tooltips, flyouts, and hover states
+- `hover` - Move mouse to element to trigger tooltips, flyouts, and hover states (default dwell: 800ms)
 - `set-value` - Set value on editable element (text, number)
 - `focus` - Move keyboard focus
 - `scroll-into-view` - Scroll element visible

--- a/scripts/test-e2e-winui-ui.ps1
+++ b/scripts/test-e2e-winui-ui.ps1
@@ -351,12 +351,19 @@ Assert-WinappSuccess "click Counter Button" -WinappArgs @("ui", "click", "Counte
 # --- wait-for counter = Count: 4 (click may use different coordinates on different screens) ---
 Assert-WinappSuccess "wait-for: counter after click" -WinappArgs @("ui", "wait-for", "CounterDisplay", "-a", "$appPid", "-t", "3000")
 
+# --- hover (exercises mouse hover + dwell) ---
+Assert-WinappSuccess "hover Counter Button" -WinappArgs @("ui", "hover", "Counter Button", "-a", "$appPid", "--json", "--dwell-time", "200")
+
+# --- hover + screenshot --capture-screen (tooltip workflow from docs) ---
+$ssHover = Join-Path $ScreenshotDir "05-hover-screen.png"
+Assert-WinappSuccess "screenshot after hover" -WinappArgs @("ui", "screenshot", "-a", "$appPid", "-o", $ssHover, "--capture-screen")
+
 # --- screenshot --capture-screen ---
-$ssScreen = Join-Path $ScreenshotDir "05-capture-screen.png"
+$ssScreen = Join-Path $ScreenshotDir "06-capture-screen.png"
 Assert-WinappSuccess "screenshot --capture-screen" -WinappArgs @("ui", "screenshot", "-a", "$appPid", "-o", $ssScreen, "--capture-screen")
 
 # --- screenshot --focus (exercises new WGC + foreground path) ---
-$ssFocus = Join-Path $ScreenshotDir "06-focus.png"
+$ssFocus = Join-Path $ScreenshotDir "07-focus.png"
 Assert-WinappSuccess "screenshot --focus" -WinappArgs @("ui", "screenshot", "-a", "$appPid", "-o", $ssFocus, "--focus")
 
 # --- wait-for: element exists ---
@@ -393,8 +400,9 @@ Assert-ScreenshotValid "screenshot: 01-initial.png" $ssInitial
 Assert-ScreenshotValid "screenshot: 02-after-counter.png" $ssCounter
 Assert-ScreenshotValid "screenshot: 03-after-input.png" $ssInput
 Assert-ScreenshotValid "screenshot: 04-after-submit.png" $ssSubmit
-Assert-ScreenshotValid "screenshot: 05-capture-screen.png" $ssScreen
-Assert-ScreenshotValid "screenshot: 06-focus.png" $ssFocus
+Assert-ScreenshotValid "screenshot: 05-hover-screen.png" $ssHover
+Assert-ScreenshotValid "screenshot: 06-capture-screen.png" $ssScreen
+Assert-ScreenshotValid "screenshot: 07-focus.png" $ssFocus
 
 # ============================================================================
 # Summary

--- a/src/winapp-CLI/WinApp.Cli.Tests/FakeUiServices.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/FakeUiServices.cs
@@ -80,3 +80,19 @@ internal class FakeUiSessionService : IUiSessionService
     public Task<UiSessionInfo> ResolveSessionAsync(string? app, long? hwnd, CancellationToken ct)
         => Task.FromResult(SessionResult);
 }
+
+/// <summary>
+/// Fake mouse input for testing — records calls instead of issuing real SendInput.
+/// </summary>
+internal class FakeMouseInput : WinApp.Cli.Helpers.IMouseInput
+{
+    public record HoverCall(int ScreenX, int ScreenY);
+    public record ClickCall(int ScreenX, int ScreenY, bool DoubleClick, bool RightClick);
+
+    public List<HoverCall> HoverCalls { get; } = [];
+    public List<ClickCall> ClickCalls { get; } = [];
+
+    public void Hover(int screenX, int screenY) => HoverCalls.Add(new(screenX, screenY));
+    public void Click(int screenX, int screenY, bool doubleClick = false, bool rightClick = false)
+        => ClickCalls.Add(new(screenX, screenY, doubleClick, rightClick));
+}

--- a/src/winapp-CLI/WinApp.Cli.Tests/UiCommandTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/UiCommandTests.cs
@@ -13,14 +13,17 @@ public class UiCommandTests : BaseCommandTests
 {
     private FakeUiAutomationService _fakeUia = null!;
     private FakeUiSessionService _fakeSession = null!;
+    private FakeMouseInput _fakeMouse = null!;
 
     protected override IServiceCollection ConfigureServices(IServiceCollection services)
     {
         _fakeUia = new FakeUiAutomationService();
         _fakeSession = new FakeUiSessionService();
+        _fakeMouse = new FakeMouseInput();
         return services
             .AddSingleton<IUiAutomationService>(_fakeUia)
-            .AddSingleton<IUiSessionService>(_fakeSession);
+            .AddSingleton<IUiSessionService>(_fakeSession)
+            .AddSingleton<WinApp.Cli.Helpers.IMouseInput>(_fakeMouse);
     }
 
     [TestMethod]
@@ -565,15 +568,88 @@ public class UiCommandTests : BaseCommandTests
     }
 
     [TestMethod]
-    public async Task Hover_Json_EmitsEnvelope()
+    public async Task Hover_Json_EmitsFullEnvelopeWithCorrectValues()
     {
         _fakeUia.FindSingleResult = new UiElement { Id = "e0", Type = "Button", Selector = "btn-info-5678", X = 50, Y = 60, Width = 120, Height = 40 };
 
         var command = GetRequiredService<UiHoverCommand>();
         var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["btn-info-5678", "-a", "TestApp", "--json", "--dwell-time", "0"]);
         Assert.AreEqual(0, exitCode);
-        StringAssert.Contains(TestAnsiConsole.Output, "\"dwellTimeMs\":");
-        StringAssert.Contains(TestAnsiConsole.Output, "\"elementId\":");
+
+        // Deserialize and assert exact JSON shape (L1)
+        var result = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(TestAnsiConsole.Output);
+        Assert.AreEqual("btn-info-5678", result.GetProperty("elementId").GetString());
+        Assert.AreEqual(110, result.GetProperty("x").GetInt32()); // 50 + 120/2
+        Assert.AreEqual(80, result.GetProperty("y").GetInt32());  // 60 + 40/2
+        Assert.AreEqual(0, result.GetProperty("dwellTimeMs").GetInt32());
+        Assert.AreEqual(0, result.GetProperty("hwnd").GetInt64()); // fake session has no window handle
+
+        // Verify fake mouse received correct coordinates (M2)
+        Assert.AreEqual(1, _fakeMouse.HoverCalls.Count);
+        Assert.AreEqual(110, _fakeMouse.HoverCalls[0].ScreenX);
+        Assert.AreEqual(80, _fakeMouse.HoverCalls[0].ScreenY);
+    }
+
+    [TestMethod]
+    public async Task Hover_DefaultDwellTime_Uses800ms()
+    {
+        _fakeUia.FindSingleResult = new UiElement { Id = "e0", Type = "Button", Selector = "btn-info-5678", X = 10, Y = 10, Width = 100, Height = 100 };
+
+        var command = GetRequiredService<UiHoverCommand>();
+        // Omit --dwell-time to test default
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["btn-info-5678", "-a", "TestApp", "--json"]);
+        Assert.AreEqual(0, exitCode);
+
+        var result = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(TestAnsiConsole.Output);
+        Assert.AreEqual(800, result.GetProperty("dwellTimeMs").GetInt32());
+    }
+
+    [TestMethod]
+    [DataRow(10000, DisplayName = "Max boundary (10000) is valid")]
+    [DataRow(0, DisplayName = "Min boundary (0) is valid")]
+    public async Task Hover_BoundaryDwellTime_Succeeds(int dwellTime)
+    {
+        _fakeUia.FindSingleResult = new UiElement { Id = "e0", Type = "Button", Selector = "btn-x-0", X = 0, Y = 0, Width = 10, Height = 10 };
+
+        var command = GetRequiredService<UiHoverCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["btn-x-0", "-a", "TestApp", "--json", "--dwell-time", dwellTime.ToString()]);
+        Assert.AreEqual(0, exitCode);
+    }
+
+    [TestMethod]
+    [DataRow(-1, DisplayName = "Negative dwell time")]
+    [DataRow(10001, DisplayName = "Over-max dwell time")]
+    public async Task Hover_InvalidDwellTime_ReturnsError(int dwellTime)
+    {
+        var command = GetRequiredService<UiHoverCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["btn-x-0", "-a", "TestApp", "--json", "--dwell-time", dwellTime.ToString()]);
+        Assert.AreEqual(1, exitCode);
+    }
+
+    [TestMethod]
+    public async Task Hover_MissingSelectorArgument_ReturnsError()
+    {
+        var command = GetRequiredService<UiHoverCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["-a", "TestApp", "--json"]);
+        Assert.AreEqual(1, exitCode);
+    }
+
+    [TestMethod]
+    public async Task Hover_ElementWithWindowHandle_UsesElementHwnd()
+    {
+        _fakeUia.FindSingleResult = new UiElement
+        {
+            Id = "popup-btn", Type = "Button", Selector = "popup-btn-001",
+            X = 200, Y = 300, Width = 80, Height = 30,
+            WindowHandle = 99999
+        };
+
+        var command = GetRequiredService<UiHoverCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["popup-btn-001", "-a", "TestApp", "--json", "--dwell-time", "0"]);
+        Assert.AreEqual(0, exitCode);
+
+        var result = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(TestAnsiConsole.Output);
+        Assert.AreEqual(99999, result.GetProperty("hwnd").GetInt64());
     }
 
     [TestMethod]

--- a/src/winapp-CLI/WinApp.Cli.Tests/UiCommandTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/UiCommandTests.cs
@@ -595,6 +595,16 @@ public class UiCommandTests : BaseCommandTests
     }
 
     [TestMethod]
+    public async Task Hover_ZeroSizeElement_ReturnsError()
+    {
+        _fakeUia.FindSingleResult = new UiElement { Id = "e0", Type = "Button", Selector = "btn-tiny-0000", X = 10, Y = 20, Width = 0, Height = 0 };
+
+        var command = GetRequiredService<UiHoverCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["btn-tiny-0000", "-a", "TestApp", "--json"]);
+        Assert.AreEqual(1, exitCode);
+    }
+
+    [TestMethod]
     public async Task Focus_Json_EmitsEnvelope()
     {
         _fakeUia.FindSingleResult = new UiElement { Id = "e0", Type = "Edit", Selector = "edit-name-1234" };

--- a/src/winapp-CLI/WinApp.Cli.Tests/UiCommandTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/UiCommandTests.cs
@@ -565,6 +565,36 @@ public class UiCommandTests : BaseCommandTests
     }
 
     [TestMethod]
+    public async Task Hover_Json_EmitsEnvelope()
+    {
+        _fakeUia.FindSingleResult = new UiElement { Id = "e0", Type = "Button", Selector = "btn-info-5678", X = 50, Y = 60, Width = 120, Height = 40 };
+
+        var command = GetRequiredService<UiHoverCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["btn-info-5678", "-a", "TestApp", "--json"]);
+        Assert.AreEqual(0, exitCode);
+        StringAssert.Contains(TestAnsiConsole.Output, "\"dwellTimeMs\":");
+        StringAssert.Contains(TestAnsiConsole.Output, "\"elementId\":");
+    }
+
+    [TestMethod]
+    public async Task Hover_MissingApp_ReturnsError()
+    {
+        var command = GetRequiredService<UiHoverCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["btn-info-5678", "--json"]);
+        Assert.AreEqual(1, exitCode);
+    }
+
+    [TestMethod]
+    public async Task Hover_ElementNotFound_ReturnsError()
+    {
+        _fakeUia.FindSingleResult = null;
+
+        var command = GetRequiredService<UiHoverCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["btn-nonexist-0000", "-a", "TestApp", "--json"]);
+        Assert.AreEqual(1, exitCode);
+    }
+
+    [TestMethod]
     public async Task Focus_Json_EmitsEnvelope()
     {
         _fakeUia.FindSingleResult = new UiElement { Id = "e0", Type = "Edit", Selector = "edit-name-1234" };

--- a/src/winapp-CLI/WinApp.Cli.Tests/UiCommandTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/UiCommandTests.cs
@@ -570,7 +570,7 @@ public class UiCommandTests : BaseCommandTests
         _fakeUia.FindSingleResult = new UiElement { Id = "e0", Type = "Button", Selector = "btn-info-5678", X = 50, Y = 60, Width = 120, Height = 40 };
 
         var command = GetRequiredService<UiHoverCommand>();
-        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["btn-info-5678", "-a", "TestApp", "--json"]);
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["btn-info-5678", "-a", "TestApp", "--json", "--dwell-time", "0"]);
         Assert.AreEqual(0, exitCode);
         StringAssert.Contains(TestAnsiConsole.Output, "\"dwellTimeMs\":");
         StringAssert.Contains(TestAnsiConsole.Output, "\"elementId\":");

--- a/src/winapp-CLI/WinApp.Cli/Commands/UiClickCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/UiClickCommand.cs
@@ -44,6 +44,7 @@ internal class UiClickCommand : Command, IShortDescription
         IUiSessionService sessionService,
         IUiAutomationService uiAutomation,
         ISelectorService selectorService,
+        IMouseInput mouseInput,
         IAnsiConsole ansiConsole,
         ILogger<UiClickCommand> logger) : AsynchronousCommandLineAction
     {
@@ -94,16 +95,19 @@ internal class UiClickCommand : Command, IShortDescription
                     return 1;
                 }
 
+                // Use the element's own window handle if available, otherwise fall back to session
+                var targetHwnd = element.WindowHandle ?? session.WindowHandle;
+
                 // Bring target window to foreground
-                if (session.WindowHandle != 0)
+                if (targetHwnd != 0)
                 {
                     Windows.Win32.PInvoke.SetForegroundWindow(
-                        new Windows.Win32.Foundation.HWND((nint)session.WindowHandle));
+                        new Windows.Win32.Foundation.HWND((nint)targetHwnd));
                     await Task.Delay(100, cancellationToken); // let window activate
                 }
 
                 // Perform the click via SendInput
-                MouseInput.Click(centerX, centerY, doubleClick, rightClick);
+                mouseInput.Click(centerX, centerY, doubleClick, rightClick);
 
                 var elementId = (element.Selector ?? element.Id ?? "");
 
@@ -115,7 +119,7 @@ internal class UiClickCommand : Command, IShortDescription
                         ClickType = clickType,
                         X = centerX,
                         Y = centerY,
-                        Hwnd = session.WindowHandle
+                        Hwnd = targetHwnd
                     };
                     ansiConsole.Profile.Out.Writer.WriteLine(
                         JsonSerializer.Serialize(result, UiJsonContext.Default.UiClickResult));

--- a/src/winapp-CLI/WinApp.Cli/Commands/UiCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/UiCommand.cs
@@ -18,6 +18,7 @@ internal class UiCommand : Command, IShortDescription
         UiScreenshotCommand screenshotCommand,
         UiInvokeCommand invokeCommand,
         UiClickCommand clickCommand,
+        UiHoverCommand hoverCommand,
         UiSetValueCommand setValueCommand,
         UiFocusCommand focusCommand,
         UiScrollIntoViewCommand scrollIntoViewCommand,
@@ -36,6 +37,7 @@ internal class UiCommand : Command, IShortDescription
         Subcommands.Add(screenshotCommand);
         Subcommands.Add(invokeCommand);
         Subcommands.Add(clickCommand);
+        Subcommands.Add(hoverCommand);
         Subcommands.Add(setValueCommand);
         Subcommands.Add(focusCommand);
         Subcommands.Add(scrollIntoViewCommand);

--- a/src/winapp-CLI/WinApp.Cli/Commands/UiHoverCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/UiHoverCommand.cs
@@ -64,7 +64,7 @@ internal class UiHoverCommand : Command, IShortDescription
             if (dwellTime < 0 || dwellTime > 10_000)
             {
                 logger.LogError("{Symbol} --dwell-time must be between 0 and 10000 ms.", UiSymbols.Error);
-                UiJsonError.Emit(json, "invalid-argument", "--dwell-time must be between 0 and 10000 ms.", null);
+                UiJsonError.Emit(json, UiJsonError.CodeInvalidArguments, "--dwell-time must be between 0 and 10000 ms.");
                 return 1;
             }
 

--- a/src/winapp-CLI/WinApp.Cli/Commands/UiHoverCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/UiHoverCommand.cs
@@ -38,6 +38,7 @@ internal class UiHoverCommand : Command, IShortDescription
         IUiSessionService sessionService,
         IUiAutomationService uiAutomation,
         ISelectorService selectorService,
+        IMouseInput mouseInput,
         IAnsiConsole ansiConsole,
         ILogger<UiHoverCommand> logger) : AsynchronousCommandLineAction
     {
@@ -90,16 +91,19 @@ internal class UiHoverCommand : Command, IShortDescription
                     return 1;
                 }
 
+                // Use the element's own window handle if available, otherwise fall back to session
+                var targetHwnd = element.WindowHandle ?? session.WindowHandle;
+
                 // Bring target window to foreground
-                if (session.WindowHandle != 0)
+                if (targetHwnd != 0)
                 {
                     Windows.Win32.PInvoke.SetForegroundWindow(
-                        new Windows.Win32.Foundation.HWND((nint)session.WindowHandle));
+                        new Windows.Win32.Foundation.HWND((nint)targetHwnd));
                     await Task.Delay(100, cancellationToken);
                 }
 
                 // Move mouse to element center with a small wiggle to trigger hover detection
-                MouseInput.Hover(centerX, centerY);
+                mouseInput.Hover(centerX, centerY);
 
                 // Wait for dwell time to allow hover effects to appear
                 await Task.Delay(dwellTime, cancellationToken);
@@ -114,7 +118,7 @@ internal class UiHoverCommand : Command, IShortDescription
                         X = centerX,
                         Y = centerY,
                         DwellTimeMs = dwellTime,
-                        Hwnd = session.WindowHandle
+                        Hwnd = targetHwnd
                     };
                     ansiConsole.Profile.Out.Writer.WriteLine(
                         JsonSerializer.Serialize(result, UiJsonContext.Default.UiHoverResult));

--- a/src/winapp-CLI/WinApp.Cli/Commands/UiHoverCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/UiHoverCommand.cs
@@ -1,0 +1,136 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.CommandLine.Parsing;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Spectre.Console;
+using WinApp.Cli.Helpers;
+using WinApp.Cli.Models;
+using WinApp.Cli.Services;
+
+namespace WinApp.Cli.Commands;
+
+internal class UiHoverCommand : Command, IShortDescription
+{
+    public string ShortDescription => "Move the mouse to an element to trigger hover effects like tooltips";
+
+    public static Option<int> DwellTimeOption { get; } = new("--dwell-time")
+    {
+        Description = "Time in milliseconds to wait after hovering for hover effects to appear (default: 800)",
+        DefaultValueFactory = _ => 800
+    };
+
+    public UiHoverCommand()
+        : base("hover", "Move the mouse to an element's center to trigger hover effects (tooltips, flyouts, visual states). " +
+               "Uses SendInput for realistic mouse movement and waits for a configurable dwell time.")
+    {
+        Arguments.Add(SharedUiOptions.SelectorArgument);
+        Options.Add(SharedUiOptions.AppOption);
+        Options.Add(SharedUiOptions.WindowOption);
+        Options.Add(DwellTimeOption);
+        Options.Add(WinAppRootCommand.JsonOption);
+    }
+
+    public class Handler(
+        IUiSessionService sessionService,
+        IUiAutomationService uiAutomation,
+        ISelectorService selectorService,
+        IAnsiConsole ansiConsole,
+        ILogger<UiHoverCommand> logger) : AsynchronousCommandLineAction
+    {
+        public override async Task<int> InvokeAsync(ParseResult parseResult, CancellationToken cancellationToken = default)
+        {
+            var json = parseResult.GetValue(WinAppRootCommand.JsonOption);
+            var selectorStr = parseResult.GetValue(SharedUiOptions.SelectorArgument);
+            var app = parseResult.GetValue(SharedUiOptions.AppOption);
+            var window = parseResult.GetValue(SharedUiOptions.WindowOption);
+            var dwellTime = parseResult.GetValue(DwellTimeOption);
+
+            if (string.IsNullOrWhiteSpace(app) && window is null)
+            {
+                UiErrors.MissingApp(logger, json);
+                return 1;
+            }
+
+            if (string.IsNullOrWhiteSpace(selectorStr))
+            {
+                UiErrors.MissingSelector(logger, "hover", json);
+                return 1;
+            }
+
+            try
+            {
+                var session = await sessionService.ResolveSessionAsync(app, window, cancellationToken);
+                var selector = selectorService.Parse(selectorStr);
+                var element = await uiAutomation.FindSingleElementAsync(session, selector, cancellationToken);
+
+                if (element is null)
+                {
+                    UiErrors.ElementNotFound(logger, selectorStr, json);
+                    return 1;
+                }
+
+                int centerX = (int)(element.X + element.Width / 2.0);
+                int centerY = (int)(element.Y + element.Height / 2.0);
+
+                if (element.Width == 0 || element.Height == 0)
+                {
+                    logger.LogError("{Symbol} Element has zero size — cannot hover.", UiSymbols.Error);
+                    UiJsonError.Emit(json, UiJsonError.CodeZeroSize, "Element has zero size — cannot hover.", selectorStr);
+                    return 1;
+                }
+
+                // Bring target window to foreground
+                if (session.WindowHandle != 0)
+                {
+                    Windows.Win32.PInvoke.SetForegroundWindow(
+                        new Windows.Win32.Foundation.HWND((nint)session.WindowHandle));
+                    await Task.Delay(100, cancellationToken);
+                }
+
+                // Move mouse to element center with a small wiggle to trigger hover detection
+                MouseInput.Hover(centerX, centerY);
+
+                // Wait for dwell time to allow hover effects to appear
+                await Task.Delay(dwellTime, cancellationToken);
+
+                var elementId = element.Selector ?? element.Id ?? "";
+
+                if (json)
+                {
+                    var result = new UiHoverResult
+                    {
+                        ElementId = elementId,
+                        X = centerX,
+                        Y = centerY,
+                        DwellTimeMs = dwellTime,
+                        Hwnd = session.WindowHandle
+                    };
+                    ansiConsole.Profile.Out.Writer.WriteLine(
+                        JsonSerializer.Serialize(result, UiJsonContext.Default.UiHoverResult));
+                }
+                else
+                {
+                    logger.LogInformation("{Symbol} Hovered on {ElementId} at ({X}, {Y}) — dwelled {DwellTime}ms",
+                        UiSymbols.Check, elementId, centerX, centerY, dwellTime);
+                }
+
+                return 0;
+            }
+            catch (System.Runtime.InteropServices.COMException comEx)
+            {
+                logger.LogDebug("COM error: {HResult} {StackTrace}", comEx.HResult, comEx.StackTrace);
+                UiErrors.StaleElement(logger, json);
+                return 1;
+            }
+            catch (Exception ex)
+            {
+                UiErrors.GenericError(logger, ex, json);
+                return 1;
+            }
+        }
+    }
+}

--- a/src/winapp-CLI/WinApp.Cli/Commands/UiHoverCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/UiHoverCommand.cs
@@ -61,6 +61,13 @@ internal class UiHoverCommand : Command, IShortDescription
                 return 1;
             }
 
+            if (dwellTime < 0 || dwellTime > 10_000)
+            {
+                logger.LogError("{Symbol} --dwell-time must be between 0 and 10000 ms.", UiSymbols.Error);
+                UiJsonError.Emit(json, "invalid-argument", "--dwell-time must be between 0 and 10000 ms.", null);
+                return 1;
+            }
+
             try
             {
                 var session = await sessionService.ResolveSessionAsync(app, window, cancellationToken);

--- a/src/winapp-CLI/WinApp.Cli/Helpers/HostBuilderExtensions.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/HostBuilderExtensions.cs
@@ -50,6 +50,7 @@ internal static class StoreHostBuilderExtensions
             .AddSingleton<IMSStoreCLIService, MSStoreCLIService>()
             .AddSingleton<IUpdateNotificationService, UpdateNotificationService>()
             // UI Automation services
+            .AddSingleton<IMouseInput, RealMouseInput>()
             .AddSingleton<ISelectorService, SelectorService>()
             .AddSingleton<IUiSessionService, UiSessionService>()
             .AddSingleton<IUiAutomationService, UiAutomationService>();

--- a/src/winapp-CLI/WinApp.Cli/Helpers/HostBuilderExtensions.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/HostBuilderExtensions.cs
@@ -89,6 +89,7 @@ internal static class StoreHostBuilderExtensions
                 .UseCommandHandler<UiScreenshotCommand, UiScreenshotCommand.Handler>()
                 .UseCommandHandler<UiInvokeCommand, UiInvokeCommand.Handler>()
                 .UseCommandHandler<UiClickCommand, UiClickCommand.Handler>()
+                .UseCommandHandler<UiHoverCommand, UiHoverCommand.Handler>()
                 .UseCommandHandler<UiSetValueCommand, UiSetValueCommand.Handler>()
                 .UseCommandHandler<UiFocusCommand, UiFocusCommand.Handler>()
                 .UseCommandHandler<UiScrollIntoViewCommand, UiScrollIntoViewCommand.Handler>()

--- a/src/winapp-CLI/WinApp.Cli/Helpers/IMouseInput.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/IMouseInput.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+namespace WinApp.Cli.Helpers;
+
+/// <summary>
+/// Abstraction over mouse input for testability.
+/// Real implementation calls SendInput P/Invoke; fakes record coordinates.
+/// </summary>
+internal interface IMouseInput
+{
+    /// <summary>
+    /// Moves the cursor to the target with a wiggle to trigger hover/tooltip detection.
+    /// </summary>
+    void Hover(int screenX, int screenY);
+
+    /// <summary>
+    /// Clicks at screen coordinates.
+    /// </summary>
+    void Click(int screenX, int screenY, bool doubleClick = false, bool rightClick = false);
+}

--- a/src/winapp-CLI/WinApp.Cli/Helpers/MouseInput.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/MouseInput.cs
@@ -59,8 +59,8 @@ internal static class MouseInput
         int vw = PInvoke.GetSystemMetrics(Windows.Win32.UI.WindowsAndMessaging.SYSTEM_METRICS_INDEX.SM_CXVIRTUALSCREEN);
         int vh = PInvoke.GetSystemMetrics(Windows.Win32.UI.WindowsAndMessaging.SYSTEM_METRICS_INDEX.SM_CYVIRTUALSCREEN);
 
-        int absoluteX = (int)(((screenX - vx) * 65535.0) / vw);
-        int absoluteY = (int)(((screenY - vy) * 65535.0) / vh);
+        int absoluteX = Math.Clamp((int)Math.Round(((screenX - vx) * 65535.0) / Math.Max(vw - 1, 1)), 0, 65535);
+        int absoluteY = Math.Clamp((int)Math.Round(((screenY - vy) * 65535.0) / Math.Max(vh - 1, 1)), 0, 65535);
 
         Span<INPUT> inputs =
         [

--- a/src/winapp-CLI/WinApp.Cli/Helpers/MouseInput.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/MouseInput.cs
@@ -53,9 +53,14 @@ internal static class MouseInput
 
     private static void SendMove(int screenX, int screenY)
     {
-        // Convert screen coordinates to normalized absolute coordinates (0–65535)
-        int absoluteX = (int)((screenX * 65535.0) / PInvoke.GetSystemMetrics(Windows.Win32.UI.WindowsAndMessaging.SYSTEM_METRICS_INDEX.SM_CXSCREEN));
-        int absoluteY = (int)((screenY * 65535.0) / PInvoke.GetSystemMetrics(Windows.Win32.UI.WindowsAndMessaging.SYSTEM_METRICS_INDEX.SM_CYSCREEN));
+        // Normalize against the full virtual desktop to support multi-monitor setups
+        int vx = PInvoke.GetSystemMetrics(Windows.Win32.UI.WindowsAndMessaging.SYSTEM_METRICS_INDEX.SM_XVIRTUALSCREEN);
+        int vy = PInvoke.GetSystemMetrics(Windows.Win32.UI.WindowsAndMessaging.SYSTEM_METRICS_INDEX.SM_YVIRTUALSCREEN);
+        int vw = PInvoke.GetSystemMetrics(Windows.Win32.UI.WindowsAndMessaging.SYSTEM_METRICS_INDEX.SM_CXVIRTUALSCREEN);
+        int vh = PInvoke.GetSystemMetrics(Windows.Win32.UI.WindowsAndMessaging.SYSTEM_METRICS_INDEX.SM_CYVIRTUALSCREEN);
+
+        int absoluteX = (int)(((screenX - vx) * 65535.0) / vw);
+        int absoluteY = (int)(((screenY - vy) * 65535.0) / vh);
 
         Span<INPUT> inputs =
         [
@@ -66,7 +71,7 @@ internal static class MouseInput
                 {
                     dx = absoluteX,
                     dy = absoluteY,
-                    dwFlags = MOUSE_EVENT_FLAGS.MOUSEEVENTF_MOVE | MOUSE_EVENT_FLAGS.MOUSEEVENTF_ABSOLUTE
+                    dwFlags = MOUSE_EVENT_FLAGS.MOUSEEVENTF_MOVE | MOUSE_EVENT_FLAGS.MOUSEEVENTF_ABSOLUTE | MOUSE_EVENT_FLAGS.MOUSEEVENTF_VIRTUALDESK
                 }}
             }
         ];
@@ -75,7 +80,13 @@ internal static class MouseInput
         {
             fixed (INPUT* pInputs = inputs)
             {
-                PInvoke.SendInput((uint)inputs.Length, pInputs, sizeof(INPUT));
+                var sent = PInvoke.SendInput((uint)inputs.Length, pInputs, sizeof(INPUT));
+                if (sent == 0)
+                {
+                    throw new InvalidOperationException(
+                        "SendInput failed — the target window may be elevated (running as admin). " +
+                        "Try running this CLI as administrator.");
+                }
             }
         }
     }

--- a/src/winapp-CLI/WinApp.Cli/Helpers/MouseInput.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/MouseInput.cs
@@ -11,6 +11,26 @@ namespace WinApp.Cli.Helpers;
 /// </summary>
 internal static class MouseInput
 {
+    /// <summary>
+    /// Moves the cursor to the target position with a small wiggle to trigger hover/tooltip detection.
+    /// Uses SendInput MOUSEEVENTF_MOVE|MOUSEEVENTF_ABSOLUTE to ensure apps see real WM_MOUSEMOVE messages.
+    /// </summary>
+    public static void Hover(int screenX, int screenY)
+    {
+        // Move to target via SendInput (absolute coordinates)
+        SendMove(screenX, screenY);
+        Thread.Sleep(30);
+
+        // Small wiggle (±2px) to ensure the app registers mouse entry
+        SendMove(screenX + 2, screenY);
+        Thread.Sleep(20);
+        SendMove(screenX, screenY + 2);
+        Thread.Sleep(20);
+
+        // Return to center and stop — dwell timer starts now
+        SendMove(screenX, screenY);
+    }
+
     public static void Click(int screenX, int screenY, bool doubleClick = false, bool rightClick = false)
     {
         // Move cursor to the target position
@@ -28,6 +48,35 @@ internal static class MouseInput
         {
             Thread.Sleep(50); // inter-click delay
             SendClick(downFlag, upFlag);
+        }
+    }
+
+    private static void SendMove(int screenX, int screenY)
+    {
+        // Convert screen coordinates to normalized absolute coordinates (0–65535)
+        int absoluteX = (int)((screenX * 65535.0) / PInvoke.GetSystemMetrics(Windows.Win32.UI.WindowsAndMessaging.SYSTEM_METRICS_INDEX.SM_CXSCREEN));
+        int absoluteY = (int)((screenY * 65535.0) / PInvoke.GetSystemMetrics(Windows.Win32.UI.WindowsAndMessaging.SYSTEM_METRICS_INDEX.SM_CYSCREEN));
+
+        Span<INPUT> inputs =
+        [
+            new INPUT
+            {
+                type = INPUT_TYPE.INPUT_MOUSE,
+                Anonymous = { mi = new MOUSEINPUT
+                {
+                    dx = absoluteX,
+                    dy = absoluteY,
+                    dwFlags = MOUSE_EVENT_FLAGS.MOUSEEVENTF_MOVE | MOUSE_EVENT_FLAGS.MOUSEEVENTF_ABSOLUTE
+                }}
+            }
+        ];
+
+        unsafe
+        {
+            fixed (INPUT* pInputs = inputs)
+            {
+                PInvoke.SendInput((uint)inputs.Length, pInputs, sizeof(INPUT));
+            }
         }
     }
 

--- a/src/winapp-CLI/WinApp.Cli/Helpers/RealMouseInput.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/RealMouseInput.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+namespace WinApp.Cli.Helpers;
+
+/// <summary>
+/// Production implementation — delegates to <see cref="MouseInput"/> static P/Invoke helpers.
+/// </summary>
+internal class RealMouseInput : IMouseInput
+{
+    public void Hover(int screenX, int screenY) => MouseInput.Hover(screenX, screenY);
+
+    public void Click(int screenX, int screenY, bool doubleClick = false, bool rightClick = false)
+        => MouseInput.Click(screenX, screenY, doubleClick, rightClick);
+}

--- a/src/winapp-CLI/WinApp.Cli/Helpers/UiJsonContext.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/UiJsonContext.cs
@@ -30,6 +30,7 @@ namespace WinApp.Cli.Helpers;
 [JsonSerializable(typeof(UiSetValueResult))]
 [JsonSerializable(typeof(UiFocusResult))]
 [JsonSerializable(typeof(UiScrollIntoViewResult))]
+[JsonSerializable(typeof(UiHoverResult))]
 [JsonSerializable(typeof(UiErrorResult))]
 [JsonSerializable(typeof(UiErrorInfo))]
 [JsonSerializable(typeof(UiFocusedResult))]
@@ -211,5 +212,14 @@ internal sealed class UiFocusResult
 internal sealed class UiScrollIntoViewResult
 {
     public string ElementId { get; set; } = "";
+    public long Hwnd { get; set; }
+}
+
+internal sealed class UiHoverResult
+{
+    public string ElementId { get; set; } = "";
+    public int X { get; set; }
+    public int Y { get; set; }
+    public int DwellTimeMs { get; set; }
     public long Hwnd { get; set; }
 }

--- a/src/winapp-npm/src/winapp-commands.ts
+++ b/src/winapp-npm/src/winapp-commands.ts
@@ -700,6 +700,36 @@ export async function uiGetValue(options: UiGetValueOptions = {}): Promise<Winap
 }
 
 // ---------------------------------------------------------------------------
+// ui hover
+// ---------------------------------------------------------------------------
+
+export interface UiHoverOptions extends CommonOptions {
+  /** Semantic slug (e.g., btn-minimize-d1a0) or text to search by name/automationId */
+  selector?: string;
+  /** Target app (process name, window title, or PID). Lists windows if ambiguous. */
+  app?: string;
+  /** Time in milliseconds to wait after hovering for hover effects to appear (default: 800) */
+  dwellTime?: number;
+  /** Format output as JSON */
+  json?: boolean;
+  /** Target window by HWND (stable handle from list output). Takes precedence over --app. */
+  window?: number;
+}
+
+/**
+ * Move the mouse to an element's center to trigger hover effects (tooltips, flyouts, visual states). Uses SendInput for realistic mouse movement and waits for a configurable dwell time.
+ */
+export async function uiHover(options: UiHoverOptions = {}): Promise<WinappResult> {
+  const args: string[] = ['ui', 'hover'];
+  if (options.selector) args.push(options.selector);
+  if (options.app) args.push('--app', options.app);
+  if (options.dwellTime !== undefined) args.push('--dwell-time', options.dwellTime.toString());
+  if (options.json) args.push('--json');
+  if (options.window !== undefined) args.push('--window', options.window.toString());
+  return execCommand(args, options);
+}
+
+// ---------------------------------------------------------------------------
 // ui inspect
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
fixes #557 

Adds a new  winapp ui hover  command that moves the mouse to an element's center  using  SendInput  with a small wiggle, then waits a configurable dwell time for  hover effects (tooltips, flyouts, visual states) to appear.

 ### Usage

 winapp ui hover btn-info-a1b2 -a myapp
 winapp ui hover btn-info-a1b2 -a myapp --dwell-time 1200
 winapp ui hover btn-info-a1b2 -a myapp; winapp ui screenshot -a myapp  --capture-screen -o tooltip.png

 ### What's included

 • C# command ( UiHoverCommand.cs ) following the same pattern as  ui click 
 • Mouse movement via  SendInput  with  MOUSEEVENTF_ABSOLUTE |    MOUSEEVENTF_VIRTUALDESK  for multi-monitor support
 •  --dwell-time  option (default 800ms, validated 0–10000ms)
 • npm SDK wrapper ( uiHover()  in  winapp-commands.ts )
 • Tests — 4 unit tests (happy path, missing app, element not found, zero-size    element)
 • Docs — updated  ui-automation.md ,  usage.md , skill fragments, agent file,    npm-usage.md