### PR TITLE
Update ESRP for SFI

### DIFF
--- a/.pipelines/release-vsc.yml
+++ b/.pipelines/release-vsc.yml
@@ -143,7 +143,7 @@ extends:
               filePath: $(System.DefaultWorkingDirectory)\scripts\package-vsc.ps1
               arguments: "-Stable -CliBinariesPath '$(System.DefaultWorkingDirectory)/artifacts/public-cli'"
           - ${{ if eq(parameters.DoEsrp, 'true') }}:
-            - task: EsrpCodeSigning@5
+            - task: EsrpCodeSigning@6
               displayName: Code Sign ESRP - VSIX Package
               inputs:
                 ConnectedServiceName: $(SigningServiceName)

--- a/.pipelines/release.yml
+++ b/.pipelines/release.yml
@@ -300,7 +300,7 @@ extends:
                 waitforreleasecompletion: true
                 owners: '$(EsrpOwnersEmail)'
                 approvers: '$(EsrpApproversEmail)'
-                serviceendpointurl: 'https://api.esrp.microsoft.com'
+                serviceendpointurl: 'https://msazurecloud.onmicrosoft.com/api.esrp.microsoft.com'
                 mainpublisher: 'ESRPRELPACMAN'
                 domaintenantid: ${{ parameters.signingIdentity.tenantId }}
 

--- a/.pipelines/templates/build.yaml
+++ b/.pipelines/templates/build.yaml
@@ -17,7 +17,7 @@ steps:
     filePath: $(System.DefaultWorkingDirectory)\scripts\build-cli.ps1
     arguments: "-Stable:$${{ parameters.stable }} -SkipMsix"
 - ${{ if eq(parameters['DoEsrp'], 'true') }}:
-  - task: EsrpCodeSigning@5
+  - task: EsrpCodeSigning@6
     displayName: Code Sign ESRP - CLI
     inputs:
       ConnectedServiceName: ${{ parameters.signingIdentity.serviceName }}
@@ -68,7 +68,7 @@ steps:
     filePath: $(System.DefaultWorkingDirectory)\scripts\package-msix.ps1
     arguments: "-Stable:$${{ parameters.stable }}"
 - ${{ if eq(parameters['DoEsrp'], 'true') }}:
-  - task: EsrpCodeSigning@5
+  - task: EsrpCodeSigning@6
     displayName: Code Sign ESRP - MSIX Packages
     inputs:
       ConnectedServiceName: ${{ parameters.signingIdentity.serviceName }}
@@ -97,7 +97,7 @@ steps:
                 "ToolVersion": "1.0"
             }
         ]
-  - task: EsrpCodeSigning@5
+  - task: EsrpCodeSigning@6
     displayName: Code Sign ESRP - NuGet Packages
     inputs:
       ConnectedServiceName: ${{ parameters.signingIdentity.serviceName }}


### PR DESCRIPTION
## Description
Changes for new SFI requirements around ESRP. Updated Signing task version and changed endpoint URL. 

## AI Description

<!-- ai-description-start -->
The pull request updates the ESRP (Extended Signing Reference Policy) implementation to meet new SFI (Service Framework Interface) requirements. Key changes include updating the EsrpCodeSigning task version from 5 to 6 and modifying the service endpoint URL to a new domain. 
```yaml
- task: EsrpCodeSigning@6
```
<!-- ai-description-end -->
