### PR TITLE
Add `--update-csproj` to `winapp manifest add-alias`

### DIFF
--- a/.claude/skills/winapp-manifest/SKILL.md
+++ b/.claude/skills/winapp-manifest/SKILL.md
@@ -103,7 +103,7 @@ winapp manifest add-alias --update-csproj
 
 This adds a `uap5:AppExecutionAlias` extension to the manifest. If the alias already exists, the command reports it and exits successfully.
 
-With `--update-csproj`, the command also sets `<WinAppRunUseExecutionAlias>true</WinAppRunUseExecutionAlias>` in the `.csproj` next to the manifest (adding or updating the property), so `winapp run` / `dotnet run` launch the app through the alias and keep console I/O in the current terminal.
+With `--update-csproj`, the command also sets `<WinAppRunUseExecutionAlias>true</WinAppRunUseExecutionAlias>` in the `.csproj` next to the manifest (adding or updating the property), so `winapp run` / `dotnet run` launch the app through the alias and keep console I/O in the current terminal. The alias is still added to the manifest, but the command exits non-zero if it cannot find a `.csproj` or insert the property, so the request is never silently dropped.
 
 > **When combined with `winapp run --with-alias`** or the `WinAppRunUseExecutionAlias` MSBuild property, this enables apps to run in the current terminal with inherited stdin/stdout/stderr instead of opening a new window.
 

--- a/.claude/skills/winapp-manifest/SKILL.md
+++ b/.claude/skills/winapp-manifest/SKILL.md
@@ -96,9 +96,14 @@ winapp manifest add-alias --name myapp
 
 # Target a specific manifest file
 winapp manifest add-alias --manifest ./path/to/Package.appxmanifest
+
+# Also enable the alias for 'winapp run' / 'dotnet run' (.NET projects)
+winapp manifest add-alias --update-csproj
 ```
 
 This adds a `uap5:AppExecutionAlias` extension to the manifest. If the alias already exists, the command reports it and exits successfully.
+
+With `--update-csproj`, the command also sets `<WinAppRunUseExecutionAlias>true</WinAppRunUseExecutionAlias>` in the `.csproj` next to the manifest (adding or updating the property), so `winapp run` / `dotnet run` launch the app through the alias and keep console I/O in the current terminal.
 
 > **When combined with `winapp run --with-alias`** or the `WinAppRunUseExecutionAlias` MSBuild property, this enables apps to run in the current terminal with inherited stdin/stdout/stderr instead of opening a new window.
 
@@ -214,3 +219,4 @@ Add an execution alias (uap5:AppExecutionAlias) to a Package.appxmanifest. This 
 | `--app-id` | Application Id to add the alias to (default: first Application element) | (none) |
 | `--manifest` | Path to Package.appxmanifest or appxmanifest.xml file (default: search current directory) | (none) |
 | `--name` | Alias name (e.g. 'myapp.exe'). Default: inferred from the Executable attribute in the manifest. | (none) |
+| `--update-csproj` | Also set <WinAppRunUseExecutionAlias>true</WinAppRunUseExecutionAlias> in the .NET project (.csproj) next to the manifest, so 'winapp run' / 'dotnet run' launch the app through this execution alias and keep console I/O in the current terminal. | (none) |

--- a/.github/plugin/skills/winapp-cli/manifest/SKILL.md
+++ b/.github/plugin/skills/winapp-cli/manifest/SKILL.md
@@ -103,7 +103,7 @@ winapp manifest add-alias --update-csproj
 
 This adds a `uap5:AppExecutionAlias` extension to the manifest. If the alias already exists, the command reports it and exits successfully.
 
-With `--update-csproj`, the command also sets `<WinAppRunUseExecutionAlias>true</WinAppRunUseExecutionAlias>` in the `.csproj` next to the manifest (adding or updating the property), so `winapp run` / `dotnet run` launch the app through the alias and keep console I/O in the current terminal.
+With `--update-csproj`, the command also sets `<WinAppRunUseExecutionAlias>true</WinAppRunUseExecutionAlias>` in the `.csproj` next to the manifest (adding or updating the property), so `winapp run` / `dotnet run` launch the app through the alias and keep console I/O in the current terminal. The alias is still added to the manifest, but the command exits non-zero if it cannot find a `.csproj` or insert the property, so the request is never silently dropped.
 
 > **When combined with `winapp run --with-alias`** or the `WinAppRunUseExecutionAlias` MSBuild property, this enables apps to run in the current terminal with inherited stdin/stdout/stderr instead of opening a new window.
 

--- a/.github/plugin/skills/winapp-cli/manifest/SKILL.md
+++ b/.github/plugin/skills/winapp-cli/manifest/SKILL.md
@@ -96,9 +96,14 @@ winapp manifest add-alias --name myapp
 
 # Target a specific manifest file
 winapp manifest add-alias --manifest ./path/to/Package.appxmanifest
+
+# Also enable the alias for 'winapp run' / 'dotnet run' (.NET projects)
+winapp manifest add-alias --update-csproj
 ```
 
 This adds a `uap5:AppExecutionAlias` extension to the manifest. If the alias already exists, the command reports it and exits successfully.
+
+With `--update-csproj`, the command also sets `<WinAppRunUseExecutionAlias>true</WinAppRunUseExecutionAlias>` in the `.csproj` next to the manifest (adding or updating the property), so `winapp run` / `dotnet run` launch the app through the alias and keep console I/O in the current terminal.
 
 > **When combined with `winapp run --with-alias`** or the `WinAppRunUseExecutionAlias` MSBuild property, this enables apps to run in the current terminal with inherited stdin/stdout/stderr instead of opening a new window.
 
@@ -214,3 +219,4 @@ Add an execution alias (uap5:AppExecutionAlias) to a Package.appxmanifest. This 
 | `--app-id` | Application Id to add the alias to (default: first Application element) | (none) |
 | `--manifest` | Path to Package.appxmanifest or appxmanifest.xml file (default: search current directory) | (none) |
 | `--name` | Alias name (e.g. 'myapp.exe'). Default: inferred from the Executable attribute in the manifest. | (none) |
+| `--update-csproj` | Also set <WinAppRunUseExecutionAlias>true</WinAppRunUseExecutionAlias> in the .NET project (.csproj) next to the manifest, so 'winapp run' / 'dotnet run' launch the app through this execution alias and keep console I/O in the current terminal. | (none) |

--- a/docs/cli-schema.json
+++ b/docs/cli-schema.json
@@ -819,6 +819,19 @@
               "required": false,
               "recursive": false
             },
+            "--update-csproj": {
+              "description": "Also set <WinAppRunUseExecutionAlias>true</WinAppRunUseExecutionAlias> in the .NET project (.csproj) next to the manifest, so 'winapp run' / 'dotnet run' launch the app through this execution alias and keep console I/O in the current terminal.",
+              "hidden": false,
+              "valueType": "System.Boolean",
+              "hasDefaultValue": true,
+              "defaultValue": false,
+              "arity": {
+                "minimum": 0,
+                "maximum": 1
+              },
+              "required": false,
+              "recursive": false
+            },
             "--verbose": {
               "description": "Enable verbose output",
               "hidden": false,

--- a/docs/dotnet-run-support.md
+++ b/docs/dotnet-run-support.md
@@ -156,6 +156,8 @@ Launch via execution alias (for console apps):
 </PropertyGroup>
 ```
 
+> **Tip:** `winapp manifest add-alias --update-csproj` adds the required `uap5:ExecutionAlias` to the manifest and sets this property in the adjacent `.csproj` for you.
+
 Register identity without launching:
 ```xml
 <PropertyGroup>

--- a/docs/fragments/skills/winapp-cli/manifest.md
+++ b/docs/fragments/skills/winapp-cli/manifest.md
@@ -91,9 +91,14 @@ winapp manifest add-alias --name myapp
 
 # Target a specific manifest file
 winapp manifest add-alias --manifest ./path/to/Package.appxmanifest
+
+# Also enable the alias for 'winapp run' / 'dotnet run' (.NET projects)
+winapp manifest add-alias --update-csproj
 ```
 
 This adds a `uap5:AppExecutionAlias` extension to the manifest. If the alias already exists, the command reports it and exits successfully.
+
+With `--update-csproj`, the command also sets `<WinAppRunUseExecutionAlias>true</WinAppRunUseExecutionAlias>` in the `.csproj` next to the manifest (adding or updating the property), so `winapp run` / `dotnet run` launch the app through the alias and keep console I/O in the current terminal.
 
 > **When combined with `winapp run --with-alias`** or the `WinAppRunUseExecutionAlias` MSBuild property, this enables apps to run in the current terminal with inherited stdin/stdout/stderr instead of opening a new window.
 

--- a/docs/fragments/skills/winapp-cli/manifest.md
+++ b/docs/fragments/skills/winapp-cli/manifest.md
@@ -98,7 +98,7 @@ winapp manifest add-alias --update-csproj
 
 This adds a `uap5:AppExecutionAlias` extension to the manifest. If the alias already exists, the command reports it and exits successfully.
 
-With `--update-csproj`, the command also sets `<WinAppRunUseExecutionAlias>true</WinAppRunUseExecutionAlias>` in the `.csproj` next to the manifest (adding or updating the property), so `winapp run` / `dotnet run` launch the app through the alias and keep console I/O in the current terminal.
+With `--update-csproj`, the command also sets `<WinAppRunUseExecutionAlias>true</WinAppRunUseExecutionAlias>` in the `.csproj` next to the manifest (adding or updating the property), so `winapp run` / `dotnet run` launch the app through the alias and keep console I/O in the current terminal. The alias is still added to the manifest, but the command exits non-zero if it cannot find a `.csproj` or insert the property, so the request is never silently dropped.
 
 > **When combined with `winapp run --with-alias`** or the `WinAppRunUseExecutionAlias` MSBuild property, this enables apps to run in the current terminal with inherited stdin/stdout/stderr instead of opening a new window.
 

--- a/docs/guides/dotnet.md
+++ b/docs/guides/dotnet.md
@@ -122,21 +122,15 @@ To fix this, you'll add an execution alias to the manifest and tell the run inte
 
 > **Skip this step if you're building a UI app** (WPF, WinForms, WinUI). Those apps render their own window, so the default AUMID launch is what you want.
 
-1. Add the execution alias to your manifest:
+1. Add the execution alias to your manifest and enable it for `dotnet run` in one step:
 
    ```powershell
-   winapp manifest add-alias
+   winapp manifest add-alias --update-csproj
    ```
 
-   This adds a `uap5:ExecutionAlias` to `Package.appxmanifest` (defaulting to your project's exe name) so the app can be launched by name from a terminal.
+   This adds a `uap5:ExecutionAlias` to `Package.appxmanifest` (defaulting to your project's exe name) so the app can be launched by name from a terminal, and sets `<WinAppRunUseExecutionAlias>true</WinAppRunUseExecutionAlias>` in your `.csproj`. With this property set, `dotnet run` launches the app via its execution alias and inherits the current terminal's stdin/stdout/stderr so you see console output inline.
 
-2. Tell the `dotnet run` integration to use the alias. Open `dotnet-app.csproj` and add the following inside any `<PropertyGroup>` (or create a new `<PropertyGroup>` if needed):
-
-   ```xml
-   <WinAppRunUseExecutionAlias>true</WinAppRunUseExecutionAlias>
-   ```
-
-   With this property set, `dotnet run` launches the app via its execution alias and inherits the current terminal's stdin/stdout/stderr so you see console output inline.
+   To do the two steps separately, run `winapp manifest add-alias` and then add `<WinAppRunUseExecutionAlias>true</WinAppRunUseExecutionAlias>` to any `<PropertyGroup>` in `dotnet-app.csproj` yourself.
 
 ## 5. Debug with Identity
 

--- a/docs/npm-usage.md
+++ b/docs/npm-usage.md
@@ -226,6 +226,7 @@ function manifestAddAlias(options?: ManifestAddAliasOptions): Promise<WinappResu
 | `appId` | `string \| undefined` | No | Application Id to add the alias to (default: first Application element) |
 | `manifest` | `string \| undefined` | No | Path to Package.appxmanifest or appxmanifest.xml file (default: search current directory) |
 | `name` | `string \| undefined` | No | Alias name (e.g. 'myapp.exe'). Default: inferred from the Executable attribute in the manifest. |
+| `updateCsproj` | `boolean \| undefined` | No | Also set <WinAppRunUseExecutionAlias>true</WinAppRunUseExecutionAlias> in the .NET project (.csproj) next to the manifest, so 'winapp run' / 'dotnet run' launch the app through this execution alias and keep console I/O in the current terminal. |
 
 *Also accepts [CommonOptions](#commonoptions) (`quiet`, `verbose`, `cwd`).*
 
@@ -1205,6 +1206,7 @@ type ManifestTemplates = "packaged" | "sparse"
 | `appId` | `string \| undefined` | No | Application Id to add the alias to (default: first Application element) |
 | `manifest` | `string \| undefined` | No | Path to Package.appxmanifest or appxmanifest.xml file (default: search current directory) |
 | `name` | `string \| undefined` | No | Alias name (e.g. 'myapp.exe'). Default: inferred from the Executable attribute in the manifest. |
+| `updateCsproj` | `boolean \| undefined` | No | Also set <WinAppRunUseExecutionAlias>true</WinAppRunUseExecutionAlias> in the .NET project (.csproj) next to the manifest, so 'winapp run' / 'dotnet run' launch the app through this execution alias and keep console I/O in the current terminal. |
 | `quiet` | `boolean \| undefined` | No | Suppress progress messages. |
 | `verbose` | `boolean \| undefined` | No | Enable verbose output. |
 | `cwd` | `string \| undefined` | No | Working directory for the CLI process (defaults to process.cwd()). |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -399,6 +399,7 @@ winapp manifest add-alias [options]
 - `--name <alias>` - Alias name (e.g. `myapp.exe`). Default: inferred from the `Executable` attribute in the manifest.
 - `--manifest <path>` - Path to Package.appxmanifest (default: search current directory)
 - `--app-id <id>` - Application Id to add the alias to (default: first Application element)
+- `--update-csproj` - Also set `<WinAppRunUseExecutionAlias>true</WinAppRunUseExecutionAlias>` in the .NET project (`.csproj`) next to the manifest, so `winapp run` / `dotnet run` launch the app through this execution alias and keep console I/O in the current terminal.
 
 **What it does:**
 
@@ -406,6 +407,7 @@ winapp manifest add-alias [options]
 - Adds the `uap5` namespace declaration if not already present
 - Adds an `<Extensions>` block with `<uap5:AppExecutionAlias>` inside the target Application element
 - If the alias already exists, reports it and exits successfully
+- With `--update-csproj`, adds or updates the `WinAppRunUseExecutionAlias` MSBuild property in the adjacent `.csproj` (no-op if no `.csproj` is found)
 
 **Examples:**
 
@@ -418,6 +420,9 @@ winapp manifest add-alias --name myapp.exe
 
 # Add alias to specific manifest
 winapp manifest add-alias --manifest ./dist/Package.appxmanifest
+
+# Add alias and enable it for 'winapp run' / 'dotnet run' (.NET projects)
+winapp manifest add-alias --update-csproj
 ```
 
 #### manifest update-assets

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -407,7 +407,7 @@ winapp manifest add-alias [options]
 - Adds the `uap5` namespace declaration if not already present
 - Adds an `<Extensions>` block with `<uap5:AppExecutionAlias>` inside the target Application element
 - If the alias already exists, reports it and exits successfully
-- With `--update-csproj`, adds or updates the `WinAppRunUseExecutionAlias` MSBuild property in the adjacent `.csproj` (no-op if no `.csproj` is found)
+- With `--update-csproj`, adds or updates the `WinAppRunUseExecutionAlias` MSBuild property in the adjacent `.csproj`. The execution alias is still added to the manifest, but the command exits non-zero if no `.csproj` is found or the property cannot be inserted (no `<PropertyGroup>`), so the situation is not silently ignored. Occurrences of the property inside XML comments are ignored and left intact.
 
 **Examples:**
 

--- a/samples/dotnet-app/test.Tests.ps1
+++ b/samples/dotnet-app/test.Tests.ps1
@@ -91,11 +91,16 @@ Describe ".NET App Guide Workflow" {
                 } finally { Pop-Location }
             }
 
-            It "Should add execution alias to manifest" -Skip:$script:skip {
+            It "Should add execution alias to manifest and enable it in the csproj" -Skip:$script:skip {
                 Push-Location $script:projectDir
                 try {
-                    Invoke-WinappCommand -Arguments "manifest add-alias"
+                    Invoke-WinappCommand -Arguments "manifest add-alias --update-csproj"
                 } finally { Pop-Location }
+            }
+
+            It "Should set WinAppRunUseExecutionAlias in the csproj" -Skip:$script:skip {
+                $csproj = Get-ChildItem -Path $script:projectDir -Filter "*.csproj" | Select-Object -First 1
+                (Get-Content -Raw $csproj.FullName) | Should -Match "<WinAppRunUseExecutionAlias>true</WinAppRunUseExecutionAlias>"
             }
 
             It "Should run app with identity via winapp run" -Skip:$script:skip {

--- a/src/winapp-CLI/WinApp.Cli.Tests/FakeDotNetService.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/FakeDotNetService.cs
@@ -82,7 +82,7 @@ internal class FakeDotNetService : IDotNetService
     public Task<bool> EnsureEnableMsixToolingAsync(FileInfo csprojPath, CancellationToken cancellationToken = default)
         => _real.EnsureEnableMsixToolingAsync(csprojPath, cancellationToken);
 
-    public Task<bool> EnsureWinAppRunUseExecutionAliasAsync(FileInfo csprojPath, CancellationToken cancellationToken = default)
+    public Task<CsprojPropertyOutcome> EnsureWinAppRunUseExecutionAliasAsync(FileInfo csprojPath, CancellationToken cancellationToken = default)
         => _real.EnsureWinAppRunUseExecutionAliasAsync(csprojPath, cancellationToken);
 
     public Task<bool> RemoveWindowsPackageTypeNoneAsync(FileInfo csprojPath, CancellationToken cancellationToken = default)

--- a/src/winapp-CLI/WinApp.Cli.Tests/FakeDotNetService.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/FakeDotNetService.cs
@@ -82,6 +82,9 @@ internal class FakeDotNetService : IDotNetService
     public Task<bool> EnsureEnableMsixToolingAsync(FileInfo csprojPath, CancellationToken cancellationToken = default)
         => _real.EnsureEnableMsixToolingAsync(csprojPath, cancellationToken);
 
+    public Task<bool> EnsureWinAppRunUseExecutionAliasAsync(FileInfo csprojPath, CancellationToken cancellationToken = default)
+        => _real.EnsureWinAppRunUseExecutionAliasAsync(csprojPath, cancellationToken);
+
     public Task<bool> RemoveWindowsPackageTypeNoneAsync(FileInfo csprojPath, CancellationToken cancellationToken = default)
         => _real.RemoveWindowsPackageTypeNoneAsync(csprojPath, cancellationToken);
 

--- a/src/winapp-CLI/WinApp.Cli.Tests/ManifestAddAliasCommandTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/ManifestAddAliasCommandTests.cs
@@ -857,7 +857,7 @@ public class ManifestAddAliasCommandTests : BaseCommandTests
     }
 
     [TestMethod]
-    public async Task AddAlias_UpdateCsproj_NoCsproj_StillSucceeds()
+    public async Task AddAlias_UpdateCsproj_NoCsproj_AddsAliasButReturnsError()
     {
         // Arrange - manifest but no .csproj next to it
         var manifestPath = CreateManifest("""
@@ -878,18 +878,213 @@ public class ManifestAddAliasCommandTests : BaseCommandTests
         // Act
         var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["--manifest", manifestPath, "--update-csproj"]);
 
-        // Assert - alias still added, no failure when no project is present
-        Assert.AreEqual(0, exitCode, "Command should succeed even when no .csproj is present");
+        // Assert - alias still added, but --update-csproj could not be honored so the command reports failure
+        Assert.AreEqual(1, exitCode, "Command should report failure when --update-csproj is requested but no .csproj is present");
         var content = await File.ReadAllTextAsync(manifestPath);
         Assert.Contains("uap5:ExecutionAlias", content, "Should still add the execution alias");
     }
 
-    private string CreateCsproj(string content)
+    [TestMethod]
+    public async Task AddAlias_UpdateCsproj_PropertyAlreadyTrue_LeavesCsprojUnchanged()
     {
-        var path = Path.Combine(_tempDirectory.FullName, "test-app.csproj");
+        // Arrange
+        var manifestPath = CreateDefaultManifest();
+        var csprojContent = """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
+                <WinAppRunUseExecutionAlias>true</WinAppRunUseExecutionAlias>
+              </PropertyGroup>
+            </Project>
+            """;
+        var csprojPath = CreateCsproj(csprojContent);
+
+        var command = GetRequiredService<ManifestAddAliasCommand>();
+
+        // Act
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["--manifest", manifestPath, "--update-csproj"]);
+
+        // Assert
+        Assert.AreEqual(0, exitCode, "Command should succeed");
+        var csproj = await File.ReadAllTextAsync(csprojPath);
+        Assert.AreEqual(csprojContent, csproj, "Csproj should be byte-for-byte unchanged when already true");
+    }
+
+    [TestMethod]
+    public async Task AddAlias_UpdateCsproj_CommentedOutProperty_DoesNotCorruptCsproj()
+    {
+        // Arrange - the property exists only inside an XML comment; the regex must not splice into it
+        var manifestPath = CreateDefaultManifest();
+        var csprojPath = CreateCsproj("""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
+                <!-- <WinAppRunUseExecutionAlias>false</WinAppRunUseExecutionAlias> -->
+              </PropertyGroup>
+            </Project>
+            """);
+
+        var command = GetRequiredService<ManifestAddAliasCommand>();
+
+        // Act
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["--manifest", manifestPath, "--update-csproj"]);
+
+        // Assert
+        Assert.AreEqual(0, exitCode, "Command should succeed");
+        var csproj = await File.ReadAllTextAsync(csprojPath);
+
+        // The file must remain valid XML (a corrupting splice would produce nested/unbalanced comments)
+        var doc = System.Xml.Linq.XDocument.Parse(csproj);
+        var liveProperties = doc.Descendants()
+            .Count(e => e.Name.LocalName == "WinAppRunUseExecutionAlias" && e.Value.Trim() == "true");
+        Assert.AreEqual(1, liveProperties, "Should add exactly one live property set to true");
+        Assert.Contains("<!-- <WinAppRunUseExecutionAlias>false</WinAppRunUseExecutionAlias> -->", csproj, "Original commented-out property should be preserved intact");
+    }
+
+    [TestMethod]
+    public async Task AddAlias_UpdateCsproj_TargetFrameworksPlural_AddsProperty()
+    {
+        // Arrange - no singular <TargetFramework>; insertion must fall back to <PropertyGroup>
+        var manifestPath = CreateDefaultManifest();
+        var csprojPath = CreateCsproj("""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFrameworks>net10.0-windows10.0.26100.0;net8.0</TargetFrameworks>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        var command = GetRequiredService<ManifestAddAliasCommand>();
+
+        // Act
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["--manifest", manifestPath, "--update-csproj"]);
+
+        // Assert
+        Assert.AreEqual(0, exitCode, "Command should succeed");
+        var csproj = await File.ReadAllTextAsync(csprojPath);
+        System.Xml.Linq.XDocument.Parse(csproj);
+        Assert.Contains("<WinAppRunUseExecutionAlias>true</WinAppRunUseExecutionAlias>", csproj, "Should add the property");
+    }
+
+    [TestMethod]
+    public async Task AddAlias_UpdateCsproj_NoPropertyGroup_ReturnsError()
+    {
+        // Arrange - no insertion point at all
+        var manifestPath = CreateDefaultManifest();
+        var csprojContent = """
+            <Project Sdk="Microsoft.NET.Sdk">
+            </Project>
+            """;
+        var csprojPath = CreateCsproj(csprojContent);
+
+        var command = GetRequiredService<ManifestAddAliasCommand>();
+
+        // Act
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["--manifest", manifestPath, "--update-csproj"]);
+
+        // Assert
+        Assert.AreEqual(1, exitCode, "Command should report failure when there is no insertion point");
+        var csproj = await File.ReadAllTextAsync(csprojPath);
+        Assert.AreEqual(csprojContent, csproj, "Csproj should be unchanged when it cannot be updated");
+    }
+
+    [TestMethod]
+    public async Task AddAlias_UpdateCsproj_MultipleCsproj_UpdatesAll()
+    {
+        // Arrange
+        var manifestPath = CreateDefaultManifest();
+        var csprojA = CreateCsproj("""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """, "app-a.csproj");
+        var csprojB = CreateCsproj("""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """, "app-b.csproj");
+
+        var command = GetRequiredService<ManifestAddAliasCommand>();
+
+        // Act
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["--manifest", manifestPath, "--update-csproj"]);
+
+        // Assert
+        Assert.AreEqual(0, exitCode, "Command should succeed");
+        Assert.Contains("<WinAppRunUseExecutionAlias>true</WinAppRunUseExecutionAlias>", await File.ReadAllTextAsync(csprojA), "First csproj should be updated");
+        Assert.Contains("<WinAppRunUseExecutionAlias>true</WinAppRunUseExecutionAlias>", await File.ReadAllTextAsync(csprojB), "Second csproj should be updated");
+    }
+
+    [TestMethod]
+    public async Task AddAlias_AlreadyExists_UpdateCsproj_SetsProperty()
+    {
+        // Arrange - manifest already has the alias; --update-csproj should still set the property
+        var manifestPath = CreateManifest("""
+            <?xml version="1.0" encoding="utf-8"?>
+            <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+                     xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5"
+                     xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
+                     IgnorableNamespaces="uap5 uap10">
+              <Identity Name="test-app" Publisher="CN=test" Version="1.0.0.0" />
+              <Applications>
+                <Application Id="testApp" Executable="myapp.exe" EntryPoint="Windows.FullTrustApplication">
+                  <Extensions>
+                    <uap5:Extension Category="windows.appExecutionAlias">
+                      <uap5:AppExecutionAlias>
+                        <uap5:ExecutionAlias Alias="myapp.exe" />
+                      </uap5:AppExecutionAlias>
+                    </uap5:Extension>
+                  </Extensions>
+                </Application>
+              </Applications>
+            </Package>
+            """);
+        var csprojPath = CreateCsproj("""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        var command = GetRequiredService<ManifestAddAliasCommand>();
+
+        // Act
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["--manifest", manifestPath, "--name", "myapp.exe", "--update-csproj"]);
+
+        // Assert
+        Assert.AreEqual(0, exitCode, "Command should succeed when alias already exists");
+        var csproj = await File.ReadAllTextAsync(csprojPath);
+        Assert.Contains("<WinAppRunUseExecutionAlias>true</WinAppRunUseExecutionAlias>", csproj, "Should set the property even when the alias already exists");
+    }
+
+    private string CreateCsproj(string content)
+        => CreateCsproj(content, "test-app.csproj");
+
+    private string CreateCsproj(string content, string fileName)
+    {
+        var path = Path.Combine(_tempDirectory.FullName, fileName);
         File.WriteAllText(path, content);
         return path;
     }
+
+    private string CreateDefaultManifest()
+        => CreateManifest("""
+            <?xml version="1.0" encoding="utf-8"?>
+            <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+                     xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
+                     IgnorableNamespaces="uap10">
+              <Identity Name="test-app" Publisher="CN=test" Version="1.0.0.0" />
+              <Applications>
+                <Application Id="testApp" Executable="myapp.exe" EntryPoint="Windows.FullTrustApplication">
+                </Application>
+              </Applications>
+            </Package>
+            """);
 
     #endregion
 

--- a/src/winapp-CLI/WinApp.Cli.Tests/ManifestAddAliasCommandTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/ManifestAddAliasCommandTests.cs
@@ -40,6 +40,7 @@ public class ManifestAddAliasCommandTests : BaseCommandTests
         Assert.IsTrue(command.Options.Any(o => o.Name == "--name"), "Should have --name option");
         Assert.IsTrue(command.Options.Any(o => o.Name == "--manifest"), "Should have --manifest option");
         Assert.IsTrue(command.Options.Any(o => o.Name == "--app-id"), "Should have --app-id option");
+        Assert.IsTrue(command.Options.Any(o => o.Name == "--update-csproj"), "Should have --update-csproj option");
     }
 
     #endregion
@@ -743,6 +744,154 @@ public class ManifestAddAliasCommandTests : BaseCommandTests
     #endregion
 
     #region Helper methods
+
+    #region --update-csproj tests
+
+    [TestMethod]
+    public async Task AddAlias_UpdateCsproj_AddsWinAppRunUseExecutionAliasProperty()
+    {
+        // Arrange
+        var manifestPath = CreateManifest("""
+            <?xml version="1.0" encoding="utf-8"?>
+            <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+                     xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
+                     IgnorableNamespaces="uap10">
+              <Identity Name="test-app" Publisher="CN=test" Version="1.0.0.0" />
+              <Applications>
+                <Application Id="testApp" Executable="myapp.exe" EntryPoint="Windows.FullTrustApplication">
+                </Application>
+              </Applications>
+            </Package>
+            """);
+        var csprojPath = CreateCsproj("""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <OutputType>Exe</OutputType>
+                <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        var command = GetRequiredService<ManifestAddAliasCommand>();
+
+        // Act
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["--manifest", manifestPath, "--update-csproj"]);
+
+        // Assert
+        Assert.AreEqual(0, exitCode, "Command should succeed");
+        var csproj = await File.ReadAllTextAsync(csprojPath);
+        Assert.Contains("<WinAppRunUseExecutionAlias>true</WinAppRunUseExecutionAlias>", csproj, "Should set the property to true");
+    }
+
+    [TestMethod]
+    public async Task AddAlias_UpdateCsproj_UpdatesExistingFalseProperty()
+    {
+        // Arrange
+        var manifestPath = CreateManifest("""
+            <?xml version="1.0" encoding="utf-8"?>
+            <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+                     xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
+                     IgnorableNamespaces="uap10">
+              <Identity Name="test-app" Publisher="CN=test" Version="1.0.0.0" />
+              <Applications>
+                <Application Id="testApp" Executable="myapp.exe" EntryPoint="Windows.FullTrustApplication">
+                </Application>
+              </Applications>
+            </Package>
+            """);
+        var csprojPath = CreateCsproj("""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
+                <WinAppRunUseExecutionAlias>false</WinAppRunUseExecutionAlias>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        var command = GetRequiredService<ManifestAddAliasCommand>();
+
+        // Act
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["--manifest", manifestPath, "--update-csproj"]);
+
+        // Assert
+        Assert.AreEqual(0, exitCode, "Command should succeed");
+        var csproj = await File.ReadAllTextAsync(csprojPath);
+        Assert.Contains("<WinAppRunUseExecutionAlias>true</WinAppRunUseExecutionAlias>", csproj, "Should update the property to true");
+        Assert.DoesNotContain("<WinAppRunUseExecutionAlias>false</WinAppRunUseExecutionAlias>", csproj, "Should not leave the false value");
+    }
+
+    [TestMethod]
+    public async Task AddAlias_WithoutUpdateCsproj_DoesNotModifyCsproj()
+    {
+        // Arrange
+        var manifestPath = CreateManifest("""
+            <?xml version="1.0" encoding="utf-8"?>
+            <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+                     xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
+                     IgnorableNamespaces="uap10">
+              <Identity Name="test-app" Publisher="CN=test" Version="1.0.0.0" />
+              <Applications>
+                <Application Id="testApp" Executable="myapp.exe" EntryPoint="Windows.FullTrustApplication">
+                </Application>
+              </Applications>
+            </Package>
+            """);
+        var csprojContent = """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """;
+        var csprojPath = CreateCsproj(csprojContent);
+
+        var command = GetRequiredService<ManifestAddAliasCommand>();
+
+        // Act
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["--manifest", manifestPath]);
+
+        // Assert
+        Assert.AreEqual(0, exitCode, "Command should succeed");
+        var csproj = await File.ReadAllTextAsync(csprojPath);
+        Assert.AreEqual(csprojContent, csproj, "Csproj should be unchanged without --update-csproj");
+    }
+
+    [TestMethod]
+    public async Task AddAlias_UpdateCsproj_NoCsproj_StillSucceeds()
+    {
+        // Arrange - manifest but no .csproj next to it
+        var manifestPath = CreateManifest("""
+            <?xml version="1.0" encoding="utf-8"?>
+            <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+                     xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
+                     IgnorableNamespaces="uap10">
+              <Identity Name="test-app" Publisher="CN=test" Version="1.0.0.0" />
+              <Applications>
+                <Application Id="testApp" Executable="myapp.exe" EntryPoint="Windows.FullTrustApplication">
+                </Application>
+              </Applications>
+            </Package>
+            """);
+
+        var command = GetRequiredService<ManifestAddAliasCommand>();
+
+        // Act
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["--manifest", manifestPath, "--update-csproj"]);
+
+        // Assert - alias still added, no failure when no project is present
+        Assert.AreEqual(0, exitCode, "Command should succeed even when no .csproj is present");
+        var content = await File.ReadAllTextAsync(manifestPath);
+        Assert.Contains("uap5:ExecutionAlias", content, "Should still add the execution alias");
+    }
+
+    private string CreateCsproj(string content)
+    {
+        var path = Path.Combine(_tempDirectory.FullName, "test-app.csproj");
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    #endregion
 
     private string CreateManifest(string content)
     {

--- a/src/winapp-CLI/WinApp.Cli/Commands/ManifestAddAliasCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/ManifestAddAliasCommand.cs
@@ -84,7 +84,7 @@ internal class ManifestAddAliasCommand : Command, IShortDescription
                     logger.LogInformation("{UISymbol} Added execution alias '{Alias}' to {Manifest}", UiSymbols.Check, result.AliasName, resolvedManifest.FullName);
                     if (updateCsproj)
                     {
-                        await UpdateCsprojAsync(resolvedManifest, cancellationToken);
+                        return await UpdateCsprojAsync(resolvedManifest, cancellationToken);
                     }
                     return 0;
 
@@ -92,7 +92,7 @@ internal class ManifestAddAliasCommand : Command, IShortDescription
                     logger.LogInformation("{UISymbol} Execution alias '{Alias}' already exists in the manifest.", UiSymbols.Warning, result.AliasName);
                     if (updateCsproj)
                     {
-                        await UpdateCsprojAsync(resolvedManifest, cancellationToken);
+                        return await UpdateCsprojAsync(resolvedManifest, cancellationToken);
                     }
                     return 0;
 
@@ -133,34 +133,45 @@ internal class ManifestAddAliasCommand : Command, IShortDescription
             }
         }
 
-        private async Task UpdateCsprojAsync(FileInfo manifest, CancellationToken cancellationToken)
+        private async Task<int> UpdateCsprojAsync(FileInfo manifest, CancellationToken cancellationToken)
         {
             var projectDirectory = manifest.Directory;
             if (projectDirectory == null || !projectDirectory.Exists)
             {
-                logger.LogWarning("{UISymbol} Could not locate the project directory for the manifest; skipped updating the .csproj.", UiSymbols.Warning);
-                return;
+                logger.LogWarning("{UISymbol} --update-csproj was requested but the project directory for the manifest could not be located; WinAppRunUseExecutionAlias was not set.", UiSymbols.Warning);
+                return 1;
             }
 
             var csprojFiles = dotNetService.FindCsproj(projectDirectory);
             if (csprojFiles.Count == 0)
             {
-                logger.LogWarning("{UISymbol} No .csproj found next to the manifest; skipped setting WinAppRunUseExecutionAlias.", UiSymbols.Warning);
-                return;
+                logger.LogWarning("{UISymbol} --update-csproj was requested but no .csproj was found next to the manifest; WinAppRunUseExecutionAlias was not set.", UiSymbols.Warning);
+                return 1;
             }
 
+            var hadFailure = false;
             foreach (var csproj in csprojFiles)
             {
-                var modified = await dotNetService.EnsureWinAppRunUseExecutionAliasAsync(csproj, cancellationToken);
-                if (modified)
+                var outcome = await dotNetService.EnsureWinAppRunUseExecutionAliasAsync(csproj, cancellationToken);
+                switch (outcome)
                 {
-                    logger.LogInformation("{UISymbol} Set WinAppRunUseExecutionAlias=true in {Csproj}", UiSymbols.Check, csproj.FullName);
-                }
-                else
-                {
-                    logger.LogInformation("{UISymbol} WinAppRunUseExecutionAlias is already enabled in {Csproj}", UiSymbols.Check, csproj.FullName);
+                    case CsprojPropertyOutcome.Added:
+                    case CsprojPropertyOutcome.Updated:
+                        logger.LogInformation("{UISymbol} Set WinAppRunUseExecutionAlias=true in {Csproj}", UiSymbols.Check, csproj.FullName);
+                        break;
+
+                    case CsprojPropertyOutcome.AlreadyTrue:
+                        logger.LogInformation("{UISymbol} WinAppRunUseExecutionAlias is already enabled in {Csproj}", UiSymbols.Check, csproj.FullName);
+                        break;
+
+                    default:
+                        logger.LogWarning("{UISymbol} Could not set WinAppRunUseExecutionAlias in {Csproj} (no <PropertyGroup> found). Add <WinAppRunUseExecutionAlias>true</WinAppRunUseExecutionAlias> manually.", UiSymbols.Warning, csproj.FullName);
+                        hadFailure = true;
+                        break;
                 }
             }
+
+            return hadFailure ? 1 : 0;
         }
     }
 }

--- a/src/winapp-CLI/WinApp.Cli/Commands/ManifestAddAliasCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/ManifestAddAliasCommand.cs
@@ -17,6 +17,7 @@ internal class ManifestAddAliasCommand : Command, IShortDescription
     public static Option<string> NameOption { get; }
     public static Option<FileInfo> ManifestOption { get; }
     public static Option<string> AppIdOption { get; }
+    public static Option<bool> UpdateCsprojOption { get; }
 
     static ManifestAddAliasCommand()
     {
@@ -35,6 +36,12 @@ internal class ManifestAddAliasCommand : Command, IShortDescription
         {
             Description = "Application Id to add the alias to (default: first Application element)"
         };
+
+        UpdateCsprojOption = new Option<bool>("--update-csproj")
+        {
+            Description = "Also set <WinAppRunUseExecutionAlias>true</WinAppRunUseExecutionAlias> in the .NET project (.csproj) next to the manifest, " +
+                "so 'winapp run' / 'dotnet run' launch the app through this execution alias and keep console I/O in the current terminal."
+        };
     }
 
     public ManifestAddAliasCommand() : base("add-alias", "Add an execution alias (uap5:AppExecutionAlias) to a Package.appxmanifest. " +
@@ -44,15 +51,17 @@ internal class ManifestAddAliasCommand : Command, IShortDescription
         Options.Add(NameOption);
         Options.Add(ManifestOption);
         Options.Add(AppIdOption);
+        Options.Add(UpdateCsprojOption);
     }
 
-    public class Handler(IManifestService manifestService, ICurrentDirectoryProvider currentDirectoryProvider, ILogger<ManifestAddAliasCommand> logger) : AsynchronousCommandLineAction
+    public class Handler(IManifestService manifestService, IDotNetService dotNetService, ICurrentDirectoryProvider currentDirectoryProvider, ILogger<ManifestAddAliasCommand> logger) : AsynchronousCommandLineAction
     {
         public override async Task<int> InvokeAsync(ParseResult parseResult, CancellationToken cancellationToken = default)
         {
             var aliasName = parseResult.GetValue(NameOption);
             var manifestFile = parseResult.GetValue(ManifestOption);
             var appId = parseResult.GetValue(AppIdOption);
+            var updateCsproj = parseResult.GetValue(UpdateCsprojOption);
 
             // Find manifest
             FileInfo? resolvedManifest = manifestFile;
@@ -73,10 +82,18 @@ internal class ManifestAddAliasCommand : Command, IShortDescription
             {
                 case AddExecutionAliasStatus.Added:
                     logger.LogInformation("{UISymbol} Added execution alias '{Alias}' to {Manifest}", UiSymbols.Check, result.AliasName, resolvedManifest.FullName);
+                    if (updateCsproj)
+                    {
+                        await UpdateCsprojAsync(resolvedManifest, cancellationToken);
+                    }
                     return 0;
 
                 case AddExecutionAliasStatus.AlreadyExists:
                     logger.LogInformation("{UISymbol} Execution alias '{Alias}' already exists in the manifest.", UiSymbols.Warning, result.AliasName);
+                    if (updateCsproj)
+                    {
+                        await UpdateCsprojAsync(resolvedManifest, cancellationToken);
+                    }
                     return 0;
 
                 case AddExecutionAliasStatus.ConflictingAliasExists:
@@ -113,6 +130,36 @@ internal class ManifestAddAliasCommand : Command, IShortDescription
                 default:
                     logger.LogError("{UISymbol} Unexpected error adding execution alias.", UiSymbols.Error);
                     return 1;
+            }
+        }
+
+        private async Task UpdateCsprojAsync(FileInfo manifest, CancellationToken cancellationToken)
+        {
+            var projectDirectory = manifest.Directory;
+            if (projectDirectory == null || !projectDirectory.Exists)
+            {
+                logger.LogWarning("{UISymbol} Could not locate the project directory for the manifest; skipped updating the .csproj.", UiSymbols.Warning);
+                return;
+            }
+
+            var csprojFiles = dotNetService.FindCsproj(projectDirectory);
+            if (csprojFiles.Count == 0)
+            {
+                logger.LogWarning("{UISymbol} No .csproj found next to the manifest; skipped setting WinAppRunUseExecutionAlias.", UiSymbols.Warning);
+                return;
+            }
+
+            foreach (var csproj in csprojFiles)
+            {
+                var modified = await dotNetService.EnsureWinAppRunUseExecutionAliasAsync(csproj, cancellationToken);
+                if (modified)
+                {
+                    logger.LogInformation("{UISymbol} Set WinAppRunUseExecutionAlias=true in {Csproj}", UiSymbols.Check, csproj.FullName);
+                }
+                else
+                {
+                    logger.LogInformation("{UISymbol} WinAppRunUseExecutionAlias is already enabled in {Csproj}", UiSymbols.Check, csproj.FullName);
+                }
             }
         }
     }

--- a/src/winapp-CLI/WinApp.Cli/Models/CsprojPropertyOutcome.cs
+++ b/src/winapp-CLI/WinApp.Cli/Models/CsprojPropertyOutcome.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+namespace WinApp.Cli.Models;
+
+/// <summary>
+/// Result of ensuring a boolean MSBuild property is set to <c>true</c> in a .csproj.
+/// </summary>
+internal enum CsprojPropertyOutcome
+{
+    /// <summary>The property was missing and was added.</summary>
+    Added,
+
+    /// <summary>The property existed with a non-true value and was updated to <c>true</c>.</summary>
+    Updated,
+
+    /// <summary>The property already existed and was set to <c>true</c>; the file was left unchanged.</summary>
+    AlreadyTrue,
+
+    /// <summary>
+    /// The file could not be updated (it does not exist, or no insertion point such as a
+    /// &lt;PropertyGroup&gt; was found). The file was left unchanged.
+    /// </summary>
+    NotModified,
+}

--- a/src/winapp-CLI/WinApp.Cli/Services/DotNetService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/DotNetService.cs
@@ -61,6 +61,9 @@ internal partial class DotNetService : IDotNetService
     [GeneratedRegex(@"<WinAppRunUseExecutionAlias>(.*?)</WinAppRunUseExecutionAlias>", RegexOptions.IgnoreCase | RegexOptions.Singleline)]
     private static partial Regex WinAppRunUseExecutionAliasElementRegex();
 
+    [GeneratedRegex(@"<!--.*?-->", RegexOptions.Singleline)]
+    private static partial Regex XmlCommentRegex();
+
     [GeneratedRegex(@"[ \t]*<WindowsPackageType>None</WindowsPackageType>\r?\n?", RegexOptions.IgnoreCase)]
     private static partial Regex WindowsPackageTypeNoneElementRegex();
 
@@ -507,143 +510,60 @@ internal partial class DotNetService : IDotNetService
 
     public async Task<bool> EnsureEnableMsixToolingAsync(FileInfo csprojPath, CancellationToken cancellationToken = default)
     {
-        if (!csprojPath.Exists)
-        {
-            return false;
-        }
+        var outcome = await EnsureBooleanPropertyTrueAsync(
+            csprojPath,
+            EnableMsixToolingElementRegex(),
+            "EnableMsixTooling",
+            MSIXInfoComment,
+            cancellationToken);
 
-        var content = await File.ReadAllTextAsync(csprojPath.FullName, cancellationToken);
-        var match = EnableMsixToolingElementRegex().Match(content);
-
-        if (match.Success)
-        {
-            var existingValue = match.Groups[1].Value.Trim();
-
-            if (string.Equals(existingValue, "true", StringComparison.OrdinalIgnoreCase))
-            {
-                return false;
-            }
-
-            if (string.Equals(existingValue, "false", StringComparison.OrdinalIgnoreCase))
-            {
-                // Update existing element from false to true, adding a comment if one doesn't already exist
-                var replacement = "<EnableMsixTooling>true</EnableMsixTooling>";
-
-                // Check if there's already a comment above the element
-                var beforeMatch = content[..match.Index];
-                if (!beforeMatch.TrimEnd().EndsWith("-->", StringComparison.Ordinal))
-                {
-                    // Detect indentation from the EnableMsixTooling line
-                    var lastNewline = beforeMatch.LastIndexOf('\n');
-                    var indent = lastNewline >= 0 ? beforeMatch[(lastNewline + 1)..] : "";
-                    replacement = $"{indent}{MSIXInfoComment}"
-                        + Environment.NewLine + replacement;
-                    // Replace including the leading whitespace on this line
-                    content = content[..(lastNewline + 1)]
-                        + replacement
-                        + content[(match.Index + match.Length)..];
-                }
-                else
-                {
-                    content = content[..match.Index]
-                        + replacement
-                        + content[(match.Index + match.Length)..];
-                }
-
-                await File.WriteAllTextAsync(csprojPath.FullName, content, cancellationToken);
-                return true;
-            }
-
-            return false;
-        }
-
-        // Insert EnableMsixTooling after RuntimeIdentifier, TargetFramework, or at start of first PropertyGroup
-        var element =
-            MSIXInfoComment
-            + Environment.NewLine + "    <EnableMsixTooling>true</EnableMsixTooling>";
-
-        var modified = false;
-        var ridMatch = RuntimeIdentifierElementRegex().Match(content);
-        if (ridMatch.Success)
-        {
-            // Insert after the full closing </RuntimeIdentifier> tag
-            var insertPos = ridMatch.Index + ridMatch.Length;
-            content = content[..insertPos]
-                + Environment.NewLine + "    " + element
-                + content[insertPos..];
-            modified = true;
-        }
-        else
-        {
-            var tfmMatch = TargetFrameworkElementRegex().Match(content);
-            if (tfmMatch.Success)
-            {
-                var insertPos = tfmMatch.Index + tfmMatch.Length;
-                content = content[..insertPos]
-                    + Environment.NewLine + "    " + element
-                    + content[insertPos..];
-                modified = true;
-            }
-            else
-            {
-                var propGroupIdx = content.IndexOf("<PropertyGroup", StringComparison.OrdinalIgnoreCase);
-                if (propGroupIdx >= 0)
-                {
-                    var closeTag = content.IndexOf('>', propGroupIdx);
-                    if (closeTag >= 0)
-                    {
-                        var insertPos = closeTag + 1;
-                        content = content[..insertPos]
-                            + Environment.NewLine + "    " + element
-                            + content[insertPos..];
-                        modified = true;
-                    }
-                }
-            }
-        }
-
-        if (modified)
-        {
-            await File.WriteAllTextAsync(csprojPath.FullName, content, cancellationToken);
-        }
-
-        return modified;
+        return outcome is CsprojPropertyOutcome.Added or CsprojPropertyOutcome.Updated;
     }
 
     /// <summary>
-    /// Ensures the .csproj has <c>&lt;WinAppRunUseExecutionAlias&gt;true&lt;/WinAppRunUseExecutionAlias&gt;</c>.
-    /// Adds the element with an explanatory XML comment if missing, or updates it to <c>true</c> if set to <c>false</c>.
+    /// Ensures a boolean MSBuild property is set to <c>true</c> in the given .csproj, preserving
+    /// existing formatting and comments. Adds the element (with an explanatory comment) when it is
+    /// missing, or rewrites it to <c>true</c> when present with any other value.
     /// </summary>
-    /// <returns>True if the .csproj was modified, false if it already had the correct setting.</returns>
-    public async Task<bool> EnsureWinAppRunUseExecutionAliasAsync(FileInfo csprojPath, CancellationToken cancellationToken = default)
+    /// <remarks>
+    /// Matching is comment-aware: occurrences of the property (or the anchor elements used to find an
+    /// insertion point) inside an XML comment are ignored, so commented-out configuration is never
+    /// spliced into the live project.
+    /// </remarks>
+    private static async Task<CsprojPropertyOutcome> EnsureBooleanPropertyTrueAsync(
+        FileInfo csprojPath,
+        Regex propertyRegex,
+        string propertyName,
+        string comment,
+        CancellationToken cancellationToken)
     {
         if (!csprojPath.Exists)
         {
-            return false;
+            return CsprojPropertyOutcome.NotModified;
         }
 
         var content = await File.ReadAllTextAsync(csprojPath.FullName, cancellationToken);
-        var match = WinAppRunUseExecutionAliasElementRegex().Match(content);
+        var trueElement = $"<{propertyName}>true</{propertyName}>";
 
-        if (match.Success)
+        var match = FirstNonCommentMatch(content, propertyRegex);
+        if (match is not null)
         {
             var existingValue = match.Groups[1].Value.Trim();
-
             if (string.Equals(existingValue, "true", StringComparison.OrdinalIgnoreCase))
             {
-                return false;
+                return CsprojPropertyOutcome.AlreadyTrue;
             }
 
             // Update existing element to true, adding a comment if one doesn't already exist
-            var replacement = "<WinAppRunUseExecutionAlias>true</WinAppRunUseExecutionAlias>";
-
+            var replacement = trueElement;
             var beforeMatch = content[..match.Index];
             if (!beforeMatch.TrimEnd().EndsWith("-->", StringComparison.Ordinal))
             {
+                // Detect indentation from the property line
                 var lastNewline = beforeMatch.LastIndexOf('\n');
                 var indent = lastNewline >= 0 ? beforeMatch[(lastNewline + 1)..] : "";
-                replacement = $"{indent}{ExecutionAliasInfoComment}"
-                    + Environment.NewLine + replacement;
+                replacement = $"{indent}{comment}" + Environment.NewLine + replacement;
+                // Replace including the leading whitespace on this line
                 content = content[..(lastNewline + 1)]
                     + replacement
                     + content[(match.Index + match.Length)..];
@@ -656,60 +576,107 @@ internal partial class DotNetService : IDotNetService
             }
 
             await File.WriteAllTextAsync(csprojPath.FullName, content, cancellationToken);
-            return true;
+            return CsprojPropertyOutcome.Updated;
         }
 
-        // Insert WinAppRunUseExecutionAlias after RuntimeIdentifier, TargetFramework, or at start of first PropertyGroup
-        var element =
-            ExecutionAliasInfoComment
-            + Environment.NewLine + "    <WinAppRunUseExecutionAlias>true</WinAppRunUseExecutionAlias>";
+        // Insert the property after RuntimeIdentifier, TargetFramework, or at start of first PropertyGroup
+        var element = comment
+            + Environment.NewLine + "    " + trueElement;
 
-        var modified = false;
-        var ridMatch = RuntimeIdentifierElementRegex().Match(content);
-        if (ridMatch.Success)
+        var anchor = FirstNonCommentMatch(content, RuntimeIdentifierElementRegex())
+            ?? FirstNonCommentMatch(content, TargetFrameworkElementRegex());
+        if (anchor is not null)
         {
-            var insertPos = ridMatch.Index + ridMatch.Length;
+            var insertPos = anchor.Index + anchor.Length;
             content = content[..insertPos]
                 + Environment.NewLine + "    " + element
                 + content[insertPos..];
-            modified = true;
+            await File.WriteAllTextAsync(csprojPath.FullName, content, cancellationToken);
+            return CsprojPropertyOutcome.Added;
         }
-        else
+
+        var propGroupIdx = FirstNonCommentIndex(content, "<PropertyGroup");
+        if (propGroupIdx >= 0)
         {
-            var tfmMatch = TargetFrameworkElementRegex().Match(content);
-            if (tfmMatch.Success)
+            var closeTag = content.IndexOf('>', propGroupIdx);
+            if (closeTag >= 0)
             {
-                var insertPos = tfmMatch.Index + tfmMatch.Length;
+                var insertPos = closeTag + 1;
                 content = content[..insertPos]
                     + Environment.NewLine + "    " + element
                     + content[insertPos..];
-                modified = true;
-            }
-            else
-            {
-                var propGroupIdx = content.IndexOf("<PropertyGroup", StringComparison.OrdinalIgnoreCase);
-                if (propGroupIdx >= 0)
-                {
-                    var closeTag = content.IndexOf('>', propGroupIdx);
-                    if (closeTag >= 0)
-                    {
-                        var insertPos = closeTag + 1;
-                        content = content[..insertPos]
-                            + Environment.NewLine + "    " + element
-                            + content[insertPos..];
-                        modified = true;
-                    }
-                }
+                await File.WriteAllTextAsync(csprojPath.FullName, content, cancellationToken);
+                return CsprojPropertyOutcome.Added;
             }
         }
 
-        if (modified)
-        {
-            await File.WriteAllTextAsync(csprojPath.FullName, content, cancellationToken);
-        }
-
-        return modified;
+        return CsprojPropertyOutcome.NotModified;
     }
+
+    /// <summary>
+    /// Returns the first match of <paramref name="regex"/> in <paramref name="content"/> whose start
+    /// index does not fall inside an XML comment, or <c>null</c> if every match is commented out.
+    /// </summary>
+    private static Match? FirstNonCommentMatch(string content, Regex regex)
+    {
+        var comments = XmlCommentRegex().Matches(content);
+        for (var match = regex.Match(content); match.Success; match = match.NextMatch())
+        {
+            if (!IsInsideComment(match.Index, comments))
+            {
+                return match;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Returns the index of the first occurrence of <paramref name="token"/> (case-insensitive) that is
+    /// not inside an XML comment, or <c>-1</c> if every occurrence is commented out.
+    /// </summary>
+    private static int FirstNonCommentIndex(string content, string token)
+    {
+        var comments = XmlCommentRegex().Matches(content);
+        var index = content.IndexOf(token, StringComparison.OrdinalIgnoreCase);
+        while (index >= 0)
+        {
+            if (!IsInsideComment(index, comments))
+            {
+                return index;
+            }
+
+            index = content.IndexOf(token, index + token.Length, StringComparison.OrdinalIgnoreCase);
+        }
+
+        return -1;
+    }
+
+    private static bool IsInsideComment(int index, MatchCollection comments)
+    {
+        foreach (Match comment in comments)
+        {
+            if (index >= comment.Index && index < comment.Index + comment.Length)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Ensures the .csproj has <c>&lt;WinAppRunUseExecutionAlias&gt;true&lt;/WinAppRunUseExecutionAlias&gt;</c>.
+    /// Adds the element with an explanatory XML comment if missing, or updates it to <c>true</c> if set to another value.
+    /// </summary>
+    /// <returns>The outcome describing whether the property was added, updated, already correct, or could not be written.</returns>
+    public Task<CsprojPropertyOutcome> EnsureWinAppRunUseExecutionAliasAsync(FileInfo csprojPath, CancellationToken cancellationToken = default)
+        => EnsureBooleanPropertyTrueAsync(
+            csprojPath,
+            WinAppRunUseExecutionAliasElementRegex(),
+            "WinAppRunUseExecutionAlias",
+            ExecutionAliasInfoComment,
+            cancellationToken);
 
     public async Task<bool> RemoveWindowsPackageTypeNoneAsync(FileInfo csprojPath, CancellationToken cancellationToken = default)
     {

--- a/src/winapp-CLI/WinApp.Cli/Services/DotNetService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/DotNetService.cs
@@ -27,6 +27,8 @@ internal partial class DotNetService : IDotNetService
 
     private const string MSIXInfoComment = "<!-- Enables targets that generate package layout, required for running with winapp run or msix packaging -->";
 
+    private const string ExecutionAliasInfoComment = "<!-- Launches the app through its execution alias during 'winapp run'/'dotnet run' so console I/O stays in the current terminal. Requires a uap5:ExecutionAlias in the manifest (add one with 'winapp manifest add-alias'). -->";
+
     // NuGet package names for .NET WinAppSDK projects
     internal const string WINAPP_SDK_NUGET_PACKAGE = "Microsoft.WindowsAppSDK";
 
@@ -55,6 +57,9 @@ internal partial class DotNetService : IDotNetService
 
     [GeneratedRegex(@"<EnableMsixTooling>(.*?)</EnableMsixTooling>", RegexOptions.IgnoreCase | RegexOptions.Singleline)]
     private static partial Regex EnableMsixToolingElementRegex();
+
+    [GeneratedRegex(@"<WinAppRunUseExecutionAlias>(.*?)</WinAppRunUseExecutionAlias>", RegexOptions.IgnoreCase | RegexOptions.Singleline)]
+    private static partial Regex WinAppRunUseExecutionAliasElementRegex();
 
     [GeneratedRegex(@"[ \t]*<WindowsPackageType>None</WindowsPackageType>\r?\n?", RegexOptions.IgnoreCase)]
     private static partial Regex WindowsPackageTypeNoneElementRegex();
@@ -562,6 +567,107 @@ internal partial class DotNetService : IDotNetService
         if (ridMatch.Success)
         {
             // Insert after the full closing </RuntimeIdentifier> tag
+            var insertPos = ridMatch.Index + ridMatch.Length;
+            content = content[..insertPos]
+                + Environment.NewLine + "    " + element
+                + content[insertPos..];
+            modified = true;
+        }
+        else
+        {
+            var tfmMatch = TargetFrameworkElementRegex().Match(content);
+            if (tfmMatch.Success)
+            {
+                var insertPos = tfmMatch.Index + tfmMatch.Length;
+                content = content[..insertPos]
+                    + Environment.NewLine + "    " + element
+                    + content[insertPos..];
+                modified = true;
+            }
+            else
+            {
+                var propGroupIdx = content.IndexOf("<PropertyGroup", StringComparison.OrdinalIgnoreCase);
+                if (propGroupIdx >= 0)
+                {
+                    var closeTag = content.IndexOf('>', propGroupIdx);
+                    if (closeTag >= 0)
+                    {
+                        var insertPos = closeTag + 1;
+                        content = content[..insertPos]
+                            + Environment.NewLine + "    " + element
+                            + content[insertPos..];
+                        modified = true;
+                    }
+                }
+            }
+        }
+
+        if (modified)
+        {
+            await File.WriteAllTextAsync(csprojPath.FullName, content, cancellationToken);
+        }
+
+        return modified;
+    }
+
+    /// <summary>
+    /// Ensures the .csproj has <c>&lt;WinAppRunUseExecutionAlias&gt;true&lt;/WinAppRunUseExecutionAlias&gt;</c>.
+    /// Adds the element with an explanatory XML comment if missing, or updates it to <c>true</c> if set to <c>false</c>.
+    /// </summary>
+    /// <returns>True if the .csproj was modified, false if it already had the correct setting.</returns>
+    public async Task<bool> EnsureWinAppRunUseExecutionAliasAsync(FileInfo csprojPath, CancellationToken cancellationToken = default)
+    {
+        if (!csprojPath.Exists)
+        {
+            return false;
+        }
+
+        var content = await File.ReadAllTextAsync(csprojPath.FullName, cancellationToken);
+        var match = WinAppRunUseExecutionAliasElementRegex().Match(content);
+
+        if (match.Success)
+        {
+            var existingValue = match.Groups[1].Value.Trim();
+
+            if (string.Equals(existingValue, "true", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            // Update existing element to true, adding a comment if one doesn't already exist
+            var replacement = "<WinAppRunUseExecutionAlias>true</WinAppRunUseExecutionAlias>";
+
+            var beforeMatch = content[..match.Index];
+            if (!beforeMatch.TrimEnd().EndsWith("-->", StringComparison.Ordinal))
+            {
+                var lastNewline = beforeMatch.LastIndexOf('\n');
+                var indent = lastNewline >= 0 ? beforeMatch[(lastNewline + 1)..] : "";
+                replacement = $"{indent}{ExecutionAliasInfoComment}"
+                    + Environment.NewLine + replacement;
+                content = content[..(lastNewline + 1)]
+                    + replacement
+                    + content[(match.Index + match.Length)..];
+            }
+            else
+            {
+                content = content[..match.Index]
+                    + replacement
+                    + content[(match.Index + match.Length)..];
+            }
+
+            await File.WriteAllTextAsync(csprojPath.FullName, content, cancellationToken);
+            return true;
+        }
+
+        // Insert WinAppRunUseExecutionAlias after RuntimeIdentifier, TargetFramework, or at start of first PropertyGroup
+        var element =
+            ExecutionAliasInfoComment
+            + Environment.NewLine + "    <WinAppRunUseExecutionAlias>true</WinAppRunUseExecutionAlias>";
+
+        var modified = false;
+        var ridMatch = RuntimeIdentifierElementRegex().Match(content);
+        if (ridMatch.Success)
+        {
             var insertPos = ridMatch.Index + ridMatch.Length;
             content = content[..insertPos]
                 + Environment.NewLine + "    " + element

--- a/src/winapp-CLI/WinApp.Cli/Services/IDotNetService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/IDotNetService.cs
@@ -106,6 +106,15 @@ internal interface IDotNetService
     Task<bool> EnsureEnableMsixToolingAsync(FileInfo csprojPath, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Ensures the .csproj has <c>&lt;WinAppRunUseExecutionAlias&gt;true&lt;/WinAppRunUseExecutionAlias&gt;</c>.
+    /// Adds the element with an explanatory XML comment if missing, or updates it to <c>true</c> if set to <c>false</c>.
+    /// This makes <c>winapp run</c> / <c>dotnet run</c> launch the app through its execution alias so console I/O
+    /// stays in the current terminal.
+    /// </summary>
+    /// <returns>True if the .csproj was modified, false if it already had the correct setting.</returns>
+    Task<bool> EnsureWinAppRunUseExecutionAliasAsync(FileInfo csprojPath, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Removes <c>&lt;WindowsPackageType&gt;None&lt;/WindowsPackageType&gt;</c> if found in the .csproj,
     /// since this property prevents the app from running as a packaged application.
     /// </summary>

--- a/src/winapp-CLI/WinApp.Cli/Services/IDotNetService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/IDotNetService.cs
@@ -111,8 +111,8 @@ internal interface IDotNetService
     /// This makes <c>winapp run</c> / <c>dotnet run</c> launch the app through its execution alias so console I/O
     /// stays in the current terminal.
     /// </summary>
-    /// <returns>True if the .csproj was modified, false if it already had the correct setting.</returns>
-    Task<bool> EnsureWinAppRunUseExecutionAliasAsync(FileInfo csprojPath, CancellationToken cancellationToken = default);
+    /// <returns>The outcome describing whether the property was added, updated, already correct, or could not be written.</returns>
+    Task<CsprojPropertyOutcome> EnsureWinAppRunUseExecutionAliasAsync(FileInfo csprojPath, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Removes <c>&lt;WindowsPackageType&gt;None&lt;/WindowsPackageType&gt;</c> if found in the .csproj,

--- a/src/winapp-npm/src/winapp-commands.ts
+++ b/src/winapp-npm/src/winapp-commands.ts
@@ -2,7 +2,7 @@
  * AUTO-GENERATED — DO NOT EDIT
  *
  * Regenerate with:  npm run generate-commands
- * Source schema version: 0.3.3
+ * Source schema version: 0.4.1
  *
  * Programmatic wrappers for all winapp CLI commands.
  * Each function builds the CLI arguments, invokes the native CLI,
@@ -281,6 +281,8 @@ export interface ManifestAddAliasOptions extends CommonOptions {
   manifest?: string;
   /** Alias name (e.g. 'myapp.exe'). Default: inferred from the Executable attribute in the manifest. */
   name?: string;
+  /** Also set <WinAppRunUseExecutionAlias>true</WinAppRunUseExecutionAlias> in the .NET project (.csproj) next to the manifest, so 'winapp run' / 'dotnet run' launch the app through this execution alias and keep console I/O in the current terminal. */
+  updateCsproj?: boolean;
 }
 
 /**
@@ -291,6 +293,7 @@ export async function manifestAddAlias(options: ManifestAddAliasOptions = {}): P
   if (options.appId) args.push('--app-id', options.appId);
   if (options.manifest) args.push('--manifest', options.manifest);
   if (options.name) args.push('--name', options.name);
+  if (options.updateCsproj) args.push('--update-csproj');
   return execCommand(args, options);
 }
 


### PR DESCRIPTION
fixes #520 

Adds an opt-in `--update-csproj` flag that sets `<WinAppRunUseExecutionAlias>true</WinAppRunUseExecutionAlias>` in the `.csproj` next to the manifest, so `winapp run` / `dotnet run` launch the app through its execution alias and keep console I/O in the current terminal.

### What's included
- **New flag** `--update-csproj` on `manifest add-alias`. Default off; behavior is fully additive.
- **Comment-aware csproj editing.** Property and anchor (`RuntimeIdentifier` / `TargetFramework` / `<PropertyGroup>`) matches inside XML comments are skipped, so commented-out config is never spliced into the live project. Shared `EnsureBooleanPropertyTrueAsync` helper now backs both `EnsureWinAppRunUseExecutionAliasAsync` and the existing `EnsureEnableMsixToolingAsync`.
- **Accurate reporting.** New `CsprojPropertyOutcome` (`Added` / `Updated` / `AlreadyTrue` / `NotModified`) drives precise logging. The alias is still written, but the command exits non-zero when `--update-csproj` is requested and no `.csproj` / insertion point is found, instead of silently no-op-ing.
- **Docs** updated: `usage.md`, `dotnet-run-support.md`, and the `manifest` skill fragment.

### Testing
- 6 new edge-case tests (commented-out-property regression, already-true no-op, `<TargetFrameworks>`-only, no-`<PropertyGroup>` error, multiple csproj, already-exists alias + flag).
- Full suite: **1334 passed, 1 env-skip, 0 failed**. Release build clean (analyzers pass).

### Notes
- No breaking changes — flag is opt-in and `IDotNetService` is internal.
- Autogenerated docs (`cli-schema.json`, plugin/`.claude` SKILL.md) are regenerated by `scripts/build-cli.ps1` during the official build.