### PR TITLE
Also fail on Pester block/container failures (not just failed tests)

### DIFF
--- a/scripts/build-cli.ps1
+++ b/scripts/build-cli.ps1
@@ -403,13 +403,14 @@ try
                         $pesterConfig = New-PesterConfiguration
                         $pesterConfig.Run.Path = $NuGetTestsPath
                         $pesterConfig.Run.Exit = $false
+                        $pesterConfig.Run.PassThru = $true
                         $pesterConfig.Output.Verbosity = 'Normal'
                         $pesterResult = Invoke-Pester -Configuration $pesterConfig
-                        if ($pesterResult.FailedCount -gt 0) {
+                        if (($pesterResult.FailedCount + $pesterResult.FailedBlocksCount + $pesterResult.FailedContainersCount) -gt 0) {
                             if ($FailOnTestFailure) {
-                                Write-Error "Stopping build due to NuGet Pester test failures (FailOnTestFailure flag set): $($pesterResult.FailedCount) failed"
+                                Write-Error "Stopping build due to NuGet Pester test failures (FailOnTestFailure flag set): $($pesterResult.FailedCount) failed test(s), $($pesterResult.FailedBlocksCount) failed block(s), $($pesterResult.FailedContainersCount) failed container(s)"
                             } else {
-                                Write-Warning "NuGet Pester tests had $($pesterResult.FailedCount) failure(s) — continuing"
+                                Write-Warning "NuGet Pester tests had $($pesterResult.FailedCount) failed test(s), $($pesterResult.FailedBlocksCount) failed block(s), $($pesterResult.FailedContainersCount) failed container(s) — continuing"
                             }
                         } else {
                             Write-Host "[TEST] NuGet Pester tests passed: $($pesterResult.PassedCount) passed, $($pesterResult.SkippedCount) skipped" -ForegroundColor Green


### PR DESCRIPTION
> ⚠️ This PR was generated by an AI agent (GitHub Copilot CLI). Please review accordingly.

I've been seeing this commonly across Pester 5 build scripts and I'm fixing it where it looks like it could hide real failures.

In Pester 5 a run reports three independent failure counts:

- `FailedCount` — failed tests (`It`)
- `FailedBlocksCount` — failed `BeforeAll` / `AfterAll`
- `FailedContainersCount` — files that error during discovery / fail to load

Gating on only `FailedCount` means a `BeforeAll` that throws, or a test file that fails to load, leaves `FailedCount = 0` and the build passes green despite real failures. Pester itself derives the overall pass/fail from the sum of all three.

This includes all three counts in the gate, and reports each count (failed tests, blocks, containers) in the messages instead of only the failed test count.

While here I also set `Run.PassThru = $true` on the Pester configuration — without it `Invoke-Pester` returns nothing, so `$pesterResult` was `$null` and the gate never actually fired.
