### PR TITLE
Actually fail the build on NuGet Pester failures (add missing exit 1)

### DIFF
--- a/scripts/build-cli.ps1
+++ b/scripts/build-cli.ps1
@@ -409,6 +409,7 @@ try
                         if (($pesterResult.FailedCount + $pesterResult.FailedBlocksCount + $pesterResult.FailedContainersCount) -gt 0) {
                             if ($FailOnTestFailure) {
                                 Write-Error "Stopping build due to NuGet Pester test failures (FailOnTestFailure flag set): $($pesterResult.FailedCount) failed test(s), $($pesterResult.FailedBlocksCount) failed block(s), $($pesterResult.FailedContainersCount) failed container(s)"
+                                exit 1
                             } else {
                                 Write-Warning "NuGet Pester tests had $($pesterResult.FailedCount) failed test(s), $($pesterResult.FailedBlocksCount) failed block(s), $($pesterResult.FailedContainersCount) failed container(s) — continuing"
                             }


### PR DESCRIPTION
## Problem

#605 fixed the NuGet Pester test gate in `scripts/build-cli.ps1` — it added `$pesterConfig.Run.PassThru = $true` (so `Invoke-Pester` returns a result object) and changed the failure condition to count failed tests + blocks + containers. That made the gate *reachable* for the first time.

But the gate was still incomplete: when a failure is detected and `$FailOnTestFailure` is set (default `$true`), it called `Write-Error` but never called `exit 1`. Under PowerShell's default `$ErrorActionPreference = 'Continue'` — which is exactly what GitHub Actions' default `pwsh` shell uses, and what `.github/workflows/build-package.yml` (`.\scripts\build-cli.ps1 -SkipDocs`) relies on — `Write-Error` is **non-terminating**. So the script printed "Stopping build…" and then kept running and exited `0`. The build did **not** actually fail on NuGet Pester failures under GitHub Actions. (It only failed in Azure DevOps `.pipelines/templates/build.yaml`, where `PowerShell@2` forces `errorActionPreference=stop`.)

## Fix

Add `exit 1` immediately after the `Write-Error` in the NuGet Pester gate, making it consistent with the two sibling gates in the same file that already do this:

- the npm unit-tests gate (~line 246–247)
- the CLI unit-tests gate (~line 298–299)

This is a single-line change.

## Verification

- `scripts/build-cli.ps1` parses cleanly (`[System.Management.Automation.Language.Parser]::ParseFile`).
- `git diff` confirms the only change is the added `exit 1` line.