### PR TITLE
Fix @-prefixed args swallowed by response-file expansion (#619)

### DIFF
--- a/src/winapp-CLI/WinApp.Cli.Tests/WinAppParserConfigurationTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/WinAppParserConfigurationTests.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using WinApp.Cli.Commands;
+using WinApp.Cli.Helpers;
+
+namespace WinApp.Cli.Tests;
+
+/// <summary>
+/// Regression tests for <see cref="WinAppParserConfiguration.Default"/>.
+/// </summary>
+/// <remarks>
+/// Guards issue #619: argument values that begin with <c>@</c> (chat/social mentions such as
+/// <c>@assistant</c>, npm scopes such as <c>@scope/pkg</c>, positional emails, etc.) must be passed
+/// through to the command handler as literal text and must NOT be interpreted as
+/// System.CommandLine <c>@responsefile</c> indirection. Before the fix, response-file token expansion
+/// was left enabled, so <c>winapp ui search "@assistant"</c> failed at parse time with
+/// "Response file not found 'assistant'." and the handler never ran.
+/// </remarks>
+[TestClass]
+public class WinAppParserConfigurationTests : BaseCommandTests
+{
+    private static string ErrorSummary(System.CommandLine.ParseResult parseResult) =>
+        "Leading '@' value must not trigger response-file expansion. Parse errors: " +
+        string.Join("; ", parseResult.Errors.Select(e => e.Message));
+
+    [TestMethod]
+    public void PassesLeadingAtValueThroughAsLiteral_ForSearchSelector()
+    {
+        var rootCommand = GetRequiredService<WinAppRootCommand>();
+        var args = new[] { "ui", "search", "@assistant", "-a", "fakeapp" };
+
+        var parseResult = rootCommand.Parse(args, WinAppParserConfiguration.Default);
+
+        Assert.AreEqual(0, parseResult.Errors.Count, ErrorSummary(parseResult));
+        Assert.AreEqual("@assistant", parseResult.GetValue(SharedUiOptions.SelectorArgument));
+    }
+
+    [TestMethod]
+    public void PassesLeadingAtValueThroughAsLiteral_ForSetValueArgument()
+    {
+        var rootCommand = GetRequiredService<WinAppRootCommand>();
+        var args = new[] { "ui", "set-value", "txt-name", "@somebody", "-a", "fakeapp" };
+
+        var parseResult = rootCommand.Parse(args, WinAppParserConfiguration.Default);
+
+        Assert.AreEqual(0, parseResult.Errors.Count, ErrorSummary(parseResult));
+        Assert.AreEqual("@somebody", parseResult.GetValue(SharedUiOptions.ValueArgument));
+    }
+
+    [TestMethod]
+    public void PassesNpmScopeStyleValueThroughAsLiteral()
+    {
+        var rootCommand = GetRequiredService<WinAppRootCommand>();
+        var args = new[] { "ui", "search", "@scope/pkg", "-a", "fakeapp" };
+
+        var parseResult = rootCommand.Parse(args, WinAppParserConfiguration.Default);
+
+        Assert.AreEqual(0, parseResult.Errors.Count, ErrorSummary(parseResult));
+        Assert.AreEqual("@scope/pkg", parseResult.GetValue(SharedUiOptions.SelectorArgument));
+    }
+
+    [TestMethod]
+    public void PassesPlainValueThroughUnchanged()
+    {
+        var rootCommand = GetRequiredService<WinAppRootCommand>();
+        var args = new[] { "ui", "search", "assistant", "-a", "fakeapp" };
+
+        var parseResult = rootCommand.Parse(args, WinAppParserConfiguration.Default);
+
+        Assert.AreEqual(0, parseResult.Errors.Count, ErrorSummary(parseResult));
+        Assert.AreEqual("assistant", parseResult.GetValue(SharedUiOptions.SelectorArgument));
+    }
+}

--- a/src/winapp-CLI/WinApp.Cli.Tests/WinAppParserConfigurationTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/WinAppParserConfigurationTests.cs
@@ -49,6 +49,18 @@ public class WinAppParserConfigurationTests : BaseCommandTests
     }
 
     [TestMethod]
+    public void PassesLeadingAtValueThroughAsLiteral_ForAppOption()
+    {
+        var rootCommand = GetRequiredService<WinAppRootCommand>();
+        var args = new[] { "ui", "search", "selector", "-a", "@fakeapp" };
+
+        var parseResult = rootCommand.Parse(args, WinAppParserConfiguration.Default);
+
+        Assert.AreEqual(0, parseResult.Errors.Count, ErrorSummary(parseResult));
+        Assert.AreEqual("@fakeapp", parseResult.GetValue(SharedUiOptions.AppOption));
+    }
+
+    [TestMethod]
     public void PassesNpmScopeStyleValueThroughAsLiteral()
     {
         var rootCommand = GetRequiredService<WinAppRootCommand>();

--- a/src/winapp-CLI/WinApp.Cli/Helpers/WinAppParserConfiguration.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/WinAppParserConfiguration.cs
@@ -12,11 +12,20 @@ namespace WinApp.Cli.Helpers;
 /// POSIX bundling is disabled because winapp uses a Windows-style CLI that does not advertise
 /// short-option clustering (e.g. <c>-abc</c>) or attached-value short options (e.g. <c>-w7932630</c>),
 /// and the silent reinterpretation of <c>-app</c> as <c>-a pp</c> is a usability trap (issue #467).
+/// <para>
+/// Response-file token expansion is disabled (<see cref="ParserConfiguration.ResponseFileTokenReplacer"/>
+/// set to <see langword="null"/>) so that argument values beginning with <c>@</c> are passed through as
+/// literal text rather than being interpreted as <c>@responsefile</c> indirection. winapp is an
+/// app-automation CLI that is frequently used to drive chat/assistant UIs where <c>@mention</c> values
+/// are common (e.g. <c>winapp ui search "@assistant"</c>); it does not need response-file support, and
+/// leaving it enabled silently swallowed such values at parse time (issue #619).
+/// </para>
 /// </remarks>
 internal static class WinAppParserConfiguration
 {
     public static ParserConfiguration Default { get; } = new()
     {
-        EnablePosixBundling = false
+        EnablePosixBundling = false,
+        ResponseFileTokenReplacer = null
     };
 }


### PR DESCRIPTION
## Summary

Fixes #619.

Argument **values** beginning with `@` (e.g. `winapp ui search "@assistant"`) were intercepted by System.CommandLine's response-file token expansion. The parser treated `@assistant` as "read arguments from a file named `assistant`", failed at parse time with `Response file not found 'assistant'.`, printed help, and exited 1 — the command handler never ran. Because the failure happened at parse time, `--json` was also ignored (plain-text error + help instead of the standard JSON error envelope).

This broke common inputs: chat/social `@mention` text (`winapp ui search "@assistant"`, `winapp ui set-value <sel> "@somebody"`), npm scopes (`@scope/pkg`), positional emails, etc. — a frequent foot-gun since `winapp ui` is used heavily to drive chat/assistant UIs.

## Root cause

`WinAppParserConfiguration.Default` set `EnablePosixBundling = false` but left `ResponseFileTokenReplacer` at its (non-null) default, so `@`-token expansion stayed enabled for every winapp parse.

## Fix

Set `ResponseFileTokenReplacer = null` in `WinAppParserConfiguration.Default`, disabling response-file expansion globally so `@`-prefixed values pass through as literal text. winapp is an app-automation CLI and does not need `@responsefile` indirection. All real System.CommandLine parse entry points route through this shared config (`Program.cs` ×2, `CompleteCommand.cs`), so a single change fixes it everywhere — including the secondary `--json` symptom (the handler now runs and emits the normal JSON envelope).

## Trade-offs

The only thing given up is System.CommandLine's `@responsefile` indirection (`winapp <cmd> @args.txt`). It is **undocumented, unused (0 references across CLI source, docs, samples, scripts, npm wrapper, and tests), and ill-suited** to a short-command automation CLI. The bug it fixes has **no workaround today** — with expansion on there is no escape syntax, so `@assistant` is simply broken. The change is trivially reversible if a genuine need ever surfaces.

Rejected alternatives: a replacer that expands only when the file exists (non-deterministic per-cwd) and a `@@file` escaping convention (extra surface for an unused feature) — both worse.

## Tests

New `WinApp.Cli.Tests/WinAppParserConfigurationTests.cs` asserts `@`-leading values parse with no errors and reach handlers as literals:
- `ui search "@assistant"` → `SelectorArgument == "@assistant"`
- `ui set-value txt-name "@somebody"` → `ValueArgument == "@somebody"`
- `ui search "@scope/pkg"` → literal passthrough
- plain-value guard (`assistant`) still parses unchanged

## Verification

- New tests 4/4; existing typo tests 7/7; broader parsing suite (CompleteCommand, WindowsCommandLine, UiCommand, CliSchema, CustomHelp, GlobalOptionPreScan) 199/199.
- Full solution compiles clean in Release (0 warnings / 0 errors).
- **End-to-end** against the built CLI: `winapp ui search "@assistant" -a fakeapp --json` and `"@handle"` now return the standard JSON error envelope (`No running app found matching 'fakeapp'.`) — identical to the plain-`assistant` control — instead of "Response file not found".
- Confirmed no command-surface change (regenerating docs produced only version-string churn, reverted).

No docs/samples changes needed — the only "response file" doc reference is the unrelated cppwinrt `.cppwinrt.rsp` build file.