### PR TITLE
Collect coverage on a Debug build for accurate line coverage (#630)

### DIFF
--- a/scripts/build-cli.ps1
+++ b/scripts/build-cli.ps1
@@ -205,9 +205,14 @@ try
         exit 1
     }
 
-    # Step 3: Build test project (CLI is already built from publish, this mainly compiles tests)
-    Write-Host "[BUILD] Building CLI solution..." -ForegroundColor Blue
-    dotnet build $CliSolutionPath -c Release
+    # Step 3: Build the solution in Debug to compile the tests. Coverage is collected on
+    # this Debug build (Step 5) -- optimized Release builds under-count line coverage (many
+    # block-brace lines report hits=0). The shipped CLI artifact is the Release `dotnet publish`
+    # above; this Debug build exists only to run the test suite. See issue #630.
+    # TreatWarningsAsErrors is Release-only (Directory.Build.props), so pass it explicitly here
+    # to keep the warning-as-error quality gate the previous Release test build provided.
+    Write-Host "[BUILD] Building CLI solution (Debug, for tests + coverage)..." -ForegroundColor Blue
+    dotnet build $CliSolutionPath -c Debug -p:TreatWarningsAsErrors=true
     if ($LASTEXITCODE -ne 0) {
         Write-Error "Failed to build CLI solution"
         exit 1
@@ -257,13 +262,14 @@ try
     # Step 5: Run tests (unless skipped)
     if (-not $SkipTests) {
         Write-Host "[TEST] Running tests..." -ForegroundColor Blue
-        # Measure coverage against hand-written product source only. coverage.runsettings
-        # excludes generated interop (CsWin32/COM/Regex generators in obj\**) from the
-        # denominator; without it the reported number is diluted from a meaningful ~49% to a
-        # meaningless ~18%. Hand-written services (incl. the hardware/COM/GPU interop) are NOT
-        # excluded -- they are covered by real tests. See issue #630.
+        # Measure coverage honestly. Two things distort the raw number: (1) auto-generated
+        # interop (CsWin32/COM/Regex generators in obj\**) inflates the denominator -- excluded
+        # via coverage.runsettings; (2) optimized Release builds report many block-brace lines as
+        # hits=0, so line coverage is under-counted -- so we collect on the Debug build from
+        # Step 3. Hand-written services (incl. the hardware/COM/GPU interop) are NOT excluded;
+        # they are covered by real tests. See issue #630.
         $CoverageSettings = (Resolve-Path "$CliSolutionDir\coverage.runsettings").Path
-        dotnet run --project $CliTestsProjectPath -c Release --no-build --results-directory $CliSolutionDir\TestResults --report-trx --coverage --coverage-settings $CoverageSettings --coverage-output-format cobertura
+        dotnet run --project $CliTestsProjectPath -c Debug --no-build --results-directory $CliSolutionDir\TestResults --report-trx --coverage --coverage-settings $CoverageSettings --coverage-output-format cobertura
         $TestExitCode = $LASTEXITCODE
     
         # Copy test results to artifacts BEFORE checking for failure - find all TRX files

--- a/scripts/coverage-report.ps1
+++ b/scripts/coverage-report.ps1
@@ -10,7 +10,14 @@
     state machines under obj\**) is excluded from the denominator.
 
     Without that exclusion the raw number is dominated by generated code and
-    reports ~18% instead of the real ~49% over hand-written source. See issue #630.
+    reports ~18% instead of the real figure over hand-written source. See issue #630.
+
+    Coverage is collected on a Debug build. On optimized Release builds the compiler
+    often drops or merges the sequence points for standalone block braces (and duplicate
+    returns), so the Microsoft coverage engine reports many '{'/'}' lines as hits=0 even
+    when the code fully executes -- systematically under-counting line coverage and
+    capping control-flow-heavy files around 70-80%. Debug builds map lines faithfully,
+    which is the standard configuration for coverage.
 
     The script parses the produced Cobertura report, de-duplicates line hits across
     partial classes / build configs, and prints:
@@ -23,7 +30,9 @@
     so it can be used as a CI gate.
 
 .PARAMETER Configuration
-    Build configuration to test. Default: Release.
+    Build configuration to test. Default: Debug -- Release optimizations make the
+    coverage engine under-count line coverage (many block-brace lines report hits=0).
+    Only pass -Configuration Release if you specifically need it.
 
 .PARAMETER Filter
     Optional MTP test filter (e.g. "FullyQualifiedName~MsixService"). Note: a filtered
@@ -64,7 +73,7 @@
 #>
 [CmdletBinding()]
 param(
-    [string]$Configuration = "Release",
+    [string]$Configuration = "Debug",
     [string]$Filter,
     [string]$Area,
     [ValidateRange(0, 100)][double]$Threshold = -1,

--- a/src/winapp-CLI/WinApp.Cli.Tests/README.md
+++ b/src/winapp-CLI/WinApp.Cli.Tests/README.md
@@ -108,7 +108,9 @@ The E2E tests provide comprehensive coverage of real-world scenarios, ensuring t
 We gate coverage on the **testable surface** of the CLI, not the raw line count. The raw
 `--coverage` denominator is dominated by generated interop (CsWin32 `NativeMethods.g.cs`,
 `ComInterfaceGenerator` COM shims for D3D11/UI Automation, `RegexGenerator`) emitted into
-`obj\`, which made the reported number misleading (~18% vs. ~49% real). See issue #630.
+`obj\`, which — together with Release-build brace under-counting (see **Why a Debug build**
+below) — made the reported number misleading (~18% raw vs. ~59% real over hand-written
+source). See issue #630.
 
 ### Measuring
 
@@ -120,16 +122,33 @@ pwsh scripts\coverage-report.ps1
 pwsh scripts\coverage-report.ps1 -Area Services -Filter "FullyQualifiedName~MsixService" -Threshold 95
 ```
 
-`build-cli.ps1` also runs the suite with `src\winapp-CLI\coverage.runsettings` so CI numbers
-match local ones.
+`build-cli.ps1` runs the suite the same way — a **Debug** build with
+`src\winapp-CLI\coverage.runsettings` — so the coverage number CI posts on your PR matches
+what `coverage-report.ps1` prints locally.
+
+### Why a Debug build
+
+Coverage is collected on a **Debug** build, not Release. On optimized Release builds the C#
+compiler often drops or merges the sequence points for standalone block braces (and duplicate
+`return` statements), so the Microsoft coverage engine reports many `{`/`}` lines as `hits=0`
+**even when the method fully executes** — systematically under-counting line coverage and
+capping control-flow-heavy files around 70–80%. Debug builds map every line faithfully, so the
+number reflects what the tests actually exercised. This is the standard configuration for
+coverage measurement.
+
+The shipped CLI is still the Release `dotnet publish`, and it's exercised end-to-end by the
+sample and npm E2E suites — so moving the C# unit suite to Debug for coverage doesn't drop
+Release-artifact validation. The Debug solution build passes `-p:TreatWarningsAsErrors=true`
+so it keeps the warning-as-error gate that `Directory.Build.props` otherwise applies only to
+Release.
 
 ### What's excluded (and why)
 
 **Only generated code is excluded** — via `coverage.runsettings` (`obj\**`, `*.g.cs`,
 `*.Designer.cs`, plus the `[GeneratedCode]` attribute). This is the CsWin32 P/Invoke thunks,
 `ComInterfaceGenerator` COM shims, and `RegexGenerator` state machines. It isn't hand-written,
-so it doesn't belong in the denominator. That single change is what moves the reported number
-from the misleading ~18% to the real figure.
+so it doesn't belong in the denominator. That change is the biggest single correction to the
+raw ~18%; the Debug build (above) closes the remaining brace-undercount gap.
 
 **Hardware / COM / GPU code is _not_ excluded.** `UiAutomationService`, `WgcCapture`, and the
 keyboard/mouse input helpers are real product code and stay in the denominator. This foundation


### PR DESCRIPTION
Follow-up to #632. That PR fixed the biggest coverage distortion (generated code inflating the denominator), but it still collected coverage on an optimized **Release** build — where the Microsoft coverage engine reports many standalone block-brace lines (`{`/`}`) as `hits=0` even when the code executes (it drops or merges their sequence points). That deflates line coverage and caps control-flow-heavy files at ~70–80%.

## Fix

Collect coverage on a **Debug** build, which maps lines faithfully (the standard configuration for .NET coverage). No test content changes.

- `coverage-report.ps1`: default `-Configuration Debug` (+ rationale in help).
- `build-cli.ps1`: build + run the test/coverage pass in Debug so the CI-posted cobertura `line-rate` matches local runs. Pass `-p:TreatWarningsAsErrors=true` on the Debug build to keep the warning-as-error gate that `Directory.Build.props` otherwise applies only to Release. The shipped CLI is still the Release `dotnet publish` — only the test run moves to Debug, and the Release artifact stays exercised end-to-end by the sample/npm E2E suites.
- `README`: document why Debug and correct the baseline figure.

## Impact on the honest baseline

| | Overall | ManifestService.cs |
|---|---|---|
| Release (understated) | ~48.8% | 62–71% |
| **Debug (accurate)** | **~59.5%** | **81.7%** |

Same tests, ~11 points higher — the gap was pure Release brace under-counting. This makes the number CI posts on PRs honest and unblocks the per-file 95% target for the follow-up coverage PRs (the ~70–80% "ceiling" was a measurement artifact, not real code that couldn't be covered).

## Review

Ran the repo's `pr-review` skill (7 specialists + a GPT multi-model cross-check) and validated at runtime:
- Full Debug coverage run (1,637 pass / 1 skipped; 3 pre-existing env-only E2E failures) → 59.5%.
- Debug build with `-p:TreatWarningsAsErrors=true` → 0 warnings, 0 errors.
- Confirmed packaging / MSIX / NuGet / docs-generation consume the Release `publish` output, not the solution `bin`; the CI metrics baseline transitions cleanly.

Closes out the Release-measurement half of #630.
