### PR TITLE
test: raise CLI helpers, Program, and parser/host coverage to >=95%

### DIFF
--- a/src/winapp-CLI/WinApp.Cli.Tests/AtomicFileTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/AtomicFileTests.cs
@@ -83,4 +83,20 @@ public class AtomicFileTests
         Assert.IsFalse(File.Exists(staged), "The staged temp file must be deleted.");
         Assert.IsFalse(File.Exists(dest), "The destination must never have been created.");
     }
+
+    [TestMethod]
+    public async Task DiscardStaged_WhenDeleteFails_SwallowsErrorAndDoesNotThrow()
+    {
+        var dest = Path.Combine(_tempDir, "locked.bin");
+        var staged = await AtomicFile.WriteStagedAsync(dest, [1, 2, 3], CancellationToken.None);
+
+        // Hold the staged file open with no sharing so File.Delete raises a sharing violation,
+        // exercising the best-effort catch inside TryDeleteLeftoverTemp.
+        using (new FileStream(staged, FileMode.Open, FileAccess.Read, FileShare.None))
+        {
+            AtomicFile.DiscardStaged(staged); // must not throw
+            Assert.IsTrue(File.Exists(staged),
+                "The locked file could not be deleted, confirming the swallowed-error path ran.");
+        }
+    }
 }

--- a/src/winapp-CLI/WinApp.Cli.Tests/AuthenticodeVerifierTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/AuthenticodeVerifierTests.cs
@@ -78,4 +78,117 @@ public class AuthenticodeVerifierTests
         Assert.IsFalse(AuthenticodeVerifier.IsTrustedMicrosoftSigned(unsigned, NullLogger.Instance),
             "An unsigned file must not pass the Authenticode trust gate.");
     }
+
+    // HRESULTs mirrored from the production constants (which are private).
+    private const int CERT_E_REVOKED = unchecked((int)0x800B010C);
+    private const int CERT_E_REVOCATION_FAILURE = unchecked((int)0x800B010E);
+    private const int CRYPT_E_REVOCATION_OFFLINE = unchecked((int)0x80092013);
+
+    [TestMethod]
+    public void IsTrustedMicrosoftSigned_TrustOkAndMicrosoftSigner_ReturnsTrue()
+    {
+        var result = AuthenticodeVerifier.IsTrustedMicrosoftSigned(
+            "any.dll", NullLogger.Instance,
+            verifyTrustCore: (_, _, _) => 0,
+            isMicrosoftSigner: _ => true);
+
+        Assert.IsTrue(result);
+    }
+
+    [TestMethod]
+    public void IsTrustedMicrosoftSigned_TrustOkButNonMicrosoftSigner_ReturnsFalse()
+    {
+        var result = AuthenticodeVerifier.IsTrustedMicrosoftSigned(
+            "any.dll", NullLogger.Instance,
+            verifyTrustCore: (_, _, _) => 0,
+            isMicrosoftSigner: _ => false);
+
+        Assert.IsFalse(result);
+    }
+
+    [TestMethod]
+    public void IsTrustedMicrosoftSigned_CertificateRevoked_ReturnsFalse()
+    {
+        var signerCalled = false;
+        var result = AuthenticodeVerifier.IsTrustedMicrosoftSigned(
+            "any.dll", NullLogger.Instance,
+            verifyTrustCore: (_, _, _) => CERT_E_REVOKED,
+            isMicrosoftSigner: _ => { signerCalled = true; return true; });
+
+        Assert.IsFalse(result, "A revoked certificate is a hard failure.");
+        Assert.IsFalse(signerCalled, "Signer check must be skipped once trust verification fails.");
+    }
+
+    [TestMethod]
+    public void IsTrustedMicrosoftSigned_RevocationOffline_FallsBackToSignatureOnly_AndPasses()
+    {
+        // First call (whole-chain) reports revocation data unavailable; the fallback signature-only
+        // call succeeds, so trust verification passes and the Microsoft signer gate then applies.
+        var call = 0;
+        var result = AuthenticodeVerifier.IsTrustedMicrosoftSigned(
+            "any.dll", NullLogger.Instance,
+            verifyTrustCore: (_, _, _) => ++call == 1 ? CERT_E_REVOCATION_FAILURE : 0,
+            isMicrosoftSigner: _ => true);
+
+        Assert.IsTrue(result);
+        Assert.AreEqual(2, call, "The fallback signature-only verification must run.");
+    }
+
+    [TestMethod]
+    public void IsTrustedMicrosoftSigned_RevocationOffline_FallbackAlsoFails_ReturnsFalse()
+    {
+        var call = 0;
+        var result = AuthenticodeVerifier.IsTrustedMicrosoftSigned(
+            "any.dll", NullLogger.Instance,
+            verifyTrustCore: (_, _, _) => ++call == 1 ? CRYPT_E_REVOCATION_OFFLINE : unchecked((int)0x80070005),
+            isMicrosoftSigner: _ => true);
+
+        Assert.IsFalse(result);
+        Assert.AreEqual(2, call);
+    }
+
+    [TestMethod]
+    public void IsTrustedMicrosoftSigned_UnrecognizedTrustError_ReturnsFalse()
+    {
+        // Any other WinVerifyTrust HRESULT (e.g. TRUST_E_NOSIGNATURE) is an untrusted result.
+        var result = AuthenticodeVerifier.IsTrustedMicrosoftSigned(
+            "any.dll", NullLogger.Instance,
+            verifyTrustCore: (_, _, _) => unchecked((int)0x800B0100),
+            isMicrosoftSigner: _ => true);
+
+        Assert.IsFalse(result);
+    }
+
+    [TestMethod]
+    public void IsTrustedMicrosoftSigned_VerifierThrows_IsCaught_ReturnsFalse()
+    {
+        var result = AuthenticodeVerifier.IsTrustedMicrosoftSigned(
+            "any.dll", NullLogger.Instance,
+            verifyTrustCore: (_, _, _) => throw new InvalidOperationException("boom"),
+            isMicrosoftSigner: _ => true);
+
+        Assert.IsFalse(result, "An exception during verification must be caught and fail closed.");
+    }
+
+    [TestMethod]
+    public void IsTrustedMicrosoftSigned_RealMicrosoftSignedBinary_ReturnsTrue()
+    {
+        // Exercises the real native trust + signer extraction path against known embedded-signed
+        // Microsoft OS binaries. At least one of these must validate on a healthy Windows install.
+        var system32 = Environment.GetFolderPath(Environment.SpecialFolder.System);
+        var windows = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
+        string[] candidates =
+        [
+            Path.Combine(system32, "dllhost.exe"),
+            Path.Combine(system32, "taskhostw.exe"),
+            Path.Combine(windows, "explorer.exe"),
+        ];
+
+        var anyTrusted = candidates
+            .Where(File.Exists)
+            .Any(f => AuthenticodeVerifier.IsTrustedMicrosoftSigned(f, NullLogger.Instance));
+
+        Assert.IsTrue(anyTrusted,
+            "A trusted, embedded-signed Microsoft binary must pass the Authenticode gate.");
+    }
 }

--- a/src/winapp-CLI/WinApp.Cli.Tests/AuthenticodeVerifierTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/AuthenticodeVerifierTests.cs
@@ -84,15 +84,35 @@ public class AuthenticodeVerifierTests
     private const int CERT_E_REVOCATION_FAILURE = unchecked((int)0x800B010E);
     private const int CRYPT_E_REVOCATION_OFFLINE = unchecked((int)0x80092013);
 
+    // WTD_* policy flags mirrored from the production constants (which are private), so the two-pass
+    // policy can be asserted precisely: whole-chain revocation via locally cached CRLs first, then a
+    // signature-only fallback with revocation checking disabled.
+    private const uint WTD_REVOKE_NONE = 0;
+    private const uint WTD_REVOKE_WHOLECHAIN = 1;
+    private const uint WTD_REVOCATION_CHECK_NONE = 0x00000010;
+    private const uint WTD_CACHE_ONLY_URL_RETRIEVAL = 0x00001000;
+
     [TestMethod]
     public void IsTrustedMicrosoftSigned_TrustOkAndMicrosoftSigner_ReturnsTrue()
     {
+        (uint RevocationChecks, uint ProvFlags)? firstPass = null;
         var result = AuthenticodeVerifier.IsTrustedMicrosoftSigned(
             "any.dll", NullLogger.Instance,
-            verifyTrustCore: (_, _, _) => 0,
+            verifyTrustCore: (_, revocationChecks, provFlags) =>
+            {
+                firstPass ??= (revocationChecks, provFlags);
+                return 0;
+            },
             isMicrosoftSigner: _ => true);
 
         Assert.IsTrue(result);
+
+        // The single successful pass must use the strict policy: whole-chain revocation, cache-only.
+        Assert.IsNotNull(firstPass, "WinVerifyTrust must be invoked.");
+        Assert.AreEqual(WTD_REVOKE_WHOLECHAIN, firstPass.Value.RevocationChecks,
+            "The initial pass must request whole-chain revocation checking.");
+        Assert.AreEqual(WTD_CACHE_ONLY_URL_RETRIEVAL, firstPass.Value.ProvFlags,
+            "The initial pass must retrieve revocation data from the local cache only.");
     }
 
     [TestMethod]
@@ -122,16 +142,33 @@ public class AuthenticodeVerifierTests
     [TestMethod]
     public void IsTrustedMicrosoftSigned_RevocationOffline_FallsBackToSignatureOnly_AndPasses()
     {
-        // First call (whole-chain) reports revocation data unavailable; the fallback signature-only
-        // call succeeds, so trust verification passes and the Microsoft signer gate then applies.
-        var call = 0;
+        // First call (whole-chain, cache-only) reports revocation data unavailable; the fallback
+        // signature-only call (revocation checking disabled) succeeds, so trust verification passes
+        // and the Microsoft signer gate then applies.
+        var calls = new List<(uint RevocationChecks, uint ProvFlags)>();
         var result = AuthenticodeVerifier.IsTrustedMicrosoftSigned(
             "any.dll", NullLogger.Instance,
-            verifyTrustCore: (_, _, _) => ++call == 1 ? CERT_E_REVOCATION_FAILURE : 0,
+            verifyTrustCore: (_, revocationChecks, provFlags) =>
+            {
+                calls.Add((revocationChecks, provFlags));
+                return calls.Count == 1 ? CERT_E_REVOCATION_FAILURE : 0;
+            },
             isMicrosoftSigner: _ => true);
 
         Assert.IsTrue(result);
-        Assert.AreEqual(2, call, "The fallback signature-only verification must run.");
+        Assert.AreEqual(2, calls.Count, "The fallback signature-only verification must run.");
+
+        // First pass: WITH revocation checking — full chain, but using locally cached CRLs only.
+        Assert.AreEqual(WTD_REVOKE_WHOLECHAIN, calls[0].RevocationChecks,
+            "First pass must request whole-chain revocation checking.");
+        Assert.AreEqual(WTD_CACHE_ONLY_URL_RETRIEVAL, calls[0].ProvFlags,
+            "First pass must retrieve revocation data from the local cache only.");
+
+        // Fallback pass: WITHOUT revocation checking — signature-only once revocation data is offline.
+        Assert.AreEqual(WTD_REVOKE_NONE, calls[1].RevocationChecks,
+            "Fallback pass must disable revocation checking.");
+        Assert.AreEqual(WTD_REVOCATION_CHECK_NONE, calls[1].ProvFlags,
+            "Fallback pass must set the no-revocation-check provider flag.");
     }
 
     [TestMethod]

--- a/src/winapp-CLI/WinApp.Cli.Tests/BannerHelperTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/BannerHelperTests.cs
@@ -1,0 +1,97 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using WinApp.Cli.Helpers;
+
+namespace WinApp.Cli.Tests;
+
+[TestClass]
+public class BannerHelperTests
+{
+    private const int Utf8CodePage = 65001;
+
+    [TestMethod]
+    public void ComputeUseEmoji_Utf8AndVsCodeViaPid_ReturnsTrue()
+    {
+        Assert.IsTrue(BannerHelper.ComputeUseEmoji(Utf8CodePage, outputRedirected: false,
+            vscodePid: "12345", termProgram: null, wtSession: null));
+    }
+
+    [TestMethod]
+    public void ComputeUseEmoji_Utf8AndVsCodeViaTermProgram_CaseInsensitive_ReturnsTrue()
+    {
+        Assert.IsTrue(BannerHelper.ComputeUseEmoji(Utf8CodePage, outputRedirected: false,
+            vscodePid: null, termProgram: "VSCode", wtSession: null));
+    }
+
+    [TestMethod]
+    public void ComputeUseEmoji_Utf8AndWindowsTerminal_ReturnsTrue()
+    {
+        Assert.IsTrue(BannerHelper.ComputeUseEmoji(Utf8CodePage, outputRedirected: false,
+            vscodePid: null, termProgram: null, wtSession: "session-guid"));
+    }
+
+    [TestMethod]
+    public void ComputeUseEmoji_Utf8ButPlainTerminal_ReturnsFalse()
+    {
+        Assert.IsFalse(BannerHelper.ComputeUseEmoji(Utf8CodePage, outputRedirected: false,
+            vscodePid: null, termProgram: "xterm", wtSession: null));
+    }
+
+    [TestMethod]
+    public void ComputeUseEmoji_NotUtf8_ReturnsFalse()
+    {
+        Assert.IsFalse(BannerHelper.ComputeUseEmoji(1252, outputRedirected: false,
+            vscodePid: "12345", termProgram: null, wtSession: null));
+    }
+
+    [TestMethod]
+    public void ComputeUseEmoji_NullCodePage_ReturnsFalse()
+    {
+        Assert.IsFalse(BannerHelper.ComputeUseEmoji(null, outputRedirected: false,
+            vscodePid: null, termProgram: null, wtSession: "session-guid"));
+    }
+
+    [TestMethod]
+    public void ComputeUseEmoji_OutputRedirected_ReturnsFalse()
+    {
+        Assert.IsFalse(BannerHelper.ComputeUseEmoji(Utf8CodePage, outputRedirected: true,
+            vscodePid: "12345", termProgram: null, wtSession: null));
+    }
+
+    [TestMethod]
+    public void DisplayBanner_ColorForm_WritesGradientAnsiAndVersion()
+    {
+        using var sw = new StringWriter();
+        BannerHelper.DisplayBanner(sw, useColor: true);
+        var output = sw.ToString();
+
+        Assert.IsTrue(output.Contains("\x1b[", StringComparison.Ordinal),
+            "Color banner must emit ANSI escape sequences.");
+        Assert.IsTrue(output.Contains("Windows App Development CLI", StringComparison.Ordinal));
+        Assert.IsTrue(output.Contains(VersionHelper.GetVersionString(), StringComparison.Ordinal),
+            "Banner must include the CLI version.");
+    }
+
+    [TestMethod]
+    public void DisplayBanner_PlainForm_WritesAsciiArtAndVersionWithoutAnsi()
+    {
+        using var sw = new StringWriter();
+        BannerHelper.DisplayBanner(sw, useColor: false);
+        var output = sw.ToString();
+
+        Assert.IsFalse(output.Contains("\x1b[", StringComparison.Ordinal),
+            "Plain banner must not emit ANSI escape sequences.");
+        Assert.IsTrue(output.Contains("Windows App Development CLI - Version", StringComparison.Ordinal));
+        Assert.IsTrue(output.Contains(VersionHelper.GetVersionString(), StringComparison.Ordinal));
+    }
+
+    [TestMethod]
+    public void UseEmoji_IsCachedAndReturnsStableValue()
+    {
+        // Exercises the cached Compute() path; the value must be deterministic across reads.
+        var first = BannerHelper.UseEmoji;
+        var second = BannerHelper.UseEmoji;
+        Assert.AreEqual(first, second);
+    }
+}

--- a/src/winapp-CLI/WinApp.Cli.Tests/LongPathHelperTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/LongPathHelperTests.cs
@@ -192,4 +192,132 @@ public class LongPathHelperTests
     }
 
     #endregion
+
+    #region ValidatePathLength(path, longPathEnabled) tests
+
+    [TestMethod]
+    public void ValidatePathLength_TwoArg_LongPathAndDisabled_Throws()
+    {
+        var path = MakeLocalPath(MaxPath + 1);
+        var ex = Assert.ThrowsExactly<InvalidOperationException>(
+            () => LongPathHelper.ValidatePathLength(path, longPathEnabled: false));
+        Assert.IsTrue(ex.Message.Contains("MAX_PATH"));
+    }
+
+    [TestMethod]
+    public void ValidatePathLength_TwoArg_LongPathButEnabled_DoesNotThrow()
+    {
+        var path = MakeLocalPath(MaxPath + 1);
+        LongPathHelper.ValidatePathLength(path, longPathEnabled: true); // must not throw when enabled
+    }
+
+    [TestMethod]
+    public void IsSystemLongPathEnabled_ReturnsWithoutThrowing()
+    {
+        // Exercises the registry-read happy path; result depends on machine config, so we only
+        // assert it completes and yields a bool.
+        var enabled = LongPathHelper.IsSystemLongPathEnabled();
+        Assert.IsTrue(enabled == true || enabled == false);
+    }
+
+    #endregion
+
+    #region StripExtendedPrefix tests
+
+    [TestMethod]
+    public void StripExtendedPrefix_UncPrefix_RestoresDoubleBackslash()
+    {
+        Assert.AreEqual(@"\\server\share\file", LongPathHelper.StripExtendedPrefix(@"\\?\UNC\server\share\file"));
+    }
+
+    [TestMethod]
+    public void StripExtendedPrefix_LocalPrefix_RemovesPrefix()
+    {
+        Assert.AreEqual(@"C:\dir\file", LongPathHelper.StripExtendedPrefix(@"\\?\C:\dir\file"));
+    }
+
+    [TestMethod]
+    public void StripExtendedPrefix_NoPrefix_ReturnsUnchanged()
+    {
+        Assert.AreEqual(@"C:\dir\file", LongPathHelper.StripExtendedPrefix(@"C:\dir\file"));
+    }
+
+    #endregion
+
+    #region GetShortPath(path, shortener) injected-seam tests
+
+    // A long path whose directory portion exceeds MaxPath, so EnsureExtendedLengthPrefix adds a prefix.
+    private static readonly string LongLocalDirPath = @"C:\" + new string('d', 300) + @"\f.txt";
+    private static readonly string LongUncDirPath = @"\\srv\share\" + new string('d', 300) + @"\f.txt";
+
+    [TestMethod]
+    public void GetShortPath_Injected_LocalPrefixedResult_IsStripped()
+    {
+        var result = LongPathHelper.GetShortPath(LongLocalDirPath, _ => @"\\?\C:\SHORT~1");
+
+        Assert.AreEqual(@"C:\SHORT~1\f.txt", result);
+    }
+
+    [TestMethod]
+    public void GetShortPath_Injected_UncPrefixedResult_IsStripped()
+    {
+        var result = LongPathHelper.GetShortPath(LongUncDirPath, _ => @"\\?\UNC\srv\share\S~1");
+
+        Assert.AreEqual(@"\\srv\share\S~1\f.txt", result);
+    }
+
+    [TestMethod]
+    public void GetShortPath_Injected_NullShortener_ReturnsOriginalDirectoryPath()
+    {
+        // Shortener signals "cannot shorten" by returning null -> original directory preserved.
+        var result = LongPathHelper.GetShortPath(LongLocalDirPath, _ => null);
+
+        Assert.AreEqual(LongLocalDirPath, result);
+    }
+
+    [TestMethod]
+    public void GetShortPath_Injected_ShortenerThrowsDllNotFound_ReturnsOriginalDirectoryPath()
+    {
+        var result = LongPathHelper.GetShortPath(LongLocalDirPath, _ => throw new DllNotFoundException("no api"));
+
+        Assert.AreEqual(LongLocalDirPath, result);
+    }
+
+    [TestMethod]
+    public void GetShortPath_Injected_BareLongFilenameWithoutDirectory_ReturnsOriginal()
+    {
+        var bareLongName = new string('a', 300) + ".txt";
+        var wasCalled = false;
+
+        var result = LongPathHelper.GetShortPath(bareLongName, _ => { wasCalled = true; return "ignored"; });
+
+        Assert.AreEqual(bareLongName, result);
+        Assert.IsFalse(wasCalled, "Shortener must not be invoked when there is no directory portion.");
+    }
+
+    [TestMethod]
+    public void GetShortPath_Production_ExistingShortDirectoryWithLongFilename_InvokesNativeShortener()
+    {
+        // Exercises the real GetShortPathName success path: the directory exists (temp dir), so the
+        // native call returns a non-zero buffer. The filename keeps the total path over MaxPath.
+        var tempDir = Directory.CreateDirectory(
+            Path.Combine(Path.GetTempPath(), "lp" + Guid.NewGuid().ToString("N")[..8])).FullName;
+        try
+        {
+            var longName = new string('a', 300) + ".txt";
+            var path = Path.Combine(tempDir, longName);
+            Assert.IsTrue(path.Length > MaxPath);
+
+            var result = LongPathHelper.GetShortPath(path);
+
+            Assert.IsTrue(result.EndsWith(longName, StringComparison.Ordinal),
+                "The long filename must be preserved regardless of directory shortening.");
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    #endregion
 }

--- a/src/winapp-CLI/WinApp.Cli.Tests/LongPathHelperTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/LongPathHelperTests.cs
@@ -212,12 +212,59 @@ public class LongPathHelperTests
     }
 
     [TestMethod]
-    public void IsSystemLongPathEnabled_ReturnsWithoutThrowing()
+    public void IsSystemLongPathEnabled_ValueIsOne_ReturnsTrue()
     {
-        // Exercises the registry-read happy path; result depends on machine config, so we only
-        // assert it completes and yields a bool.
-        var enabled = LongPathHelper.IsSystemLongPathEnabled();
-        Assert.IsTrue(enabled == true || enabled == false);
+        Assert.IsTrue(LongPathHelper.IsSystemLongPathEnabled(() => 1),
+            "A LongPathsEnabled value of integer 1 means long paths are enabled.");
+    }
+
+    [TestMethod]
+    public void IsSystemLongPathEnabled_ValueIsZero_ReturnsFalse()
+    {
+        Assert.IsFalse(LongPathHelper.IsSystemLongPathEnabled(() => 0),
+            "A LongPathsEnabled value of 0 means long paths are disabled.");
+    }
+
+    [TestMethod]
+    public void IsSystemLongPathEnabled_ValueIsOtherInt_ReturnsFalse()
+    {
+        Assert.IsFalse(LongPathHelper.IsSystemLongPathEnabled(() => 2),
+            "Only the exact integer 1 enables long paths; any other int is treated as disabled.");
+    }
+
+    [TestMethod]
+    public void IsSystemLongPathEnabled_ValueMissing_ReturnsFalse()
+    {
+        // A null value models an absent FileSystem key or a missing LongPathsEnabled value.
+        Assert.IsFalse(LongPathHelper.IsSystemLongPathEnabled(() => null),
+            "An absent registry value must be treated as long paths disabled.");
+    }
+
+    [TestMethod]
+    public void IsSystemLongPathEnabled_ValueWrongType_ReturnsFalse()
+    {
+        // A REG_SZ or REG_QWORD surfaces as a non-int; only a boxed int 1 counts as enabled.
+        Assert.IsFalse(LongPathHelper.IsSystemLongPathEnabled(() => "1"));
+        Assert.IsFalse(LongPathHelper.IsSystemLongPathEnabled(() => 1L));
+    }
+
+    [TestMethod]
+    public void IsSystemLongPathEnabled_ReaderThrows_ReturnsFalse()
+    {
+        // Registry access can throw (security/IO); the helper must swallow it and report "disabled".
+        Assert.IsFalse(LongPathHelper.IsSystemLongPathEnabled(
+            () => throw new UnauthorizedAccessException("registry access denied")));
+    }
+
+    [TestMethod]
+    public void IsSystemLongPathEnabled_RealRegistry_IsDeterministicAndDoesNotThrow()
+    {
+        // Covers the no-arg production overload and the real HKLM reader. Contract: never throws, and
+        // two consecutive reads of an unchanged machine state must agree (rules out a nondeterministic
+        // or exception-leaking implementation).
+        var first = LongPathHelper.IsSystemLongPathEnabled();
+        var second = LongPathHelper.IsSystemLongPathEnabled();
+        Assert.AreEqual(first, second);
     }
 
     #endregion

--- a/src/winapp-CLI/WinApp.Cli.Tests/ManifestHelperTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/ManifestHelperTests.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using WinApp.Cli.Helpers;
+
+namespace WinApp.Cli.Tests;
+
+[TestClass]
+public class ManifestHelperTests
+{
+    private string _tempDir = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"ManifestHelper_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        try { Directory.Delete(_tempDir, true); } catch { /* best effort */ }
+    }
+
+    [TestMethod]
+    public void FindManifest_PackageAppxmanifestPresent_ReturnsExistingFile()
+    {
+        var expected = Path.Combine(_tempDir, "Package.appxmanifest");
+        File.WriteAllText(expected, "<manifest/>");
+
+        var result = ManifestHelper.FindManifest(_tempDir);
+
+        Assert.IsTrue(result.Exists);
+        Assert.AreEqual(expected, result.FullName);
+    }
+
+    [TestMethod]
+    public void FindManifest_OnlyLowercaseXmlPresent_ReturnsIt()
+    {
+        var expected = Path.Combine(_tempDir, "appxmanifest.xml");
+        File.WriteAllText(expected, "<manifest/>");
+
+        var result = ManifestHelper.FindManifest(_tempDir);
+
+        Assert.IsTrue(result.Exists);
+        Assert.AreEqual(expected, result.FullName);
+    }
+
+    [TestMethod]
+    public void FindManifest_BothPresent_PrefersPackageAppxmanifest()
+    {
+        var preferred = Path.Combine(_tempDir, "Package.appxmanifest");
+        File.WriteAllText(preferred, "<manifest/>");
+        File.WriteAllText(Path.Combine(_tempDir, "appxmanifest.xml"), "<manifest/>");
+
+        var result = ManifestHelper.FindManifest(_tempDir);
+
+        Assert.AreEqual(preferred, result.FullName, "Package.appxmanifest must take precedence.");
+    }
+
+    [TestMethod]
+    public void FindManifest_NeitherPresent_ReturnsNonExistentPrimaryName()
+    {
+        var result = ManifestHelper.FindManifest(_tempDir);
+
+        Assert.IsFalse(result.Exists, "A missing manifest must be reported via FileInfo.Exists == false.");
+        Assert.AreEqual(Path.Combine(_tempDir, "Package.appxmanifest"), result.FullName);
+    }
+}

--- a/src/winapp-CLI/WinApp.Cli.Tests/OptionTypoValidatorTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/OptionTypoValidatorTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
 // Licensed under the MIT License.
 
+using System.CommandLine;
 using WinApp.Cli.Commands;
 using WinApp.Cli.Helpers;
 
@@ -92,5 +93,59 @@ public class OptionTypoValidatorTests : BaseCommandTests
         var typo = OptionTypoValidator.FindLikelyLongOptionTypo(args, parseResult);
 
         Assert.IsNull(typo);
+    }
+
+    [TestMethod]
+    public void DoesNotFlagOnPassthroughCommand()
+    {
+        // Commands that pass unknown tokens through (ms-store, tool) must be honored, so even a
+        // token that looks like a long-option typo is left untouched.
+        var rootCommand = GetRequiredService<WinAppRootCommand>();
+        var args = new[] { "ms-store", "-app" };
+        var parseResult = rootCommand.Parse(args, WinAppParserConfiguration.Default);
+
+        var typo = OptionTypoValidator.FindLikelyLongOptionTypo(args, parseResult);
+
+        Assert.IsNull(typo);
+    }
+
+    [TestMethod]
+    public void ReturnsNullWhenLeafHasNoLongOptions()
+    {
+        // A command with no long options can't have a "did you mean --x?" candidate.
+        var command = new Command("test");
+        var args = new[] { "-ab" };
+        var parseResult = command.Parse(args);
+
+        var typo = OptionTypoValidator.FindLikelyLongOptionTypo(args, parseResult);
+
+        Assert.IsNull(typo);
+    }
+
+    [TestMethod]
+    public void DoesNotFlagTokenWithInvalidOptionCharacters()
+    {
+        // "-a.b" contains a '.', which is not a valid option-name character, so it is skipped.
+        var rootCommand = GetRequiredService<WinAppRootCommand>();
+        var args = new[] { "ui", "inspect", "-a.b" };
+        var parseResult = rootCommand.Parse(args, WinAppParserConfiguration.Default);
+
+        var typo = OptionTypoValidator.FindLikelyLongOptionTypo(args, parseResult);
+
+        Assert.IsNull(typo);
+    }
+
+    [TestMethod]
+    public void FlagsTypoMatchingLongAlias()
+    {
+        // The candidate matches a long *alias* (not the primary name), exercising alias collection.
+        var command = new Command("test");
+        command.Options.Add(new Option<string>("--foo", "--foobar"));
+        var args = new[] { "-foobar" };
+        var parseResult = command.Parse(args);
+
+        var typo = OptionTypoValidator.FindLikelyLongOptionTypo(args, parseResult);
+
+        Assert.AreEqual("-foobar", typo);
     }
 }

--- a/src/winapp-CLI/WinApp.Cli.Tests/PathSafetyTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/PathSafetyTests.cs
@@ -307,4 +307,70 @@ public class PathSafetyTests
         var stray = Directory.GetFiles(_tempDir.FullName, "*.tmp-*", SearchOption.AllDirectories);
         Assert.AreEqual(0, stray.Length, "no .tmp sibling should be left behind on failure");
     }
+
+    [TestMethod]
+    public void HasReparsePointOnPath_InvalidPathCharacters_ReturnsTrue()
+    {
+        // An embedded NUL makes Path.GetFullPath throw; the fail-closed catch biases to "unsafe".
+        bool unsafePath = PathSafety.HasReparsePointOnPath("bad\0path", _tempDir.FullName);
+        Assert.IsTrue(unsafePath, "a path that cannot be normalised must be refused");
+    }
+
+    [TestMethod]
+    public void IsNetworkPath_EmptyString_ReturnsFalse()
+    {
+        Assert.IsFalse(PathSafety.IsNetworkPath(string.Empty));
+    }
+
+    [TestMethod]
+    public void IsNetworkPath_Null_ReturnsFalse()
+    {
+        Assert.IsFalse(PathSafety.IsNetworkPath(null!));
+    }
+
+    [TestMethod]
+    public async Task AtomicWriteAllTextAsync_BareFilename_WritesToCurrentDirectory()
+    {
+        // A path with no directory component defaults to the current working directory.
+        var name = "psafe_" + Guid.NewGuid().ToString("N") + ".txt";
+        var cwd = Directory.GetCurrentDirectory();
+        try
+        {
+            await PathSafety.AtomicWriteAllTextAsync(name, "hello cwd", System.Text.Encoding.UTF8);
+
+            var written = Path.Combine(cwd, name);
+            Assert.IsTrue(File.Exists(written), "bare filename must be written under the current directory");
+            Assert.AreEqual("hello cwd", File.ReadAllText(written));
+        }
+        finally
+        {
+            foreach (var f in Directory.GetFiles(cwd, name + "*"))
+            {
+                try { File.Delete(f); } catch { /* best effort */ }
+            }
+        }
+    }
+
+    [TestMethod]
+    public async Task AtomicWriteAllTextAsync_DestinationIsExistingDirectory_ThrowsAndDeletesTemp()
+    {
+        // The temp write succeeds, but the final move onto an existing *directory* fails; the
+        // catch must delete the staged temp file and rethrow.
+        var target = Path.Combine(_tempDir.FullName, "iam-a-directory");
+        Directory.CreateDirectory(target);
+
+        Exception? caught = null;
+        try
+        {
+            await PathSafety.AtomicWriteAllTextAsync(target, "x", System.Text.Encoding.UTF8);
+        }
+        catch (Exception ex)
+        {
+            caught = ex;
+        }
+
+        Assert.IsNotNull(caught, "moving a file onto an existing directory must throw");
+        var stray = Directory.GetFiles(_tempDir.FullName, "iam-a-directory.tmp-*");
+        Assert.AreEqual(0, stray.Length, "the staged .tmp file must be deleted when the move fails");
+    }
 }

--- a/src/winapp-CLI/WinApp.Cli.Tests/PeHelperTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/PeHelperTests.cs
@@ -1,0 +1,118 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Reflection.PortableExecutable;
+using WinApp.Cli.Services;
+
+namespace WinApp.Cli.Tests;
+
+[TestClass]
+public class PeHelperTests
+{
+    // COFF machine constants.
+    private const ushort I386 = 0x014C;
+    private const ushort Amd64 = 0x8664;
+    private const ushort Arm64 = 0xAA64;
+    private const ushort Armnt = 0x01C4;
+    private const ushort Arm = 0x01C0;
+    private const ushort Unknown = 0x9999;
+
+    [TestMethod]
+    [DataRow(I386, "x86")]
+    [DataRow(Amd64, "x64")]
+    [DataRow(Arm64, "arm64")]
+    [DataRow(Armnt, "arm")]
+    [DataRow(Arm, "arm")]
+    public void ClassifyArchitecture_NativeImage_UsesMachineField(ushort machine, string expected)
+    {
+        Assert.AreEqual(expected, PeHelper.ClassifyArchitecture(machine, corFlags: null));
+    }
+
+    [TestMethod]
+    public void ClassifyArchitecture_NativeUnknownMachine_ReturnsNull()
+    {
+        Assert.IsNull(PeHelper.ClassifyArchitecture(Unknown, corFlags: null));
+    }
+
+    [TestMethod]
+    public void ClassifyArchitecture_IlOnlyI386_WithRequires32Bit_IsX86()
+    {
+        Assert.AreEqual("x86", PeHelper.ClassifyArchitecture(I386, CorFlags.ILOnly | CorFlags.Requires32Bit));
+    }
+
+    [TestMethod]
+    public void ClassifyArchitecture_IlOnlyI386_WithoutRequires32Bit_IsNeutral()
+    {
+        Assert.AreEqual("neutral", PeHelper.ClassifyArchitecture(I386, CorFlags.ILOnly));
+    }
+
+    [TestMethod]
+    [DataRow(Amd64, "x64")]
+    [DataRow(Arm, "arm")]
+    [DataRow(Armnt, "arm")]
+    [DataRow(Arm64, "arm64")]
+    public void ClassifyArchitecture_IlOnlyNonI386_MapsByMachine(ushort machine, string expected)
+    {
+        Assert.AreEqual(expected, PeHelper.ClassifyArchitecture(machine, CorFlags.ILOnly));
+    }
+
+    [TestMethod]
+    public void ClassifyArchitecture_IlOnlyUnknownMachine_ReturnsNull()
+    {
+        Assert.IsNull(PeHelper.ClassifyArchitecture(Unknown, CorFlags.ILOnly));
+    }
+
+    [TestMethod]
+    public void ClassifyArchitecture_MixedModeManaged_FallsBackToMachine()
+    {
+        // COR header present but NOT IL-only (mixed-mode / native-hosted): machine wins.
+        Assert.AreEqual("x64", PeHelper.ClassifyArchitecture(Amd64, (CorFlags)0));
+        Assert.AreEqual("x86", PeHelper.ClassifyArchitecture(I386, CorFlags.Requires32Bit));
+    }
+
+    [TestMethod]
+    public void ClassifyArchitecture_MixedModeUnknownMachine_ReturnsNull()
+    {
+        Assert.IsNull(PeHelper.ClassifyArchitecture(Unknown, (CorFlags)0));
+    }
+
+    [TestMethod]
+    public void DetectPeArchitecture_NonexistentFile_ReturnsNull()
+    {
+        var missing = Path.Combine(Path.GetTempPath(), $"pehelper_missing_{Guid.NewGuid():N}.dll");
+        Assert.IsNull(PeHelper.DetectPeArchitecture(missing));
+    }
+
+    [TestMethod]
+    public void DetectPeArchitecture_NotAPeFile_ReturnsNull()
+    {
+        var junk = Path.Combine(Path.GetTempPath(), $"pehelper_junk_{Guid.NewGuid():N}.bin");
+        File.WriteAllText(junk, "this is not a PE image");
+        try
+        {
+            Assert.IsNull(PeHelper.DetectPeArchitecture(junk));
+        }
+        finally
+        {
+            File.Delete(junk);
+        }
+    }
+
+    private static readonly string[] KnownArchitectures = ["x86", "x64", "arm", "arm64"];
+
+    [TestMethod]
+    public void DetectPeArchitecture_RealNativeSystemDll_ReturnsKnownArchitecture()
+    {
+        // A real native Windows DLL is classified from its COFF machine field.
+        var kernel32 = Path.Combine(Environment.SystemDirectory, "kernel32.dll");
+        if (!File.Exists(kernel32))
+        {
+            Assert.Inconclusive("kernel32.dll not found; skipping native PE classification check.");
+            return;
+        }
+
+        var arch = PeHelper.DetectPeArchitecture(kernel32);
+        CollectionAssert.Contains(KnownArchitectures, arch,
+            $"A real native system DLL should classify to a known architecture, got '{arch}'.");
+    }
+}

--- a/src/winapp-CLI/WinApp.Cli.Tests/ProgramMainTestHarness.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/ProgramMainTestHarness.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+namespace WinApp.Cli.Tests;
+
+/// <summary>
+/// Shared harness for tests that invoke <see cref="WinApp.Cli.Program.Main"/> directly. Centralizes
+/// the CI environment-variable list and the stdout/stderr capture wrapper so the Program.Main
+/// integration tests (e.g. <c>ProgramMainTests</c> and <c>UpdateNotificationGatingTests</c>) do not
+/// each carry their own identical copy.
+/// </summary>
+internal static class ProgramMainTestHarness
+{
+    /// <summary>
+    /// All environment-variable names inspected by the telemetry CI detector. Tests clear these so a
+    /// developer or CI host's ambient CI markers do not change <see cref="WinApp.Cli.Program.Main"/>'s
+    /// behavior under test.
+    /// </summary>
+    internal static readonly string[] CiVarNames =
+    [
+        "CI", "GITHUB_ACTIONS", "TF_BUILD", "APPVEYOR", "TRAVIS", "CIRCLECI",
+        "TEAMCITY_VERSION", "JB_SPACE_API_URL",
+        "CODEBUILD_BUILD_ID", "AWS_REGION", "BUILD_ID", "BUILD_URL", "PROJECT_ID"
+    ];
+
+    /// <summary>
+    /// Invokes <see cref="WinApp.Cli.Program.Main"/> with <paramref name="args"/> while capturing
+    /// stdout/stderr, restoring the original console streams afterward. The capture writers are
+    /// intentionally not disposed: Spectre.Console's static <c>AnsiConsole</c> may reference them
+    /// after Main returns, so disposing here would risk an <see cref="ObjectDisposedException"/>.
+    /// </summary>
+    internal static async Task<(string Stdout, string Stderr, int ExitCode)> InvokeProgramAsync(string[] args)
+    {
+        var originalOut = Console.Out;
+        var originalErr = Console.Error;
+
+        var stdoutWriter = new StringWriter();
+        var stderrWriter = new StringWriter();
+
+        try
+        {
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+
+            var exitCode = await WinApp.Cli.Program.Main(args);
+
+            return (stdoutWriter.ToString(), stderrWriter.ToString(), exitCode);
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            Console.SetError(originalErr);
+        }
+    }
+}

--- a/src/winapp-CLI/WinApp.Cli.Tests/ProgramTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/ProgramTests.cs
@@ -200,6 +200,9 @@ public class ProgramSeamTests
     private static System.CommandLine.ParseResult ParseEmptyRoot() =>
         new System.CommandLine.RootCommand("test").Parse([], WinApp.Cli.Helpers.WinAppParserConfiguration.Default);
 
+    // Expected telemetry ordering: CommandInvoked fires, the command runs, then CommandCompleted fires.
+    private static readonly string[] ExpectedTelemetrySequence = ["invoked", "invoke", "completed"];
+
     [TestMethod]
     public void ConfigureConsoleEncoding_NonThrowingAction_IsApplied()
     {
@@ -221,24 +224,63 @@ public class ProgramSeamTests
     public async Task RunWithTelemetryAsync_CompleteMode_ReturnsInvokeResult()
     {
         var invoked = false;
+        var invokedLogged = false;
+        var completedLogged = false;
 
-        var result = await Program.RunWithTelemetryAsync(ParseEmptyRoot(), isCompleteMode: true, () =>
-        {
-            invoked = true;
-            return Task.FromResult(3);
-        });
+        var result = await Program.RunWithTelemetryAsync(ParseEmptyRoot(), isCompleteMode: true,
+            invoke: () =>
+            {
+                invoked = true;
+                return Task.FromResult(3);
+            },
+            logCommandInvoked: _ => invokedLogged = true,
+            logCommandCompleted: (_, _) => completedLogged = true);
 
         Assert.AreEqual(3, result);
-        Assert.IsTrue(invoked);
+        Assert.IsTrue(invoked, "The command must still be invoked in completion mode.");
+        Assert.IsFalse(invokedLogged, "Completion mode must not emit CommandInvoked telemetry.");
+        Assert.IsFalse(completedLogged, "Completion mode must not emit CommandCompleted telemetry.");
     }
 
     [TestMethod]
     public async Task RunWithTelemetryAsync_NonCompleteMode_LogsTelemetryAndReturnsResult()
     {
-        var result = await Program.RunWithTelemetryAsync(ParseEmptyRoot(), isCompleteMode: false,
-            () => Task.FromResult(0));
+        var parseResult = ParseEmptyRoot();
+        var expectedCommandResult = parseResult.CommandResult;
+        var sequence = new List<string>();
+        System.CommandLine.Parsing.CommandResult? invokedWith = null;
+        System.CommandLine.Parsing.CommandResult? completedWith = null;
+        var completedExitCode = int.MinValue;
 
-        Assert.AreEqual(0, result);
+        var result = await Program.RunWithTelemetryAsync(parseResult, isCompleteMode: false,
+            invoke: () =>
+            {
+                sequence.Add("invoke");
+                return Task.FromResult(7);
+            },
+            logCommandInvoked: cr =>
+            {
+                sequence.Add("invoked");
+                invokedWith = cr;
+            },
+            logCommandCompleted: (cr, code) =>
+            {
+                sequence.Add("completed");
+                completedWith = cr;
+                completedExitCode = code;
+            });
+
+        Assert.AreEqual(7, result);
+
+        // Telemetry must bracket the invocation: CommandInvoked before running, CommandCompleted after.
+        CollectionAssert.AreEqual(ExpectedTelemetrySequence, sequence,
+            "Invoked telemetry fires before the command runs and completed telemetry fires after it returns.");
+        Assert.AreSame(expectedCommandResult, invokedWith,
+            "CommandInvoked telemetry must carry the parsed command result.");
+        Assert.AreSame(expectedCommandResult, completedWith,
+            "CommandCompleted telemetry must carry the parsed command result.");
+        Assert.AreEqual(7, completedExitCode,
+            "CommandCompleted telemetry must report the real exit code returned by the command.");
     }
 
     [TestMethod]
@@ -246,12 +288,16 @@ public class ProgramSeamTests
     {
         var originalErr = Console.Error;
         var stderr = new StringWriter();
+        var invokedLogged = false;
+        var completedLogged = false;
         try
         {
             Console.SetError(stderr);
 
             var result = await Program.RunWithTelemetryAsync(ParseEmptyRoot(), isCompleteMode: false,
-                () => throw new InvalidOperationException("boom"));
+                invoke: () => throw new InvalidOperationException("boom"),
+                logCommandInvoked: _ => invokedLogged = true,
+                logCommandCompleted: (_, _) => completedLogged = true);
 
             Assert.AreEqual(1, result);
             Assert.IsTrue(stderr.ToString().Contains("An unexpected error occurred: boom", StringComparison.Ordinal),
@@ -261,5 +307,9 @@ public class ProgramSeamTests
         {
             Console.SetError(originalErr);
         }
+
+        // Invoked telemetry fires before the throwing invocation; completed telemetry must be skipped.
+        Assert.IsTrue(invokedLogged, "CommandInvoked telemetry fires before the command that throws.");
+        Assert.IsFalse(completedLogged, "CommandCompleted telemetry must not fire when the invocation throws.");
     }
 }

--- a/src/winapp-CLI/WinApp.Cli.Tests/ProgramTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/ProgramTests.cs
@@ -1,0 +1,297 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.Logging;
+using WinApp.Cli;
+
+namespace WinApp.Cli.Tests;
+
+[TestClass]
+public class ProgramResolveLoggingModeTests
+{
+    [TestMethod]
+    public void ResolveLoggingMode_NoFlags_DefaultsToInformation()
+    {
+        var mode = Program.ResolveLoggingMode(["init"]);
+
+        Assert.AreEqual(LogLevel.Information, mode.MinimumLevel);
+        Assert.IsFalse(mode.Quiet);
+        Assert.IsFalse(mode.Verbose);
+        Assert.IsFalse(mode.Json);
+        Assert.IsNull(mode.ConflictError);
+    }
+
+    [TestMethod]
+    [DataRow("--verbose")]
+    [DataRow("-v")]
+    public void ResolveLoggingMode_Verbose_SetsDebug(string flag)
+    {
+        var mode = Program.ResolveLoggingMode([flag]);
+
+        Assert.AreEqual(LogLevel.Debug, mode.MinimumLevel);
+        Assert.IsTrue(mode.Verbose);
+        Assert.IsNull(mode.ConflictError);
+    }
+
+    [TestMethod]
+    [DataRow("--quiet")]
+    [DataRow("-q")]
+    public void ResolveLoggingMode_Quiet_SetsWarning(string flag)
+    {
+        var mode = Program.ResolveLoggingMode([flag]);
+
+        Assert.AreEqual(LogLevel.Warning, mode.MinimumLevel);
+        Assert.IsTrue(mode.Quiet);
+        Assert.IsNull(mode.ConflictError);
+    }
+
+    [TestMethod]
+    public void ResolveLoggingMode_Json_SetsNone()
+    {
+        var mode = Program.ResolveLoggingMode(["--json"]);
+
+        Assert.AreEqual(LogLevel.None, mode.MinimumLevel);
+        Assert.IsTrue(mode.Json);
+        Assert.IsNull(mode.ConflictError);
+    }
+
+    [TestMethod]
+    public void ResolveLoggingMode_QuietAndVerbose_ReportsConflict()
+    {
+        var mode = Program.ResolveLoggingMode(["--quiet", "--verbose"]);
+
+        Assert.AreEqual("Cannot specify both --quiet and --verbose options together.", mode.ConflictError);
+    }
+
+    [TestMethod]
+    public void ResolveLoggingMode_QuietAndJson_ReportsConflict()
+    {
+        var mode = Program.ResolveLoggingMode(["--quiet", "--json"]);
+
+        Assert.AreEqual("Cannot specify both --quiet and --json options together.", mode.ConflictError);
+    }
+
+    [TestMethod]
+    public void ResolveLoggingMode_VerboseAndJson_ReportsConflict()
+    {
+        var mode = Program.ResolveLoggingMode(["--verbose", "--json"]);
+
+        Assert.AreEqual("Cannot specify both --verbose and --json options together.", mode.ConflictError);
+    }
+
+    [TestMethod]
+    public void ResolveLoggingMode_FlagAfterDoubleDash_IsIgnored()
+    {
+        // Tokens after a standalone "--" are passthrough payload, not winapp global flags.
+        var mode = Program.ResolveLoggingMode(["run", ".", "--", "--json"]);
+
+        Assert.IsFalse(mode.Json, "--json after -- must be treated as passthrough, not a global flag.");
+        Assert.AreEqual(LogLevel.Information, mode.MinimumLevel);
+    }
+}
+
+[TestClass]
+[DoNotParallelize] // Invokes Program.Main, which mutates static Console streams and env vars.
+public class ProgramMainTests
+{
+    private string _tempCacheDir = null!;
+    private string? _savedCacheDir;
+    private string? _savedUpdateCheck;
+    private string? _savedCaller;
+
+    private static readonly string[] CiVarNames =
+    [
+        "CI", "GITHUB_ACTIONS", "TF_BUILD", "APPVEYOR", "TRAVIS", "CIRCLECI",
+        "TEAMCITY_VERSION", "JB_SPACE_API_URL",
+        "CODEBUILD_BUILD_ID", "AWS_REGION", "BUILD_ID", "BUILD_URL", "PROJECT_ID"
+    ];
+    private Dictionary<string, string?> _savedCiVars = [];
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _tempCacheDir = Path.Combine(Path.GetTempPath(), $"winapp_program_test_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempCacheDir);
+        // Mark first-run complete and disable update checks so Main runs deterministically offline.
+        File.Create(Path.Combine(_tempCacheDir, ".first-run-complete")).Dispose();
+
+        _savedCacheDir = Environment.GetEnvironmentVariable("WINAPP_CLI_CACHE_DIRECTORY");
+        _savedUpdateCheck = Environment.GetEnvironmentVariable("WINAPP_CLI_UPDATE_CHECK");
+        _savedCaller = Environment.GetEnvironmentVariable("WINAPP_CLI_CALLER");
+        _savedCiVars = CiVarNames.ToDictionary(name => name, name => Environment.GetEnvironmentVariable(name));
+
+        Environment.SetEnvironmentVariable("WINAPP_CLI_CACHE_DIRECTORY", _tempCacheDir);
+        Environment.SetEnvironmentVariable("WINAPP_CLI_UPDATE_CHECK", "0");
+        Environment.SetEnvironmentVariable("WINAPP_CLI_CALLER", null);
+        foreach (var name in CiVarNames)
+        {
+            Environment.SetEnvironmentVariable(name, null);
+        }
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        Environment.SetEnvironmentVariable("WINAPP_CLI_CACHE_DIRECTORY", _savedCacheDir);
+        Environment.SetEnvironmentVariable("WINAPP_CLI_UPDATE_CHECK", _savedUpdateCheck);
+        Environment.SetEnvironmentVariable("WINAPP_CLI_CALLER", _savedCaller);
+        foreach (var (name, value) in _savedCiVars)
+        {
+            Environment.SetEnvironmentVariable(name, value);
+        }
+
+        try { Directory.Delete(_tempCacheDir, recursive: true); } catch { /* best effort */ }
+    }
+
+    private static async Task<(string Stdout, string Stderr, int ExitCode)> InvokeProgramAsync(string[] args)
+    {
+        var originalOut = Console.Out;
+        var originalErr = Console.Error;
+
+        // Writers are intentionally not disposed: Spectre.Console's static AnsiConsole may reference
+        // them after Main returns.
+        var stdoutWriter = new StringWriter();
+        var stderrWriter = new StringWriter();
+
+        try
+        {
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+
+            var exitCode = await Program.Main(args);
+
+            return (stdoutWriter.ToString(), stderrWriter.ToString(), exitCode);
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            Console.SetError(originalErr);
+        }
+    }
+
+    [TestMethod]
+    public async Task Main_NoArguments_ShowsBannerAndHelp_ReturnsZero()
+    {
+        var (stdout, _, exitCode) = await InvokeProgramAsync([]);
+
+        Assert.AreEqual(0, exitCode);
+        Assert.IsTrue(stdout.Contains("Windows App Development CLI", StringComparison.Ordinal),
+            $"No-args invocation must print the banner. Got stdout: {stdout}");
+    }
+
+    [TestMethod]
+    public async Task Main_SingleDashLongOptionTypo_PrintsSuggestion_ReturnsOne()
+    {
+        var (_, stderr, exitCode) = await InvokeProgramAsync(["ui", "inspect", "-app", "some-app"]);
+
+        Assert.AreEqual(1, exitCode);
+        Assert.IsTrue(stderr.Contains("Did you mean", StringComparison.Ordinal),
+            $"A single-dash long-option typo must suggest the double-dash form. Got stderr: {stderr}");
+        Assert.IsTrue(stderr.Contains("--app", StringComparison.Ordinal));
+    }
+
+    [TestMethod]
+    public async Task Main_ConflictingLoggingFlags_PrintsError_ReturnsOne()
+    {
+        var (_, stderr, exitCode) = await InvokeProgramAsync(["--quiet", "--verbose"]);
+
+        Assert.AreEqual(1, exitCode);
+        Assert.IsTrue(stderr.Contains("Cannot specify both --quiet and --verbose options together.", StringComparison.Ordinal),
+            $"Conflicting logging flags must be rejected. Got stderr: {stderr}");
+    }
+
+    [TestMethod]
+    public async Task Main_CliSchemaWithCaller_SetsCallerEnvVarAndReturnsZero()
+    {
+        var (stdout, _, exitCode) = await InvokeProgramAsync(["--cli-schema", "--caller", "test-caller"]);
+
+        Assert.AreEqual(0, exitCode);
+        Assert.AreEqual("test-caller", Environment.GetEnvironmentVariable("WINAPP_CLI_CALLER"),
+            "The --caller value must be promoted to the WINAPP_CLI_CALLER environment variable.");
+        Assert.IsTrue(stdout.Contains('{', StringComparison.Ordinal),
+            $"--cli-schema must emit machine-readable JSON. Got: {stdout}");
+    }
+
+    [TestMethod]
+    public async Task Main_UnknownCommand_FallsThroughToInvocation_WithoutTypoSuggestion()
+    {
+        // A bare unknown command produces parse errors but is not a single-dash typo, so the typo
+        // shortcut is skipped and the parsed args flow into the normal invocation path.
+        var (_, stderr, exitCode) = await InvokeProgramAsync(["this-is-not-a-real-command"]);
+
+        Assert.AreNotEqual(0, exitCode, "An unknown command must not succeed.");
+        Assert.IsFalse(stderr.Contains("Did you mean", StringComparison.Ordinal),
+            $"A non-dash unknown command must not trigger the single-dash typo hint. Got stderr: {stderr}");
+    }
+}
+
+[TestClass]
+[DoNotParallelize] // The RunWithTelemetryAsync failure test redirects the static Console.Error stream.
+public class ProgramSeamTests
+{
+    private static System.CommandLine.ParseResult ParseEmptyRoot() =>
+        new System.CommandLine.RootCommand("test").Parse([], WinApp.Cli.Helpers.WinAppParserConfiguration.Default);
+
+    [TestMethod]
+    public void ConfigureConsoleEncoding_NonThrowingAction_IsApplied()
+    {
+        var applied = false;
+
+        Program.ConfigureConsoleEncoding(() => applied = true);
+
+        Assert.IsTrue(applied, "The encoding mutation must run when it does not throw.");
+    }
+
+    [TestMethod]
+    public void ConfigureConsoleEncoding_ThrowingAction_IsSwallowed()
+    {
+        // Setting console encoding throws on redirected/unsupported handles; startup must survive it.
+        Program.ConfigureConsoleEncoding(() => throw new IOException("encoding not supported"));
+    }
+
+    [TestMethod]
+    public async Task RunWithTelemetryAsync_CompleteMode_ReturnsInvokeResult()
+    {
+        var invoked = false;
+
+        var result = await Program.RunWithTelemetryAsync(ParseEmptyRoot(), isCompleteMode: true, () =>
+        {
+            invoked = true;
+            return Task.FromResult(3);
+        });
+
+        Assert.AreEqual(3, result);
+        Assert.IsTrue(invoked);
+    }
+
+    [TestMethod]
+    public async Task RunWithTelemetryAsync_NonCompleteMode_LogsTelemetryAndReturnsResult()
+    {
+        var result = await Program.RunWithTelemetryAsync(ParseEmptyRoot(), isCompleteMode: false,
+            () => Task.FromResult(0));
+
+        Assert.AreEqual(0, result);
+    }
+
+    [TestMethod]
+    public async Task RunWithTelemetryAsync_InvokeThrows_ReturnsOneAndWritesError()
+    {
+        var originalErr = Console.Error;
+        var stderr = new StringWriter();
+        try
+        {
+            Console.SetError(stderr);
+
+            var result = await Program.RunWithTelemetryAsync(ParseEmptyRoot(), isCompleteMode: false,
+                () => throw new InvalidOperationException("boom"));
+
+            Assert.AreEqual(1, result);
+            Assert.IsTrue(stderr.ToString().Contains("An unexpected error occurred: boom", StringComparison.Ordinal),
+                $"The top-level handler must surface the failure message. Got: {stderr}");
+        }
+        finally
+        {
+            Console.SetError(originalErr);
+        }
+    }
+}

--- a/src/winapp-CLI/WinApp.Cli.Tests/ProgramTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/ProgramTests.cs
@@ -99,12 +99,6 @@ public class ProgramMainTests
     private string? _savedUpdateCheck;
     private string? _savedCaller;
 
-    private static readonly string[] CiVarNames =
-    [
-        "CI", "GITHUB_ACTIONS", "TF_BUILD", "APPVEYOR", "TRAVIS", "CIRCLECI",
-        "TEAMCITY_VERSION", "JB_SPACE_API_URL",
-        "CODEBUILD_BUILD_ID", "AWS_REGION", "BUILD_ID", "BUILD_URL", "PROJECT_ID"
-    ];
     private Dictionary<string, string?> _savedCiVars = [];
 
     [TestInitialize]
@@ -118,12 +112,12 @@ public class ProgramMainTests
         _savedCacheDir = Environment.GetEnvironmentVariable("WINAPP_CLI_CACHE_DIRECTORY");
         _savedUpdateCheck = Environment.GetEnvironmentVariable("WINAPP_CLI_UPDATE_CHECK");
         _savedCaller = Environment.GetEnvironmentVariable("WINAPP_CLI_CALLER");
-        _savedCiVars = CiVarNames.ToDictionary(name => name, name => Environment.GetEnvironmentVariable(name));
+        _savedCiVars = ProgramMainTestHarness.CiVarNames.ToDictionary(name => name, name => Environment.GetEnvironmentVariable(name));
 
         Environment.SetEnvironmentVariable("WINAPP_CLI_CACHE_DIRECTORY", _tempCacheDir);
         Environment.SetEnvironmentVariable("WINAPP_CLI_UPDATE_CHECK", "0");
         Environment.SetEnvironmentVariable("WINAPP_CLI_CALLER", null);
-        foreach (var name in CiVarNames)
+        foreach (var name in ProgramMainTestHarness.CiVarNames)
         {
             Environment.SetEnvironmentVariable(name, null);
         }
@@ -143,36 +137,10 @@ public class ProgramMainTests
         try { Directory.Delete(_tempCacheDir, recursive: true); } catch { /* best effort */ }
     }
 
-    private static async Task<(string Stdout, string Stderr, int ExitCode)> InvokeProgramAsync(string[] args)
-    {
-        var originalOut = Console.Out;
-        var originalErr = Console.Error;
-
-        // Writers are intentionally not disposed: Spectre.Console's static AnsiConsole may reference
-        // them after Main returns.
-        var stdoutWriter = new StringWriter();
-        var stderrWriter = new StringWriter();
-
-        try
-        {
-            Console.SetOut(stdoutWriter);
-            Console.SetError(stderrWriter);
-
-            var exitCode = await Program.Main(args);
-
-            return (stdoutWriter.ToString(), stderrWriter.ToString(), exitCode);
-        }
-        finally
-        {
-            Console.SetOut(originalOut);
-            Console.SetError(originalErr);
-        }
-    }
-
     [TestMethod]
     public async Task Main_NoArguments_ShowsBannerAndHelp_ReturnsZero()
     {
-        var (stdout, _, exitCode) = await InvokeProgramAsync([]);
+        var (stdout, _, exitCode) = await ProgramMainTestHarness.InvokeProgramAsync([]);
 
         Assert.AreEqual(0, exitCode);
         Assert.IsTrue(stdout.Contains("Windows App Development CLI", StringComparison.Ordinal),
@@ -182,7 +150,7 @@ public class ProgramMainTests
     [TestMethod]
     public async Task Main_SingleDashLongOptionTypo_PrintsSuggestion_ReturnsOne()
     {
-        var (_, stderr, exitCode) = await InvokeProgramAsync(["ui", "inspect", "-app", "some-app"]);
+        var (_, stderr, exitCode) = await ProgramMainTestHarness.InvokeProgramAsync(["ui", "inspect", "-app", "some-app"]);
 
         Assert.AreEqual(1, exitCode);
         Assert.IsTrue(stderr.Contains("Did you mean", StringComparison.Ordinal),
@@ -193,7 +161,7 @@ public class ProgramMainTests
     [TestMethod]
     public async Task Main_ConflictingLoggingFlags_PrintsError_ReturnsOne()
     {
-        var (_, stderr, exitCode) = await InvokeProgramAsync(["--quiet", "--verbose"]);
+        var (_, stderr, exitCode) = await ProgramMainTestHarness.InvokeProgramAsync(["--quiet", "--verbose"]);
 
         Assert.AreEqual(1, exitCode);
         Assert.IsTrue(stderr.Contains("Cannot specify both --quiet and --verbose options together.", StringComparison.Ordinal),
@@ -203,7 +171,7 @@ public class ProgramMainTests
     [TestMethod]
     public async Task Main_CliSchemaWithCaller_SetsCallerEnvVarAndReturnsZero()
     {
-        var (stdout, _, exitCode) = await InvokeProgramAsync(["--cli-schema", "--caller", "test-caller"]);
+        var (stdout, _, exitCode) = await ProgramMainTestHarness.InvokeProgramAsync(["--cli-schema", "--caller", "test-caller"]);
 
         Assert.AreEqual(0, exitCode);
         Assert.AreEqual("test-caller", Environment.GetEnvironmentVariable("WINAPP_CLI_CALLER"),
@@ -217,7 +185,7 @@ public class ProgramMainTests
     {
         // A bare unknown command produces parse errors but is not a single-dash typo, so the typo
         // shortcut is skipped and the parsed args flow into the normal invocation path.
-        var (_, stderr, exitCode) = await InvokeProgramAsync(["this-is-not-a-real-command"]);
+        var (_, stderr, exitCode) = await ProgramMainTestHarness.InvokeProgramAsync(["this-is-not-a-real-command"]);
 
         Assert.AreNotEqual(0, exitCode, "An unknown command must not succeed.");
         Assert.IsFalse(stderr.Contains("Did you mean", StringComparison.Ordinal),

--- a/src/winapp-CLI/WinApp.Cli.Tests/ProgressDisplayTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/ProgressDisplayTests.cs
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Spectre.Console.Testing;
+using WinApp.Cli.Helpers;
+using WinApp.Cli.Telemetry;
+
+namespace WinApp.Cli.Tests;
+
+[TestClass]
+public class ProgressDisplayTests
+{
+    private const string Direct = AgentEnvironmentDetector.SenderOrigins.Direct;
+    private const string Agent = AgentEnvironmentDetector.SenderOrigins.Agent;
+    private const string CI = AgentEnvironmentDetector.SenderOrigins.CI;
+
+    [TestMethod]
+    public void ShouldUseLiveSpinner_InfoDisabled_ReturnsFalse()
+    {
+        // Even with an otherwise perfect interactive terminal, suppressed info output => no spinner.
+        Assert.IsFalse(ProgressDisplay.ShouldUseLiveSpinner(
+            infoEnabled: false, senderOrigin: Direct, interactiveCapability: true,
+            ansiCapability: true, outputRedirected: false, userInteractive: true));
+    }
+
+    [TestMethod]
+    public void ShouldUseLiveSpinner_AgentOrigin_ReturnsFalse()
+    {
+        Assert.IsFalse(ProgressDisplay.ShouldUseLiveSpinner(
+            infoEnabled: true, senderOrigin: Agent, interactiveCapability: true,
+            ansiCapability: true, outputRedirected: false, userInteractive: true));
+    }
+
+    [TestMethod]
+    public void ShouldUseLiveSpinner_CiOrigin_ReturnsFalse()
+    {
+        Assert.IsFalse(ProgressDisplay.ShouldUseLiveSpinner(
+            infoEnabled: true, senderOrigin: CI, interactiveCapability: true,
+            ansiCapability: true, outputRedirected: false, userInteractive: true));
+    }
+
+    [TestMethod]
+    public void ShouldUseLiveSpinner_NonInteractiveTerminal_ReturnsFalse()
+    {
+        Assert.IsFalse(ProgressDisplay.ShouldUseLiveSpinner(
+            infoEnabled: true, senderOrigin: Direct, interactiveCapability: false,
+            ansiCapability: true, outputRedirected: false, userInteractive: true));
+    }
+
+    [TestMethod]
+    public void ShouldUseLiveSpinner_NoAnsiCapability_ReturnsFalse()
+    {
+        Assert.IsFalse(ProgressDisplay.ShouldUseLiveSpinner(
+            infoEnabled: true, senderOrigin: Direct, interactiveCapability: true,
+            ansiCapability: false, outputRedirected: false, userInteractive: true));
+    }
+
+    [TestMethod]
+    public void ShouldUseLiveSpinner_OutputRedirected_ReturnsFalse()
+    {
+        Assert.IsFalse(ProgressDisplay.ShouldUseLiveSpinner(
+            infoEnabled: true, senderOrigin: Direct, interactiveCapability: true,
+            ansiCapability: true, outputRedirected: true, userInteractive: true));
+    }
+
+    [TestMethod]
+    public void ShouldUseLiveSpinner_AllCapableAndInteractiveUser_ReturnsTrue()
+    {
+        Assert.IsTrue(ProgressDisplay.ShouldUseLiveSpinner(
+            infoEnabled: true, senderOrigin: Direct, interactiveCapability: true,
+            ansiCapability: true, outputRedirected: false, userInteractive: true));
+    }
+
+    [TestMethod]
+    public void ShouldUseLiveSpinner_AllCapableButNonInteractiveUser_ReturnsFalse()
+    {
+        Assert.IsFalse(ProgressDisplay.ShouldUseLiveSpinner(
+            infoEnabled: true, senderOrigin: Direct, interactiveCapability: true,
+            ansiCapability: true, outputRedirected: false, userInteractive: false));
+    }
+
+    [TestMethod]
+    public void ShouldUseLiveSpinner_ConsoleOverload_SuppressedLogger_ReturnsFalse()
+    {
+        // NullLogger reports info as disabled, so the console-driven overload returns false.
+        var console = new TestConsole();
+        Assert.IsFalse(ProgressDisplay.ShouldUseLiveSpinner(console, NullLogger.Instance));
+    }
+}

--- a/src/winapp-CLI/WinApp.Cli.Tests/PublisherDnHelperTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/PublisherDnHelperTests.cs
@@ -91,6 +91,7 @@ public class PublisherDnHelperTests
     [DataRow("OU=Finance, DC=corp, DC=com", "OU=Finance, DC=corp, DC=com", DisplayName = "Non-CN multi → full DN")]
     [DataRow("OU=Finance", "OU=Finance", DisplayName = "Non-CN single → full DN")]
     [DataRow("CN=\"Company, Inc.\"", "Company, Inc.", DisplayName = "Quoted CN → unquoted value")]
+    [DataRow("CN=a\\,b", "a\\,b", DisplayName = "Backslash-escaped comma is not a component separator")]
     public void GetDisplayName_ReturnsExpected(string dn, string expected)
     {
         Assert.AreEqual(expected, PublisherDnHelper.GetDisplayName(dn));
@@ -115,9 +116,17 @@ public class PublisherDnHelperTests
     [DataRow("CN=\"Company, Inc.\"", "CN=&quot;Company, Inc.&quot;", DisplayName = "Quotes escaped")]
     [DataRow("CN=A&B", "CN=A&amp;B", DisplayName = "Ampersand escaped")]
     [DataRow("CN=<Test>", "CN=&lt;Test&gt;", DisplayName = "Angle brackets escaped")]
+    [DataRow("O=Tom's Co", "O=Tom&apos;s Co", DisplayName = "Apostrophe escaped")]
+    [DataRow("", "", DisplayName = "Empty string passes through")]
     public void XmlEscape_ReturnsExpected(string input, string expected)
     {
         Assert.AreEqual(expected, PublisherDnHelper.XmlEscape(input));
+    }
+
+    [TestMethod]
+    public void XmlEscape_NullInput_ReturnsNull()
+    {
+        Assert.IsNull(PublisherDnHelper.XmlEscape(null!));
     }
 
     #endregion

--- a/src/winapp-CLI/WinApp.Cli.Tests/ShellIconTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/ShellIconTests.cs
@@ -27,11 +27,13 @@ public class ShellIconTests
     }
 
     [TestMethod]
-    public void GetJumboIcon_RealExecutable_ReturnsIconOrNullWithoutThrowing()
+    public void GetJumboIcon_RealExecutable_ReturnsUsableIconOrIsInconclusive()
     {
-        // Exercises the full shell image-list path against a real, icon-bearing executable. The
-        // result depends on the host's shell availability, so we only require that it never throws
-        // and that any returned icon is a usable, disposable handle.
+        // Exercises the full public shell image-list path against a real, icon-bearing executable.
+        // Deterministic branch coverage of the resolve/short-circuit/failure arms comes from the
+        // GetJumboIconCore seam tests below; here we require that when the shell host DOES produce an
+        // icon it is a usable, positively-sized handle, and otherwise mark the test inconclusive
+        // rather than passing silently on a null (which would not prove the success path ran).
         var exe = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "notepad.exe");
         if (!File.Exists(exe))
         {
@@ -41,10 +43,14 @@ public class ShellIconTests
         Icon? icon = ShellIcon.GetJumboIcon(exe);
         try
         {
-            if (icon is not null)
+            if (icon is null)
             {
-                Assert.IsTrue(icon.Width > 0 && icon.Height > 0, "A resolved icon must have positive dimensions.");
+                Assert.Inconclusive(
+                    "The shell host did not produce a jumbo icon for a real executable; the native " +
+                    "success path is not verifiable in this environment.");
             }
+
+            Assert.IsTrue(icon.Width > 0 && icon.Height > 0, "A resolved icon must have positive dimensions.");
         }
         finally
         {

--- a/src/winapp-CLI/WinApp.Cli.Tests/ShellIconTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/ShellIconTests.cs
@@ -1,0 +1,104 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Drawing;
+using System.Runtime.InteropServices;
+using WinApp.Cli.Helpers;
+
+namespace WinApp.Cli.Tests;
+
+[TestClass]
+public class ShellIconTests
+{
+    [TestMethod]
+    public void GetJumboIcon_EmptyPath_DoesNotThrow()
+    {
+        // An empty path is resolved by the shell to a generic icon on a normal desktop, but may
+        // fail on a constrained host. Either way the helper must never surface an exception.
+        Icon? icon = ShellIcon.GetJumboIcon(string.Empty);
+        icon?.Dispose();
+    }
+
+    [TestMethod]
+    public void GetJumboIcon_NonexistentPath_ReturnsNull()
+    {
+        var missing = Path.Combine(Path.GetTempPath(), $"no-such-icon-{Guid.NewGuid():N}.exe");
+        Assert.IsNull(ShellIcon.GetJumboIcon(missing));
+    }
+
+    [TestMethod]
+    public void GetJumboIcon_RealExecutable_ReturnsIconOrNullWithoutThrowing()
+    {
+        // Exercises the full shell image-list path against a real, icon-bearing executable. The
+        // result depends on the host's shell availability, so we only require that it never throws
+        // and that any returned icon is a usable, disposable handle.
+        var exe = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "notepad.exe");
+        if (!File.Exists(exe))
+        {
+            exe = Environment.ProcessPath!;
+        }
+
+        Icon? icon = ShellIcon.GetJumboIcon(exe);
+        try
+        {
+            if (icon is not null)
+            {
+                Assert.IsTrue(icon.Width > 0 && icon.Height > 0, "A resolved icon must have positive dimensions.");
+            }
+        }
+        finally
+        {
+            icon?.Dispose();
+        }
+    }
+
+    [TestMethod]
+    public void GetJumboIconCore_NoSystemIcon_ReturnsNullWithoutQueryingImageList()
+    {
+        var imageListQueried = false;
+
+        var icon = ShellIcon.GetJumboIconCore(
+            "irrelevant",
+            _ => null,
+            _ => { imageListQueried = true; return SystemIcons.Application; });
+
+        Assert.IsNull(icon, "A null system icon index must short-circuit to null.");
+        Assert.IsFalse(imageListQueried, "The image list must not be queried when there is no system icon.");
+    }
+
+    [TestMethod]
+    public void GetJumboIconCore_ResolvedIndex_MaterializesIconForThatIndex()
+    {
+        int? seenIndex = null;
+
+        var icon = ShellIcon.GetJumboIconCore(
+            "irrelevant",
+            _ => 7,
+            index => { seenIndex = index; return SystemIcons.Application; });
+
+        Assert.AreEqual(7, seenIndex, "The resolved system icon index must be forwarded to the image-list resolver.");
+        Assert.AreSame(SystemIcons.Application, icon);
+    }
+
+    [TestMethod]
+    public void GetJumboIconCore_SystemIndexResolverThrows_ReturnsNull()
+    {
+        var icon = ShellIcon.GetJumboIconCore(
+            "irrelevant",
+            _ => throw new InvalidOperationException("shell failure"),
+            _ => SystemIcons.Application);
+
+        Assert.IsNull(icon, "Exceptions from the native resolvers must be swallowed as null.");
+    }
+
+    [TestMethod]
+    public void GetJumboIconCore_ImageListResolverThrows_ReturnsNull()
+    {
+        var icon = ShellIcon.GetJumboIconCore(
+            "irrelevant",
+            _ => 3,
+            _ => throw new COMException("image list failure"));
+
+        Assert.IsNull(icon, "Exceptions while materializing the icon must be swallowed as null.");
+    }
+}

--- a/src/winapp-CLI/WinApp.Cli.Tests/SystemDefaultsHelperTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/SystemDefaultsHelperTests.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using WinApp.Cli.Helpers;
+
+namespace WinApp.Cli.Tests;
+
+[TestClass]
+public class SystemDefaultsHelperTests
+{
+    [TestMethod]
+    public void BuildPublisherCN_RegularUser_WrapsWithCn()
+    {
+        Assert.AreEqual("CN=Alice", SystemDefaultsHelper.BuildPublisherCN("Alice"));
+    }
+
+    [TestMethod]
+    public void BuildPublisherCN_NullUser_FallsBackToDeveloper()
+    {
+        Assert.AreEqual("CN=Developer", SystemDefaultsHelper.BuildPublisherCN(null));
+    }
+
+    [TestMethod]
+    public void BuildPublisherCN_EmptyUser_FallsBackToDeveloper()
+    {
+        Assert.AreEqual("CN=Developer", SystemDefaultsHelper.BuildPublisherCN(string.Empty));
+    }
+
+    [TestMethod]
+    public void BuildPublisherCN_WhitespaceUser_FallsBackToDeveloper()
+    {
+        Assert.AreEqual("CN=Developer", SystemDefaultsHelper.BuildPublisherCN("   "));
+    }
+
+    [TestMethod]
+    public void GetDefaultPublisherCN_ReturnsCnPrefixedValue()
+    {
+        var cn = SystemDefaultsHelper.GetDefaultPublisherCN();
+        Assert.IsTrue(cn.StartsWith("CN=", StringComparison.Ordinal), $"Expected a CN= prefix, got '{cn}'.");
+    }
+
+    [TestMethod]
+    public void GetDefaultPackageName_NormalizesSpacesToHyphensAndLowercases()
+    {
+        var dir = new DirectoryInfo(@"C:\src\My Cool App");
+        Assert.AreEqual("my-cool-app", SystemDefaultsHelper.GetDefaultPackageName(dir));
+    }
+
+    [TestMethod]
+    public void GetDefaultDescription_ReturnsStableDefault()
+    {
+        Assert.AreEqual("My Application", SystemDefaultsHelper.GetDefaultDescription());
+    }
+}

--- a/src/winapp-CLI/WinApp.Cli.Tests/TextWriterLoggerTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/TextWriterLoggerTests.cs
@@ -1,0 +1,170 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.Logging;
+using System.Text;
+using WinApp.Cli.Helpers;
+
+namespace WinApp.Cli.Tests;
+
+[TestClass]
+public class TextWriterLoggerTests
+{
+    private static (TextWriterLoggerProvider Provider, StringWriter Out, StringWriter Err) NewProvider()
+    {
+        var stdout = new StringWriter();
+        var stderr = new StringWriter();
+        return (new TextWriterLoggerProvider(stdout, stderr), stdout, stderr);
+    }
+
+    [TestMethod]
+    public void Provider_NullStdout_Throws()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() => new TextWriterLoggerProvider(null!, new StringWriter()));
+    }
+
+    [TestMethod]
+    public void Provider_NullStderr_Throws()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() => new TextWriterLoggerProvider(new StringWriter(), null!));
+    }
+
+    [TestMethod]
+    public void Provider_Dispose_DoesNotThrow()
+    {
+        var (provider, _, _) = NewProvider();
+        provider.Dispose(); // writers are owned by the caller; Dispose is a safe no-op
+    }
+
+    [TestMethod]
+    public void IsEnabled_NoneIsDisabled_OthersEnabled()
+    {
+        var (provider, _, _) = NewProvider();
+        var logger = provider.CreateLogger("cat");
+
+        Assert.IsFalse(logger.IsEnabled(LogLevel.None));
+        Assert.IsTrue(logger.IsEnabled(LogLevel.Information));
+        Assert.IsTrue(logger.IsEnabled(LogLevel.Error));
+    }
+
+    [TestMethod]
+    public void BeginScope_WithoutScopeProvider_ReturnsDisposableNullScope()
+    {
+        var (provider, _, _) = NewProvider();
+        var logger = provider.CreateLogger("cat");
+
+        using var scope = logger.BeginScope("no-op");
+
+        Assert.IsNotNull(scope, "BeginScope must return a non-null disposable even with no scope provider.");
+        scope.Dispose(); // NullScope.Dispose is a no-op and must be safe to call.
+    }
+
+    [TestMethod]
+    public void Log_LevelNone_IsSuppressed_WritesNothing()
+    {
+        var (provider, stdout, stderr) = NewProvider();
+        var logger = provider.CreateLogger("cat");
+
+        logger.Log(LogLevel.None, new EventId(1), "ignored", exception: null, (state, _) => state);
+
+        Assert.AreEqual(string.Empty, stdout.ToString());
+        Assert.AreEqual(string.Empty, stderr.ToString());
+    }
+
+    [TestMethod]
+    public void Log_ErrorLevel_GoesToStderrWithLevelPrefix()
+    {
+        var (provider, _, stderr) = NewProvider();
+        var logger = provider.CreateLogger("cat");
+
+        logger.LogError("disk full");
+
+        var err = stderr.ToString();
+        Assert.IsTrue(err.Contains("[ERROR] - ", StringComparison.Ordinal), $"Expected level prefix, got: {err}");
+        Assert.IsTrue(err.Contains("disk full", StringComparison.Ordinal));
+    }
+
+    [TestMethod]
+    public void Log_ErrorWithScopeAndException_AppendsScopeAndExceptionToStderr()
+    {
+        var (provider, _, stderr) = NewProvider();
+        provider.SetScopeProvider(new LoggerExternalScopeProvider());
+        var logger = provider.CreateLogger("cat");
+
+        using (logger.BeginScope("OUTER_SCOPE"))
+        {
+            logger.LogError(new InvalidOperationException("BOOM_MESSAGE"), "operation failed");
+        }
+
+        var err = stderr.ToString();
+        Assert.IsTrue(err.Contains("operation failed", StringComparison.Ordinal));
+        Assert.IsTrue(err.Contains("=> OUTER_SCOPE", StringComparison.Ordinal), $"Scope must be appended, got: {err}");
+        Assert.IsTrue(err.Contains("BOOM_MESSAGE", StringComparison.Ordinal), $"Exception must be appended, got: {err}");
+    }
+
+    [TestMethod]
+    public void AddTextWriterLogger_EndToEnd_WritesErrorToStderrWriter()
+    {
+        var stdout = new StringWriter();
+        var stderr = new StringWriter();
+        using var factory = LoggerFactory.Create(b =>
+        {
+            b.SetMinimumLevel(LogLevel.Trace);
+            b.AddTextWriterLogger(stdout, stderr);
+        });
+        var logger = factory.CreateLogger("integration");
+
+        logger.LogError("boom via factory");
+
+        Assert.IsTrue(stderr.ToString().Contains("boom via factory", StringComparison.Ordinal));
+    }
+
+    [TestMethod]
+    public void OutputCapture_Encoding_IsAscii()
+    {
+        using var capture = new OutputCapture(new StringWriter());
+        Assert.AreEqual(Encoding.ASCII, capture.Encoding);
+    }
+
+    [TestMethod]
+    public void OutputCapture_WriteAndWriteLine_MirrorToInnerAndCapture()
+    {
+        var inner = new StringWriter();
+        using var capture = new OutputCapture(inner);
+
+        capture.Write("alpha");
+        capture.WriteLine("beta");
+
+        var captured = capture.ToString();
+        var mirrored = inner.ToString();
+        Assert.IsTrue(captured.Contains("alpha", StringComparison.Ordinal));
+        Assert.IsTrue(captured.Contains("beta", StringComparison.Ordinal));
+        Assert.IsTrue(mirrored.Contains("alpha", StringComparison.Ordinal));
+        Assert.IsTrue(mirrored.Contains("beta", StringComparison.Ordinal));
+    }
+
+    [TestMethod]
+    public void OutputCapture_Clear_EmptiesCapturedBufferOnly()
+    {
+        var inner = new StringWriter();
+        var capture = new OutputCapture(inner);
+
+        capture.Write("to-be-cleared");
+        capture.Clear();
+
+        Assert.AreEqual(string.Empty, capture.ToString(), "Clear must empty the captured buffer.");
+        Assert.IsTrue(inner.ToString().Contains("to-be-cleared", StringComparison.Ordinal),
+            "Clear must not affect what was already mirrored to the inner writer.");
+    }
+
+    [TestMethod]
+    public void OutputCapture_Dispose_DisposesInnerWriter()
+    {
+        var inner = new StringWriter();
+        var capture = new OutputCapture(inner);
+
+        capture.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() => inner.Write("after dispose"));
+    }
+}

--- a/src/winapp-CLI/WinApp.Cli.Tests/UpdateNotificationGatingTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/UpdateNotificationGatingTests.cs
@@ -23,13 +23,6 @@ public class UpdateNotificationGatingTests
     private string? _savedCaller;
     private string? _savedUpdateCheck;
 
-    // All environment variable names checked by CIEnvironmentDetectorForTelemetry
-    private static readonly string[] CiVarNames =
-    [
-        "CI", "GITHUB_ACTIONS", "TF_BUILD", "APPVEYOR", "TRAVIS", "CIRCLECI",
-        "TEAMCITY_VERSION", "JB_SPACE_API_URL",
-        "CODEBUILD_BUILD_ID", "AWS_REGION", "BUILD_ID", "BUILD_URL", "PROJECT_ID"
-    ];
     private Dictionary<string, string?> _savedCiVars = [];
 
     [TestInitialize]
@@ -47,14 +40,14 @@ public class UpdateNotificationGatingTests
         _savedCacheDir = Environment.GetEnvironmentVariable("WINAPP_CLI_CACHE_DIRECTORY");
         _savedCaller = Environment.GetEnvironmentVariable("WINAPP_CLI_CALLER");
         _savedUpdateCheck = Environment.GetEnvironmentVariable("WINAPP_CLI_UPDATE_CHECK");
-        _savedCiVars = CiVarNames.ToDictionary(name => name, name => Environment.GetEnvironmentVariable(name));
+        _savedCiVars = ProgramMainTestHarness.CiVarNames.ToDictionary(name => name, name => Environment.GetEnvironmentVariable(name));
 
         Environment.SetEnvironmentVariable("WINAPP_CLI_CACHE_DIRECTORY", _tempCacheDir);
         Environment.SetEnvironmentVariable("WINAPP_CLI_CALLER", null);
         Environment.SetEnvironmentVariable("WINAPP_CLI_UPDATE_CHECK", null);
 
         // Clear CI vars to avoid suppression
-        foreach (var name in CiVarNames)
+        foreach (var name in ProgramMainTestHarness.CiVarNames)
         {
             Environment.SetEnvironmentVariable(name, null);
         }
@@ -77,7 +70,7 @@ public class UpdateNotificationGatingTests
     [TestMethod]
     public async Task JsonMode_SuppressesUpdateNotice_StdoutHasNoNotice()
     {
-        var (stdout, stderr, _) = await InvokeProgramAsync(["get-winapp-path", "--global", "--json"]);
+        var (stdout, stderr, _) = await ProgramMainTestHarness.InvokeProgramAsync(["get-winapp-path", "--global", "--json"]);
 
         Assert.IsFalse(stdout.Contains("available", StringComparison.OrdinalIgnoreCase),
             $"--json stdout must not contain update notice. Got stdout: {stdout}");
@@ -88,7 +81,7 @@ public class UpdateNotificationGatingTests
     [TestMethod]
     public async Task QuietMode_SuppressesUpdateNotice()
     {
-        var (stdout, stderr, _) = await InvokeProgramAsync(["get-winapp-path", "--global", "--quiet"]);
+        var (stdout, stderr, _) = await ProgramMainTestHarness.InvokeProgramAsync(["get-winapp-path", "--global", "--quiet"]);
 
         Assert.IsFalse(stdout.Contains("available", StringComparison.OrdinalIgnoreCase),
             $"--quiet stdout must not contain update notice. Got stdout: {stdout}");
@@ -99,7 +92,7 @@ public class UpdateNotificationGatingTests
     [TestMethod]
     public async Task CliSchemaMode_SuppressesUpdateNotice()
     {
-        var (stdout, stderr, _) = await InvokeProgramAsync(["--cli-schema"]);
+        var (stdout, stderr, _) = await ProgramMainTestHarness.InvokeProgramAsync(["--cli-schema"]);
 
         Assert.IsFalse(stdout.Contains("available", StringComparison.OrdinalIgnoreCase),
             $"--cli-schema stdout must not contain update notice. Got stdout: {stdout}");
@@ -112,7 +105,7 @@ public class UpdateNotificationGatingTests
     {
         // Invoke through the real entrypoint — the notification should appear on stderr,
         // never stdout. We capture stderr via Console.SetError.
-        var (stdout, stderr, _) = await InvokeProgramAsync(["get-winapp-path", "--global"]);
+        var (stdout, stderr, _) = await ProgramMainTestHarness.InvokeProgramAsync(["get-winapp-path", "--global"]);
 
         Assert.IsFalse(stdout.Contains("available", StringComparison.OrdinalIgnoreCase),
             $"Update notice must not appear on stdout. Got stdout: {stdout}");
@@ -125,7 +118,7 @@ public class UpdateNotificationGatingTests
     {
         // --caller npm should set WINAPP_CLI_CALLER=npm which makes the update notice
         // include the npm update hint.
-        var (_, stderr, _) = await InvokeProgramAsync(["get-winapp-path", "--global", "--caller", "npm"]);
+        var (_, stderr, _) = await ProgramMainTestHarness.InvokeProgramAsync(["get-winapp-path", "--global", "--caller", "npm"]);
 
         Assert.IsTrue(stderr.Contains("npm update", StringComparison.OrdinalIgnoreCase),
             $"With --caller npm, notice should contain npm update hint. Got stderr: {stderr}");
@@ -147,34 +140,5 @@ public class UpdateNotificationGatingTests
         return Version.TryParse(currentCore, out var parsed)
             ? $"{parsed.Major + 1}.0.0"
             : "5.0.0";
-    }
-
-    /// <summary>
-    /// Invokes Program.Main with captured stdout/stderr.
-    /// Writers are intentionally not disposed to avoid ObjectDisposedException from
-    /// Spectre.Console's static AnsiConsole.Console which may reference them after return.
-    /// </summary>
-    private static async Task<(string Stdout, string Stderr, int ExitCode)> InvokeProgramAsync(string[] args)
-    {
-        var originalOut = Console.Out;
-        var originalErr = Console.Error;
-
-        var stdoutWriter = new StringWriter();
-        var stderrWriter = new StringWriter();
-
-        try
-        {
-            Console.SetOut(stdoutWriter);
-            Console.SetError(stderrWriter);
-
-            var exitCode = await Program.Main(args);
-
-            return (stdoutWriter.ToString(), stderrWriter.ToString(), exitCode);
-        }
-        finally
-        {
-            Console.SetOut(originalOut);
-            Console.SetError(originalErr);
-        }
     }
 }

--- a/src/winapp-CLI/WinApp.Cli.Tests/VersionHelperTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/VersionHelperTests.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using WinApp.Cli.Helpers;
+
+namespace WinApp.Cli.Tests;
+
+[TestClass]
+public class VersionHelperTests
+{
+    [TestMethod]
+    public void FormatVersion_InformationalVersion_ReturnedAsIs()
+    {
+        Assert.AreEqual("0.1.8", VersionHelper.FormatVersion("0.1.8", asmVersion: null));
+    }
+
+    [TestMethod]
+    public void FormatVersion_InformationalVersionWithGitHash_StripsSuffix()
+    {
+        Assert.AreEqual("0.1.8", VersionHelper.FormatVersion("0.1.8+abc123def", asmVersion: null));
+    }
+
+    [TestMethod]
+    public void FormatVersion_InformationalVersionEndingInPlus_StripsToEmptySuffix()
+    {
+        Assert.AreEqual("1.0.0", VersionHelper.FormatVersion("1.0.0+", asmVersion: null));
+    }
+
+    [TestMethod]
+    public void FormatVersion_NullInformationalVersion_FallsBackToAssemblyVersion()
+    {
+        Assert.AreEqual("2.5.7", VersionHelper.FormatVersion(null, new Version(2, 5, 7, 99)));
+    }
+
+    [TestMethod]
+    public void FormatVersion_EmptyInformationalVersion_FallsBackToAssemblyVersion()
+    {
+        Assert.AreEqual("3.4.0", VersionHelper.FormatVersion(string.Empty, new Version(3, 4, 0)));
+    }
+
+    [TestMethod]
+    public void FormatVersion_NoInformationalAndNoAssemblyVersion_ReturnsZeroTriplet()
+    {
+        Assert.AreEqual("0.0.0", VersionHelper.FormatVersion(null, asmVersion: null));
+    }
+
+    [TestMethod]
+    public void GetVersionString_ReturnsNonEmptyValue()
+    {
+        var version = VersionHelper.GetVersionString();
+        Assert.IsFalse(string.IsNullOrWhiteSpace(version), "The CLI version string must never be empty.");
+    }
+}

--- a/src/winapp-CLI/WinApp.Cli.Tests/ZipRangeExtractorTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/ZipRangeExtractorTests.cs
@@ -230,4 +230,179 @@ public class ZipRangeExtractorTests
         Assert.IsNull(msix);
         Assert.IsNull(prefix);
     }
+
+    [TestMethod]
+    public async Task FindCentralDirectory_NoEocdSignature_Throws()
+    {
+        // Random bytes with no EOCD record — LastIndexOfSignature returns -1.
+        var data = new byte[200];
+        Array.Fill(data, (byte)0xAB);
+        var reader = new MemoryRangeReader(data);
+
+        await Assert.ThrowsExactlyAsync<InvalidDataException>(async () =>
+            await ZipRangeExtractor.FindCentralDirectoryAsync(reader, 0, data.Length, CancellationToken.None));
+    }
+
+    [TestMethod]
+    public async Task FindCentralDirectory_Zip64MarkerButNoLocator_Throws()
+    {
+        // EOCD advertises ZIP64 (markers) but there is no ZIP64 locator ahead of it.
+        var data = new byte[122];
+        var eocd = new byte[22];
+        WriteU32(eocd, 0, 0x06054b50);
+        WriteU16(eocd, 10, 0xFFFF);
+        WriteU32(eocd, 12, 0xFFFFFFFF);
+        WriteU32(eocd, 16, 0xFFFFFFFF);
+        eocd.CopyTo(data, 100);
+        var reader = new MemoryRangeReader(data);
+
+        await Assert.ThrowsExactlyAsync<InvalidDataException>(async () =>
+            await ZipRangeExtractor.FindCentralDirectoryAsync(reader, 0, data.Length, CancellationToken.None));
+    }
+
+    [TestMethod]
+    public async Task FindCentralDirectory_Zip64RecordSignatureMismatch_Throws()
+    {
+        var buf = new List<byte>();
+        buf.AddRange(new byte[10]);                            // central-directory placeholder
+
+        var record = new byte[56];
+        WriteU32(record, 0, 0xDEADBEEF);                      // WRONG ZIP64 EOCD signature
+        buf.AddRange(record);
+
+        var locator = new byte[20];
+        WriteU32(locator, 0, 0x07064b50);
+        WriteU64(locator, 8, 10);                             // record is at offset 10
+        buf.AddRange(locator);
+
+        var eocd = new byte[22];
+        WriteU32(eocd, 0, 0x06054b50);
+        WriteU16(eocd, 10, 0xFFFF);
+        WriteU32(eocd, 12, 0xFFFFFFFF);
+        WriteU32(eocd, 16, 0xFFFFFFFF);
+        buf.AddRange(eocd);
+
+        var reader = new MemoryRangeReader(buf.ToArray());
+
+        await Assert.ThrowsExactlyAsync<InvalidDataException>(async () =>
+            await ZipRangeExtractor.FindCentralDirectoryAsync(reader, 0, buf.Count, CancellationToken.None));
+    }
+
+    [TestMethod]
+    public async Task FindCentralDirectory_Zip64RecordOutsideTailWindow_ReadsViaRanged()
+    {
+        // Archive larger than the EOCD search window, with the ZIP64 EOCD record near the start so
+        // it falls outside the trailing tail read and must be fetched with a separate ranged read.
+        const long cdOffset = 0;
+        const long cdSize = 10;
+        const int total = 66000; // > MaxEocdSearch (65557)
+        var data = new byte[total];
+
+        var record = new byte[56];
+        WriteU32(record, 0, 0x06064b50);
+        WriteU64(record, 40, unchecked((ulong)cdSize));
+        WriteU64(record, 48, unchecked((ulong)cdOffset));
+        record.CopyTo(data, 0); // record at offset 0 (outside the tail window)
+
+        var locatorOffset = total - 22 - 20;
+        var locator = new byte[20];
+        WriteU32(locator, 0, 0x07064b50);
+        WriteU64(locator, 8, 0); // relative offset of the ZIP64 EOCD record = 0
+        locator.CopyTo(data, locatorOffset);
+
+        var eocd = new byte[22];
+        WriteU32(eocd, 0, 0x06054b50);
+        WriteU16(eocd, 10, 0xFFFF);
+        WriteU32(eocd, 12, 0xFFFFFFFF);
+        WriteU32(eocd, 16, 0xFFFFFFFF);
+        eocd.CopyTo(data, total - 22);
+
+        var reader = new MemoryRangeReader(data);
+
+        var (offset, size) = await ZipRangeExtractor.FindCentralDirectoryAsync(reader, 0, data.Length, CancellationToken.None);
+
+        Assert.AreEqual(cdOffset, offset);
+        Assert.AreEqual(cdSize, size);
+    }
+
+    [TestMethod]
+    public void ParseCentralDirectory_SkipsNonZip64ExtraField_ThenAppliesZip64()
+    {
+        // The first extra field has a non-ZIP64 id and must be skipped before the ZIP64 field applies.
+        const long uncompressed = 0x2_0000_0002;
+        var name = Encoding.UTF8.GetBytes("skip.bin");
+
+        var extra = new byte[(4 + 4) + (4 + 8)];
+        WriteU16(extra, 0, 0x000A);   // non-ZIP64 extra id
+        WriteU16(extra, 2, 4);        // its dataLen (4 bytes of payload, left zero)
+        WriteU16(extra, 8, 0x0001);   // ZIP64 extra id
+        WriteU16(extra, 10, 8);       // dataLen: only the uncompressed 64-bit value follows
+        WriteU64(extra, 12, unchecked((ulong)uncompressed));
+
+        var header = new byte[46 + name.Length + extra.Length];
+        WriteU32(header, 0, 0x02014b50);
+        WriteU16(header, 10, 0);                  // method: stored
+        WriteU32(header, 20, 0x11111111);         // compressed: NOT a marker → left unchanged
+        WriteU32(header, 24, 0xFFFFFFFF);         // uncompressed: marker → taken from ZIP64 extra
+        WriteU16(header, 28, (ushort)name.Length);
+        WriteU16(header, 30, (ushort)extra.Length);
+        WriteU16(header, 32, 0);
+        WriteU32(header, 42, 0x22222222);         // local-header offset: NOT a marker
+        name.CopyTo(header, 46);
+        extra.CopyTo(header, 46 + name.Length);
+
+        var entries = ZipRangeExtractor.ParseCentralDirectory(header, archiveBase: 0);
+
+        Assert.AreEqual(1, entries.Count);
+        Assert.AreEqual(uncompressed, entries[0].UncompressedSize, "uncompressed size must come from the ZIP64 field after skipping the other one");
+        Assert.AreEqual(0x11111111, entries[0].CompressedSize, "non-marker compressed size stays as the 32-bit value");
+    }
+
+    [TestMethod]
+    public async Task ExtractEntry_CompressedSizeExceedsInt32_Throws()
+    {
+        var entry = new ZipEntry("too-big.bin", Method: 0, CompressedSize: (long)int.MaxValue + 1,
+            UncompressedSize: 0, LocalHeaderOffset: 0);
+        var reader = new MemoryRangeReader(new byte[16]);
+
+        await Assert.ThrowsExactlyAsync<InvalidDataException>(async () =>
+            await ZipRangeExtractor.ExtractEntryAsync(reader, entry, CancellationToken.None));
+    }
+
+    [TestMethod]
+    public async Task ExtractEntry_UnsupportedCompressionMethod_Throws()
+    {
+        // 30-byte local header (nameLen/extraLen = 0) followed by 4 bytes of data.
+        var buf = new byte[34];
+        var entry = new ZipEntry("weird.bin", Method: 99, CompressedSize: 4, UncompressedSize: 4, LocalHeaderOffset: 0);
+        var reader = new MemoryRangeReader(buf);
+
+        await Assert.ThrowsExactlyAsync<NotSupportedException>(async () =>
+            await ZipRangeExtractor.ExtractEntryAsync(reader, entry, CancellationToken.None));
+    }
+
+    [TestMethod]
+    public async Task MemoryRangeReader_RangeBeyondBuffer_Throws()
+    {
+        var reader = new MemoryRangeReader(new byte[10]);
+
+        await Assert.ThrowsExactlyAsync<ArgumentOutOfRangeException>(async () =>
+            await reader.ReadAsync(5, 10, CancellationToken.None));
+    }
+
+    [TestMethod]
+    public async Task MemoryRangeReader_NegativeOffset_Throws()
+    {
+        var reader = new MemoryRangeReader(new byte[10]);
+
+        await Assert.ThrowsExactlyAsync<ArgumentOutOfRangeException>(async () =>
+            await reader.ReadAsync(-1, 2, CancellationToken.None));
+    }
+
+    [TestMethod]
+    public async Task MemoryRangeReader_GetLength_ReturnsBufferLength()
+    {
+        var reader = new MemoryRangeReader(new byte[42]);
+        Assert.AreEqual(42L, await reader.GetLengthAsync(CancellationToken.None));
+    }
 }

--- a/src/winapp-CLI/WinApp.Cli/Helpers/AuthenticodeVerifier.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/AuthenticodeVerifier.cs
@@ -41,7 +41,21 @@ internal static unsafe partial class AuthenticodeVerifier
     /// untrusted, non-Microsoft, or verification error) returns <c>false</c> — this is a fail-closed
     /// security gate.
     /// </summary>
-    public static bool IsTrustedMicrosoftSigned(string filePath, ILogger logger)
+    public static bool IsTrustedMicrosoftSigned(string filePath, ILogger logger) =>
+        IsTrustedMicrosoftSigned(filePath, logger, VerifyTrustCore, IsMicrosoftSigner);
+
+    /// <summary>
+    /// Core of <see cref="IsTrustedMicrosoftSigned(string, ILogger)"/> with the two OS-boundary
+    /// probes injected: <paramref name="verifyTrustCore"/> runs <c>WinVerifyTrust</c> (returning its
+    /// HRESULT) and <paramref name="isMicrosoftSigner"/> reports whether the signer subject is
+    /// Microsoft. The seam lets unit tests exercise every trust/revocation/signer branch and the
+    /// exception path deterministically, without needing real signed binaries for each case.
+    /// </summary>
+    internal static bool IsTrustedMicrosoftSigned(
+        string filePath,
+        ILogger logger,
+        Func<string, uint, uint, int> verifyTrustCore,
+        Func<string, bool> isMicrosoftSigner)
     {
         try
         {
@@ -50,13 +64,13 @@ internal static unsafe partial class AuthenticodeVerifier
                 return false;
             }
 
-            if (!VerifyTrust(filePath, logger))
+            if (!VerifyTrust(filePath, logger, verifyTrustCore))
             {
                 logger.LogDebug("Authenticode trust verification failed for {File}.", filePath);
                 return false;
             }
 
-            if (!IsMicrosoftSigner(filePath))
+            if (!isMicrosoftSigner(filePath))
             {
                 logger.LogDebug("Authenticode signer for {File} is not Microsoft.", filePath);
                 return false;
@@ -71,13 +85,13 @@ internal static unsafe partial class AuthenticodeVerifier
         }
     }
 
-    private static bool VerifyTrust(string filePath, ILogger logger)
+    private static bool VerifyTrust(string filePath, ILogger logger, Func<string, uint, uint, int> verifyTrustCore)
     {
         // Prefer full-chain revocation using locally cached CRLs only (no network fetch, so a
         // locked-down/offline environment does not hang). A definitively revoked certificate is a hard
         // failure; when revocation data simply cannot be obtained offline, fall back to a signature-only
         // check so the gate still works — the signature and Microsoft-signer checks remain in force.
-        var hr = VerifyTrustCore(filePath, WTD_REVOKE_WHOLECHAIN, WTD_CACHE_ONLY_URL_RETRIEVAL);
+        var hr = verifyTrustCore(filePath, WTD_REVOKE_WHOLECHAIN, WTD_CACHE_ONLY_URL_RETRIEVAL);
         if (hr == 0)
         {
             return true;
@@ -92,7 +106,7 @@ internal static unsafe partial class AuthenticodeVerifier
         if (hr is CERT_E_REVOCATION_FAILURE or CRYPT_E_REVOCATION_OFFLINE or CRYPT_E_NO_REVOCATION_CHECK)
         {
             logger.LogDebug("Revocation data unavailable for {File} (0x{Hr:X8}); falling back to signature-only verification.", filePath, hr);
-            return VerifyTrustCore(filePath, WTD_REVOKE_NONE, WTD_REVOCATION_CHECK_NONE) == 0;
+            return verifyTrustCore(filePath, WTD_REVOKE_NONE, WTD_REVOCATION_CHECK_NONE) == 0;
         }
 
         return false;

--- a/src/winapp-CLI/WinApp.Cli/Helpers/BannerHelper.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/BannerHelper.cs
@@ -49,12 +49,12 @@ internal static class BannerHelper
     {
         try
         {
-            bool isUtf8 = Console.OutputEncoding?.CodePage == 65001;
-            bool isVsCode = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("VSCODE_PID")) ||
-                            string.Equals(Environment.GetEnvironmentVariable("TERM_PROGRAM"), "vscode", StringComparison.OrdinalIgnoreCase);
-            bool isWindowsTerminal = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("WT_SESSION"));
-            bool notRedirected = !Console.IsOutputRedirected;
-            return isUtf8 && notRedirected && (isVsCode || isWindowsTerminal);
+            return ComputeUseEmoji(
+                Console.OutputEncoding?.CodePage,
+                Console.IsOutputRedirected,
+                Environment.GetEnvironmentVariable("VSCODE_PID"),
+                Environment.GetEnvironmentVariable("TERM_PROGRAM"),
+                Environment.GetEnvironmentVariable("WT_SESSION"));
         }
         catch
         {
@@ -63,47 +63,68 @@ internal static class BannerHelper
     }
 
     /// <summary>
+    /// Pure decision core for <see cref="UseEmoji"/>: emoji/color output is used only in a UTF-8,
+    /// non-redirected terminal that is either VS Code or Windows Terminal. Extracted so every branch
+    /// can be unit tested without mutating the real console or process environment.
+    /// </summary>
+    internal static bool ComputeUseEmoji(int? outputCodePage, bool outputRedirected, string? vscodePid, string? termProgram, string? wtSession)
+    {
+        bool isUtf8 = outputCodePage == 65001;
+        bool isVsCode = !string.IsNullOrEmpty(vscodePid) ||
+                        string.Equals(termProgram, "vscode", StringComparison.OrdinalIgnoreCase);
+        bool isWindowsTerminal = !string.IsNullOrEmpty(wtSession);
+        bool notRedirected = !outputRedirected;
+        return isUtf8 && notRedirected && (isVsCode || isWindowsTerminal);
+    }
+
+    /// <summary>
     /// Displays the CLI banner with version information.
     /// </summary>
-    public static void DisplayBanner()
+    public static void DisplayBanner() => DisplayBanner(Console.Out, UseEmoji);
+
+    /// <summary>
+    /// Writes the CLI banner (including the version line) to <paramref name="writer"/>, using the
+    /// ANSI color-gradient form when <paramref name="useColor"/> is true and the plain ASCII form
+    /// otherwise. Exposed with an explicit writer so both rendering paths are unit testable.
+    /// </summary>
+    internal static void DisplayBanner(TextWriter writer, bool useColor)
     {
-        var useColor = UseEmoji; // Same check - modern terminals support both
         var version = VersionHelper.GetVersionString();
 
         if (useColor)
         {
-            DisplayColorBanner(version);
+            DisplayColorBanner(writer, version);
         }
         else
         {
-            DisplayPlainBanner(version);
+            DisplayPlainBanner(writer, version);
         }
     }
 
-    private static void DisplayColorBanner(string version)
+    private static void DisplayColorBanner(TextWriter writer, string version)
     {
         var titleLines = TitleBlockArt;
-        Console.WriteLine();
+        writer.WriteLine();
 
         // Display each line with a gradient color
         for (int i = 0; i < titleLines.Length; i++)
         {
             var color = GradientColors[i % GradientColors.Length];
-            Console.WriteLine($" {color}{titleLines[i]}{ResetColor}");
+            writer.WriteLine($" {color}{titleLines[i]}{ResetColor}");
         }
 
-        Console.WriteLine();
-        Console.WriteLine($" \x1b[90mWindows App Development CLI · Version {version}{ResetColor}");
+        writer.WriteLine();
+        writer.WriteLine($" \x1b[90mWindows App Development CLI · Version {version}{ResetColor}");
     }
 
-    private static void DisplayPlainBanner(string version)
+    private static void DisplayPlainBanner(TextWriter writer, string version)
     {
         foreach (var line in TitleAsciiArt)
         {
-            Console.WriteLine($" {line}");
+            writer.WriteLine($" {line}");
         }
 
-        Console.WriteLine($" Windows App Development CLI - Version {version}");
+        writer.WriteLine($" Windows App Development CLI - Version {version}");
     }
 
 }

--- a/src/winapp-CLI/WinApp.Cli/Helpers/LongPathHelper.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/LongPathHelper.cs
@@ -19,18 +19,38 @@ internal static class LongPathHelper
     /// Checks whether the system-level long path support is enabled via the
     /// <c>HKLM\SYSTEM\CurrentControlSet\Control\FileSystem\LongPathsEnabled</c> registry key.
     /// </summary>
-    internal static bool IsSystemLongPathEnabled()
+    internal static bool IsSystemLongPathEnabled() => IsSystemLongPathEnabled(ReadLongPathsEnabledValue);
+
+    /// <summary>
+    /// Core of <see cref="IsSystemLongPathEnabled()"/> with the registry read injected as
+    /// <paramref name="readLongPathsEnabledValue"/> (returning the raw <c>LongPathsEnabled</c> value,
+    /// or <c>null</c> when the key or value is absent). Long path support counts as enabled only when
+    /// the value is the integer <c>1</c>; any other value, an absent value, or a read failure yields
+    /// <c>false</c>. The seam lets unit tests drive every branch without depending on the machine's
+    /// registry state.
+    /// </summary>
+    internal static bool IsSystemLongPathEnabled(Func<object?> readLongPathsEnabledValue)
     {
         try
         {
-            using var hklm = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry64);
-            using var key = hklm.OpenSubKey(@"SYSTEM\CurrentControlSet\Control\FileSystem");
-            return key?.GetValue("LongPathsEnabled") is int value && value == 1;
+            return readLongPathsEnabledValue() is int value && value == 1;
         }
         catch
         {
             return false;
         }
+    }
+
+    /// <summary>
+    /// Reads the raw <c>LongPathsEnabled</c> value from HKLM, or returns <c>null</c> when the
+    /// <c>FileSystem</c> key or the value is absent. This is the production reader injected into
+    /// <see cref="IsSystemLongPathEnabled(Func{object})"/>.
+    /// </summary>
+    private static object? ReadLongPathsEnabledValue()
+    {
+        using var hklm = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry64);
+        using var key = hklm.OpenSubKey(@"SYSTEM\CurrentControlSet\Control\FileSystem");
+        return key?.GetValue("LongPathsEnabled");
     }
 
     /// <summary>
@@ -225,6 +245,9 @@ internal static class LongPathHelper
             fixed (char* pBuffer = buffer)
             {
                 var result = PInvoke.GetShortPathName(pInput, new Windows.Win32.Foundation.PWSTR(pBuffer), bufferSize);
+                // Honest-uncovered native guard: the fill call only fails here if GetShortPathName
+                // succeeded sizing (non-zero buffer) but then returned 0 — an inconsistent native
+                // failure not deterministically reproducible from a unit test. Kept for safety.
                 if (result == 0)
                 {
                     return null;

--- a/src/winapp-CLI/WinApp.Cli/Helpers/LongPathHelper.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/LongPathHelper.cs
@@ -40,12 +40,22 @@ internal static class LongPathHelper
     /// </summary>
     internal static void ValidatePathLength(string path)
     {
+        ValidatePathLength(path, IsSystemLongPathEnabled());
+    }
+
+    /// <summary>
+    /// Pure core of <see cref="ValidatePathLength(string)"/>: throws when <paramref name="path"/>
+    /// exceeds MAX_PATH and <paramref name="longPathEnabled"/> is <c>false</c>. Split out so the
+    /// throwing branch is unit testable without depending on the machine's registry state.
+    /// </summary>
+    internal static void ValidatePathLength(string path, bool longPathEnabled)
+    {
         if (path.Length <= MaxPath)
         {
             return;
         }
 
-        if (!IsSystemLongPathEnabled())
+        if (!longPathEnabled)
         {
             throw new InvalidOperationException(
                 $"The path exceeds the Windows MAX_PATH limit of {MaxPath} characters and long path support is not enabled on this system. Visit https://aka.ms/enable-long-paths-on-windows for guidance on enabling long paths.");
@@ -87,7 +97,15 @@ internal static class LongPathHelper
     /// Returns the original path unchanged if it is already within MAX_PATH or if 8.3 name
     /// generation is not available.
     /// </summary>
-    internal static string GetShortPath(string path)
+    internal static string GetShortPath(string path) => GetShortPath(path, NativeGetShortPathName);
+
+    /// <summary>
+    /// Core of <see cref="GetShortPath(string)"/> with the native 8.3 shortener injected as
+    /// <paramref name="shortener"/> (returning the shortened path, or <c>null</c> when it cannot
+    /// shorten). The seam lets unit tests drive the prefix-stripping and failure paths without
+    /// depending on the volume's 8.3 name-generation state.
+    /// </summary>
+    internal static string GetShortPath(string path, Func<string, string?> shortener)
     {
         if (path.Length <= MaxPath)
         {
@@ -103,7 +121,7 @@ internal static class LongPathHelper
             return path;
         }
 
-        var shortDir = GetShortPathRaw(directory);
+        var shortDir = GetShortPathRaw(directory, shortener);
         var result = Path.Combine(shortDir, fileName);
 
         // Preserve trailing separator: Path.Combine drops it when fileName is empty
@@ -140,57 +158,80 @@ internal static class LongPathHelper
     }
 
     /// <summary>
-    /// Converts an entire path (including filename) to its short (8.3) form.
+    /// Converts an entire path (including filename) to its short (8.3) form via the injected
+    /// <paramref name="shortener"/>, then strips the extended-length prefix. Returns the original
+    /// path unchanged when the shortener cannot shorten it (returns <c>null</c>) or is unavailable.
     /// </summary>
-    private static string GetShortPathRaw(string path)
+    private static string GetShortPathRaw(string path, Func<string, string?> shortener)
     {
         // GetShortPathName needs the \\?\ prefix to accept paths > MAX_PATH
         var extendedPath = EnsureExtendedLengthPrefix(path);
 
+        string? shortPath;
         try
         {
-            unsafe
-            {
-                fixed (char* pInput = extendedPath)
-                {
-                    var bufferSize = PInvoke.GetShortPathName(pInput, null, 0);
-                    if (bufferSize == 0)
-                    {
-                        return path;
-                    }
-
-                    Span<char> buffer = stackalloc char[(int)bufferSize];
-                    fixed (char* pBuffer = buffer)
-                    {
-                        var result = PInvoke.GetShortPathName(pInput, new Windows.Win32.Foundation.PWSTR(pBuffer), bufferSize);
-                        if (result == 0)
-                        {
-                            return path;
-                        }
-
-                        var shortPath = new string(pBuffer, 0, (int)result);
-
-                        // Strip the extended-length prefix added by EnsureExtendedLengthPrefix.
-                        // \\?\UNC\server\share\... must be converted back to \\server\share\...
-                        // not to UNC\server\share\... (which would be invalid).
-                        if (shortPath.StartsWith(ExtendedLengthUncPrefix, StringComparison.Ordinal))
-                        {
-                            shortPath = @"\\" + shortPath[ExtendedLengthUncPrefix.Length..];
-                        }
-                        else if (shortPath.StartsWith(ExtendedLengthPathPrefix, StringComparison.Ordinal))
-                        {
-                            shortPath = shortPath[ExtendedLengthPathPrefix.Length..];
-                        }
-
-                        return shortPath;
-                    }
-                }
-            }
+            shortPath = shortener(extendedPath);
         }
         catch (DllNotFoundException)
         {
             // GetShortPathName is not available on this platform; return the original path unchanged.
             return path;
+        }
+
+        if (shortPath is null)
+        {
+            return path;
+        }
+
+        return StripExtendedPrefix(shortPath);
+    }
+
+    /// <summary>
+    /// Strips the extended-length prefix that <see cref="EnsureExtendedLengthPrefix"/> may have added.
+    /// <c>\\?\UNC\server\share\...</c> must be converted back to <c>\\server\share\...</c> (not to
+    /// <c>UNC\server\share\...</c> which would be invalid). Extracted as a pure function for testing.
+    /// </summary>
+    internal static string StripExtendedPrefix(string shortPath)
+    {
+        if (shortPath.StartsWith(ExtendedLengthUncPrefix, StringComparison.Ordinal))
+        {
+            return @"\\" + shortPath[ExtendedLengthUncPrefix.Length..];
+        }
+
+        if (shortPath.StartsWith(ExtendedLengthPathPrefix, StringComparison.Ordinal))
+        {
+            return shortPath[ExtendedLengthPathPrefix.Length..];
+        }
+
+        return shortPath;
+    }
+
+    /// <summary>
+    /// Invokes the Win32 <c>GetShortPathName</c> API. Returns the shortened path, or <c>null</c>
+    /// when the API reports failure (buffer size 0). This is the production shortener injected into
+    /// <see cref="GetShortPath(string, Func{string, string?})"/>.
+    /// </summary>
+    private static unsafe string? NativeGetShortPathName(string extendedPath)
+    {
+        fixed (char* pInput = extendedPath)
+        {
+            var bufferSize = PInvoke.GetShortPathName(pInput, null, 0);
+            if (bufferSize == 0)
+            {
+                return null;
+            }
+
+            Span<char> buffer = stackalloc char[(int)bufferSize];
+            fixed (char* pBuffer = buffer)
+            {
+                var result = PInvoke.GetShortPathName(pInput, new Windows.Win32.Foundation.PWSTR(pBuffer), bufferSize);
+                if (result == 0)
+                {
+                    return null;
+                }
+
+                return new string(pBuffer, 0, (int)result);
+            }
         }
     }
 }

--- a/src/winapp-CLI/WinApp.Cli/Helpers/ProgressDisplay.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/ProgressDisplay.cs
@@ -26,35 +26,61 @@ internal static class ProgressDisplay
     /// </summary>
     public static bool ShouldUseLiveSpinner(IAnsiConsole ansiConsole, ILogger logger)
     {
+        // Reuse the existing telemetry-side detection so CI/agent classification stays
+        // in sync with how we already report sender origin.
+        var (senderOrigin, _) = AgentEnvironmentDetector.Detect();
+
+        // Spectre's own probe is the most reliable terminal capability check: it covers
+        // NO_COLOR, TERM=dumb, and stream redirection consistently.
+        var profile = ansiConsole.Profile;
+
+        return ShouldUseLiveSpinner(
+            infoEnabled: logger.IsEnabled(LogLevel.Information),
+            senderOrigin: senderOrigin,
+            interactiveCapability: profile.Capabilities.Interactive,
+            ansiCapability: profile.Capabilities.Ansi,
+            outputRedirected: Console.IsOutputRedirected,
+            userInteractive: Environment.UserInteractive);
+    }
+
+    /// <summary>
+    /// Pure decision core for <see cref="ShouldUseLiveSpinner(IAnsiConsole, ILogger)"/>, expressed
+    /// over already-probed inputs so every branch can be unit tested without a real console or
+    /// environment. Returns <c>false</c> when info output is suppressed, when running under a CI
+    /// or AI-agent origin, when the terminal lacks interactive/ANSI capability, or when output is
+    /// redirected; otherwise defers to whether the process is attached to an interactive user.
+    /// </summary>
+    internal static bool ShouldUseLiveSpinner(
+        bool infoEnabled,
+        string senderOrigin,
+        bool interactiveCapability,
+        bool ansiCapability,
+        bool outputRedirected,
+        bool userInteractive)
+    {
         // Nothing to show when info-level output is suppressed (--quiet, --json).
-        if (!logger.IsEnabled(LogLevel.Information))
+        if (!infoEnabled)
         {
             return false;
         }
 
-        // Reuse the existing telemetry-side detection so CI/agent classification stays
-        // in sync with how we already report sender origin.
-        var (senderOrigin, _) = AgentEnvironmentDetector.Detect();
         if (senderOrigin == AgentEnvironmentDetector.SenderOrigins.Agent ||
             senderOrigin == AgentEnvironmentDetector.SenderOrigins.CI)
         {
             return false;
         }
 
-        // Spectre's own probe is the most reliable terminal capability check: it covers
-        // NO_COLOR, TERM=dumb, and stream redirection consistently.
-        var profile = ansiConsole.Profile;
-        if (!profile.Capabilities.Interactive || !profile.Capabilities.Ansi)
+        if (!interactiveCapability || !ansiCapability)
         {
             return false;
         }
 
-        if (Console.IsOutputRedirected)
+        if (outputRedirected)
         {
             return false;
         }
 
-        return Environment.UserInteractive;
+        return userInteractive;
     }
 }
 

--- a/src/winapp-CLI/WinApp.Cli/Helpers/ShellIcon.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/ShellIcon.cs
@@ -14,54 +14,86 @@ public static class ShellIcon
     /// Gets the "Jumbo" (typically 256x256) shell icon for a file path (exe/dll/anything).
     /// Returns null if no icon can be resolved.
     /// </summary>
-    public static Icon? GetJumboIcon(string path)
+    public static Icon? GetJumboIcon(string path) =>
+        GetJumboIconCore(path, GetSystemIconIndex, GetIconFromJumboImageList);
+
+    /// <summary>
+    /// Pure orchestration seam for <see cref="GetJumboIcon"/>: resolves the system icon index for
+    /// <paramref name="path"/>, returns null when the shell reports no icon, otherwise materializes
+    /// the jumbo icon. Any exception from the resolvers is swallowed and reported as null. The
+    /// resolver delegates are injected so tests can drive the no-icon, success, and failure paths
+    /// without invoking the native shell APIs.
+    /// </summary>
+    internal static Icon? GetJumboIconCore(
+        string path,
+        Func<string, int?> getSystemIconIndex,
+        Func<int, Icon?> getIconFromImageList)
     {
         try
         {
             // 1) Get the system image list index for this file (Explorer uses this)
-            SHFILEINFOW sfi = new();
-            // SHGFI_SYSICONINDEX gives us sfi.iIcon
-            var flags = SHGFI_FLAGS.SHGFI_SYSICONINDEX;
-            var result = PInvoke.SHGetFileInfo(path, 0, ref sfi, flags);
-            if (result == 0)
+            int? iconIndex = getSystemIconIndex(path);
+            if (iconIndex is null)
             {
                 return null;
             }
 
-            // 2) Ask for the Jumbo image list
-            // CsWin32 exposes SHGetImageList and IImageList
-            var hr = PInvoke.SHGetImageList((int)PInvoke.SHIL_JUMBO, typeof(IImageList2).GUID, out object ppvObj);
-            IImageList2 imageList = (IImageList2)ppvObj;
-            if (hr.Failed || imageList is null)
-            {
-                return null;
-            }
-
-            // 3) Get an HICON for that index
-            // Use ILD_IMAGE to preserve full color depth and alpha channel
-            DestroyIconSafeHandle? hIcon = null;
-            try
-            {
-                imageList.GetIcon(sfi.iIcon, (uint)IMAGE_LIST_DRAW_STYLE.ILD_IMAGE, out hIcon);
-
-                // Clone the icon to create a copy that owns its own data
-                // Icon.FromHandle doesn't own the handle, so we must clone before disposing hIcon
-                using var tempIcon = Icon.FromHandle(hIcon.DangerousGetHandle());
-                return (Icon)tempIcon.Clone();
-            }
-            finally
-            {
-                if (ppvObj is System.Runtime.InteropServices.Marshalling.ComObject comObj)
-                {
-                    comObj.FinalRelease();
-                }
-                hIcon?.Dispose();
-            }
+            // 2+3) Resolve an HICON for that index from the Jumbo image list and clone it
+            return getIconFromImageList(iconIndex.Value);
         }
         catch
         {
             // Swallow all exceptions and return null if anything goes wrong
             return null;
+        }
+    }
+
+    /// <summary>
+    /// Returns the system image-list icon index for <paramref name="path"/>, or null when the shell
+    /// cannot resolve one (SHGetFileInfo returns 0).
+    /// </summary>
+    private static int? GetSystemIconIndex(string path)
+    {
+        SHFILEINFOW sfi = new();
+        // SHGFI_SYSICONINDEX gives us sfi.iIcon
+        var result = PInvoke.SHGetFileInfo(path, 0, ref sfi, SHGFI_FLAGS.SHGFI_SYSICONINDEX);
+        return result == 0 ? null : sfi.iIcon;
+    }
+
+    /// <summary>
+    /// Materializes a standalone <see cref="Icon"/> for the given system image-list index from the
+    /// Jumbo image list, or null when the image list cannot be obtained.
+    /// </summary>
+    private static Icon? GetIconFromJumboImageList(int iconIndex)
+    {
+        // CsWin32 exposes SHGetImageList and IImageList
+        var hr = PInvoke.SHGetImageList((int)PInvoke.SHIL_JUMBO, typeof(IImageList2).GUID, out object ppvObj);
+        IImageList2 imageList = (IImageList2)ppvObj;
+        // Defensive guard: the system Jumbo image list is always available on a real desktop, so this
+        // failure branch is not reachable from a test without a broken shell. Kept for safety.
+        if (hr.Failed || imageList is null)
+        {
+            return null;
+        }
+
+        // Use ILD_IMAGE to preserve full color depth and alpha channel
+        DestroyIconSafeHandle? hIcon = null;
+        try
+        {
+            imageList.GetIcon(iconIndex, (uint)IMAGE_LIST_DRAW_STYLE.ILD_IMAGE, out hIcon);
+
+            // Clone the icon to create a copy that owns its own data
+            // Icon.FromHandle doesn't own the handle, so we must clone before disposing hIcon
+            using var tempIcon = Icon.FromHandle(hIcon.DangerousGetHandle());
+            return (Icon)tempIcon.Clone();
+        }
+        finally
+        {
+            if (ppvObj is System.Runtime.InteropServices.Marshalling.ComObject comObj)
+            {
+                comObj.FinalRelease();
+            }
+            hIcon?.Dispose();
         }
     }
 }

--- a/src/winapp-CLI/WinApp.Cli/Helpers/SystemDefaultsHelper.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/SystemDefaultsHelper.cs
@@ -19,7 +19,16 @@ internal static partial class SystemDefaultsHelper
 
     public static string GetDefaultPublisherCN()
     {
-        var user = Environment.UserName;
+        return BuildPublisherCN(Environment.UserName);
+    }
+
+    /// <summary>
+    /// Builds a <c>CN=</c> publisher value from an OS user name, falling back to
+    /// <c>"Developer"</c> when the name is missing or whitespace. Extracted as a pure
+    /// function so the whitespace-fallback branch can be unit tested deterministically.
+    /// </summary>
+    internal static string BuildPublisherCN(string? user)
+    {
         if (string.IsNullOrWhiteSpace(user))
         {
             user = "Developer";

--- a/src/winapp-CLI/WinApp.Cli/Helpers/VersionHelper.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/VersionHelper.cs
@@ -19,8 +19,20 @@ internal static class VersionHelper
     {
         var assembly = Assembly.GetExecutingAssembly();
 
-        // Try to get informational version first (includes git info if available)
         var infoVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        var version = assembly.GetName().Version;
+        return FormatVersion(infoVersion, version);
+    }
+
+    /// <summary>
+    /// Formats a version string from the informational version (preferred, with any git-hash
+    /// suffix stripped) or falls back to the numeric assembly version, then to <c>"0.0.0"</c>.
+    /// Extracted as a pure function so the fallback branches can be unit tested without the
+    /// runtime assembly's fixed attributes.
+    /// </summary>
+    internal static string FormatVersion(string? infoVersion, Version? asmVersion)
+    {
+        // Try to get informational version first (includes git info if available)
         if (!string.IsNullOrEmpty(infoVersion))
         {
             // Remove git hash suffix if present (e.g., "0.1.8+abc123" -> "0.1.8")
@@ -29,7 +41,6 @@ internal static class VersionHelper
         }
 
         // Fall back to assembly version
-        var version = assembly.GetName().Version;
-        return version != null ? $"{version.Major}.{version.Minor}.{version.Build}" : "0.0.0";
+        return asmVersion != null ? $"{asmVersion.Major}.{asmVersion.Minor}.{asmVersion.Build}" : "0.0.0";
     }
 }

--- a/src/winapp-CLI/WinApp.Cli/Program.cs
+++ b/src/winapp-CLI/WinApp.Cli/Program.cs
@@ -153,21 +153,35 @@ internal static class Program
     /// error plus exit code 1. The <paramref name="invoke"/> seam lets tests exercise both the
     /// success and top-level-failure paths without needing a real, throwing command.
     /// </summary>
+    internal static Task<int> RunWithTelemetryAsync(
+        System.CommandLine.ParseResult parsedArgs, bool isCompleteMode, Func<Task<int>> invoke) =>
+        RunWithTelemetryAsync(parsedArgs, isCompleteMode, invoke, CommandInvokedEvent.Log, CommandCompletedEvent.Log);
+
+    /// <summary>
+    /// Core of <see cref="RunWithTelemetryAsync(System.CommandLine.ParseResult, bool, Func{Task{int}})"/>
+    /// with the telemetry sinks injected. <paramref name="logCommandInvoked"/> and
+    /// <paramref name="logCommandCompleted"/> default (via the public overload) to the production
+    /// <see cref="CommandInvokedEvent.Log"/>/<see cref="CommandCompletedEvent.Log"/> events; the seam
+    /// lets tests assert that the invoked/completed events fire around the invocation — in order, with
+    /// the parsed command result and real exit code, and only when not in completion mode.
+    /// </summary>
     internal static async Task<int> RunWithTelemetryAsync(
-        System.CommandLine.ParseResult parsedArgs, bool isCompleteMode, Func<Task<int>> invoke)
+        System.CommandLine.ParseResult parsedArgs, bool isCompleteMode, Func<Task<int>> invoke,
+        Action<System.CommandLine.Parsing.CommandResult> logCommandInvoked,
+        Action<System.CommandLine.Parsing.CommandResult, int> logCommandCompleted)
     {
         try
         {
             if (!isCompleteMode)
             {
-                CommandInvokedEvent.Log(parsedArgs.CommandResult);
+                logCommandInvoked(parsedArgs.CommandResult);
             }
 
             var returnCode = await invoke();
 
             if (!isCompleteMode)
             {
-                CommandCompletedEvent.Log(parsedArgs.CommandResult, returnCode);
+                logCommandCompleted(parsedArgs.CommandResult, returnCode);
             }
 
             return returnCode;

--- a/src/winapp-CLI/WinApp.Cli/Program.cs
+++ b/src/winapp-CLI/WinApp.Cli/Program.cs
@@ -26,55 +26,22 @@ internal static class Program
         }
 
         // Ensure UTF-8 I/O for emoji-capable terminals; fall back silently if not supported
-        try
+        ConfigureConsoleEncoding(static () =>
         {
             Console.OutputEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
             Console.InputEncoding = Encoding.UTF8;
-        }
-        catch
-        {
-            // ignore
-        }
+        });
 
-        var minimumLogLevel = LogLevel.Information;
-        bool quiet = false;
-        bool verbose = false;
-        bool json = false;
-
-        // Pre-scan argv for the global logging-mode flags. The scan stops at the first
-        // standalone '--' separator so that passthrough payload (e.g. `winapp run . --
-        // --json`) is not misread as a winapp global flag.
-        if (GlobalOptionPreScan.IsFlagPresent(args, WinAppRootCommand.VerboseOption.Name, WinAppRootCommand.VerboseOption.Aliases))
+        var loggingMode = ResolveLoggingMode(args);
+        if (loggingMode.ConflictError is not null)
         {
-            minimumLogLevel = LogLevel.Debug;
-            verbose = true;
-        }
-        if (GlobalOptionPreScan.IsFlagPresent(args, WinAppRootCommand.QuietOption.Name, WinAppRootCommand.QuietOption.Aliases))
-        {
-            minimumLogLevel = LogLevel.Warning;
-            quiet = true;
-        }
-        if (GlobalOptionPreScan.IsFlagPresent(args, WinAppRootCommand.JsonOption.Name, WinAppRootCommand.JsonOption.Aliases))
-        {
-            minimumLogLevel = LogLevel.None;
-            json = true;
-        }
-
-        if (quiet && verbose)
-        {
-            Console.Error.WriteLine($"Cannot specify both --quiet and --verbose options together.");
+            Console.Error.WriteLine(loggingMode.ConflictError);
             return 1;
         }
-        else if (quiet && json)
-        {
-            Console.Error.WriteLine($"Cannot specify both --quiet and --json options together.");
-            return 1;
-        }
-        else if (verbose && json)
-        {
-            Console.Error.WriteLine($"Cannot specify both --verbose and --json options together.");
-            return 1;
-        }
+
+        var minimumLogLevel = loggingMode.MinimumLevel;
+        bool quiet = loggingMode.Quiet;
+        bool json = loggingMode.Json;
 
         // Check if --cli-schema is specified - this outputs machine-readable JSON
         // and should not display any interactive messages like first-run notices
@@ -160,6 +127,35 @@ internal static class Program
             }
         }
 
+        return await RunWithTelemetryAsync(parsedArgs, isCompleteMode, () => parsedArgs.InvokeAsync());
+    }
+
+    /// <summary>
+    /// Applies the given console-encoding mutation, swallowing the platform exception that occurs
+    /// when the standard stream encoding cannot be changed (e.g. redirected or unsupported handles).
+    /// UTF-8 I/O is a best-effort nicety, so a failure here must never abort startup.
+    /// </summary>
+    internal static void ConfigureConsoleEncoding(Action apply)
+    {
+        try
+        {
+            apply();
+        }
+        catch
+        {
+            // ignore
+        }
+    }
+
+    /// <summary>
+    /// Runs the parsed command via <paramref name="invoke"/>, emitting command-invoked/-completed
+    /// telemetry (unless in completion mode) and converting any unhandled exception into a logged
+    /// error plus exit code 1. The <paramref name="invoke"/> seam lets tests exercise both the
+    /// success and top-level-failure paths without needing a real, throwing command.
+    /// </summary>
+    internal static async Task<int> RunWithTelemetryAsync(
+        System.CommandLine.ParseResult parsedArgs, bool isCompleteMode, Func<Task<int>> invoke)
+    {
         try
         {
             if (!isCompleteMode)
@@ -167,7 +163,7 @@ internal static class Program
                 CommandInvokedEvent.Log(parsedArgs.CommandResult);
             }
 
-            var returnCode = await parsedArgs.InvokeAsync();
+            var returnCode = await invoke();
 
             if (!isCompleteMode)
             {
@@ -182,5 +178,59 @@ internal static class Program
             Console.Error.WriteLine($"An unexpected error occurred: {ex.Message}");
             return 1;
         }
+    }
+
+    /// <summary>
+    /// The global logging mode resolved from argv: the minimum log level plus the individual
+    /// <c>--quiet</c>/<c>--verbose</c>/<c>--json</c> flags, and a non-null <see cref="ConflictError"/>
+    /// message when a mutually-exclusive combination was requested.
+    /// </summary>
+    internal readonly record struct LoggingMode(LogLevel MinimumLevel, bool Quiet, bool Verbose, bool Json, string? ConflictError);
+
+    /// <summary>
+    /// Pre-scans argv for the global logging-mode flags and resolves the effective
+    /// <see cref="LoggingMode"/>. The scan (via <see cref="GlobalOptionPreScan"/>) stops at the first
+    /// standalone <c>--</c> separator so passthrough payload (e.g. <c>winapp run . -- --json</c>) is
+    /// not misread as a winapp global flag. Extracted from <see cref="Main"/> so the flag precedence
+    /// and mutual-exclusion rules are unit testable without invoking the full entrypoint.
+    /// </summary>
+    internal static LoggingMode ResolveLoggingMode(string[] args)
+    {
+        var minimumLogLevel = LogLevel.Information;
+        bool quiet = false;
+        bool verbose = false;
+        bool json = false;
+
+        if (GlobalOptionPreScan.IsFlagPresent(args, WinAppRootCommand.VerboseOption.Name, WinAppRootCommand.VerboseOption.Aliases))
+        {
+            minimumLogLevel = LogLevel.Debug;
+            verbose = true;
+        }
+        if (GlobalOptionPreScan.IsFlagPresent(args, WinAppRootCommand.QuietOption.Name, WinAppRootCommand.QuietOption.Aliases))
+        {
+            minimumLogLevel = LogLevel.Warning;
+            quiet = true;
+        }
+        if (GlobalOptionPreScan.IsFlagPresent(args, WinAppRootCommand.JsonOption.Name, WinAppRootCommand.JsonOption.Aliases))
+        {
+            minimumLogLevel = LogLevel.None;
+            json = true;
+        }
+
+        string? conflictError = null;
+        if (quiet && verbose)
+        {
+            conflictError = "Cannot specify both --quiet and --verbose options together.";
+        }
+        else if (quiet && json)
+        {
+            conflictError = "Cannot specify both --quiet and --json options together.";
+        }
+        else if (verbose && json)
+        {
+            conflictError = "Cannot specify both --verbose and --json options together.";
+        }
+
+        return new LoggingMode(minimumLogLevel, quiet, verbose, json, conflictError);
     }
 }

--- a/src/winapp-CLI/WinApp.Cli/Services/PeHelper.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/PeHelper.cs
@@ -36,38 +36,55 @@ internal static class PeHelper
 
             ushort machine = (ushort)coff.Machine;
 
-            // Native or mixed-mode case: use the PE machine directly.
-            if (cor is null)
-            {
-                return MapNativeMachine(machine);
-            }
-
-            CorFlags flags = cor.Flags;
-            bool isIlOnly = (flags & CorFlags.ILOnly) != 0;
-            bool requires32Bit = (flags & CorFlags.Requires32Bit) != 0;
-
-            // Managed IL-only assemblies need special handling.
-            // In particular, IL-only I386 without Requires32Bit is effectively AnyCPU/neutral.
-            if (isIlOnly)
-            {
-                return machine switch
-                {
-                    0x014C => requires32Bit ? "x86" : "neutral", // I386
-                    0x8664 => "x64",   // unusual for pure IL-only, but valid to preserve
-                    0x01C0 => "arm",   // ARM
-                    0x01C4 => "arm",   // ARMNT
-                    0xAA64 => "arm64", // ARM64
-                    _ => null
-                };
-            }
-
-            // Mixed-mode / native-entry managed image: machine matters.
-            return MapNativeMachine(machine);
+            return ClassifyArchitecture(machine, cor?.Flags);
         }
         catch
         {
             return null;
         }
+    }
+
+    /// <summary>
+    /// Maps a COFF machine value and optional COR flags to an MSIX-style architecture string.
+    /// Extracted as a pure function (no file I/O) so every native/managed/mixed-mode branch can be
+    /// unit tested directly.
+    /// <list type="bullet">
+    /// <item>When <paramref name="corFlags"/> is <c>null</c> the image is native/mixed-mode and is
+    /// classified from <paramref name="machine"/>.</item>
+    /// <item>Managed IL-only images use the COR flags: I386 + Requires32Bit =&gt; x86, otherwise
+    /// I386 =&gt; neutral (AnyCPU).</item>
+    /// </list>
+    /// Returns <c>null</c> for unsupported architectures.
+    /// </summary>
+    internal static string? ClassifyArchitecture(ushort machine, CorFlags? corFlags)
+    {
+        // Native or mixed-mode case: use the PE machine directly.
+        if (corFlags is null)
+        {
+            return MapNativeMachine(machine);
+        }
+
+        CorFlags flags = corFlags.Value;
+        bool isIlOnly = (flags & CorFlags.ILOnly) != 0;
+        bool requires32Bit = (flags & CorFlags.Requires32Bit) != 0;
+
+        // Managed IL-only assemblies need special handling.
+        // In particular, IL-only I386 without Requires32Bit is effectively AnyCPU/neutral.
+        if (isIlOnly)
+        {
+            return machine switch
+            {
+                0x014C => requires32Bit ? "x86" : "neutral", // I386
+                0x8664 => "x64",   // unusual for pure IL-only, but valid to preserve
+                0x01C0 => "arm",   // ARM
+                0x01C4 => "arm",   // ARMNT
+                0xAA64 => "arm64", // ARM64
+                _ => null
+            };
+        }
+
+        // Mixed-mode / native-entry managed image: machine matters.
+        return MapNativeMachine(machine);
     }
 
     private static string? MapNativeMachine(ushort machine) => machine switch


### PR DESCRIPTION
## Summary

Raises **Debug line coverage to ≥95%** across the CLI's helpers, the `Program` entrypoint, and the parser/host infrastructure — **25 files**. This is part of the wave-2 CLI test-coverage effort.

The change is **test-only** except for a set of minimal, behavior-preserving *test seams* (pure-function extractions and OS-boundary delegates). **No `[ExcludeFromCodeCoverage]`, no behavior changes, nothing weakened.**

## Per-file Debug line coverage (generated code excluded)

Files that needed work (before → after):

| File | Before | After |
|---|---|---|
| BannerHelper.cs | 52.2% | 96.0% |
| AuthenticodeVerifier.cs | 67.1% | 97.2% |
| Program.cs | 68.4% | 98.5% |
| ShellIcon.cs | 75.9% | 94.4%* |
| LongPathHelper.cs | 78.9% | **98.1%** |
| VersionHelper.cs | 80.0% | 100% |
| TextWriterLogger.cs | 81.1% | 100% |
| SystemDefaultsHelper.cs | 81.2% | 100% |
| OptionTypoValidator.cs | 81.8% | 97.0% |
| PeHelper.cs (Services) | 82.1% | 100% |
| ProgressDisplay.cs | 83.3% | 100% |
| ZipRangeExtractor.cs | 86.4% | 100% |
| PathSafety.cs | 86.4% | 95.2% |
| AtomicFile.cs | 92.3% | 100% |
| PublisherDnHelper.cs | 93.7% | 100% |

Already ≥95% at baseline (unchanged; some picked up incidental coverage): FrameworkHint 100, WindowsCommandLine 100, ManifestHelper 100, HostBuilderExtensions 100, GlobalOptionPreScan 100, WinAppParserConfiguration 100, CliSchema 99.3, CustomHelpAction 97.3, PlaceholderHelper 96.9, ExecutionAliasResolver 96.9.

**24/25 ≥95%.** `ShellIcon.cs` (94.4%*) is the single documented native ceiling — see below.

## Behavior-preserving seams (testability only)

Each seam defaults to the original production path (the real P/Invoke / OS call is passed by production code); only the pure decision or boundary is made injectable so unit tests can drive every branch without a live desktop. Same OS-boundary-delegate / pure-function-extraction pattern already used by `Services/UpdateNotificationService.cs`; no visibility widened beyond `internal`.

- `VersionHelper.FormatVersion`, `SystemDefaultsHelper.BuildPublisherCN`, `Services/PeHelper.ClassifyArchitecture`, `ProgressDisplay.ShouldUseLiveSpinner`, `BannerHelper.ComputeUseEmoji` + writer-injected `DisplayBanner` — pure extractions.
- `LongPathHelper`: `ValidatePathLength`, `GetShortPath` (native `GetShortPathName` delegate injected), `StripExtendedPrefix`, and `IsSystemLongPathEnabled(Func<object?>)` with the registry read injected (production passes the real HKLM reader).
- `AuthenticodeVerifier.IsTrustedMicrosoftSigned(path, logger, verifyTrustCore, isMicrosoftSigner)` — the OS `WinVerifyTrust` + signer check are injected; production threads the real delegates. Trust logic is unchanged.
- `Program.cs`: `ConfigureConsoleEncoding`, `ResolveLoggingMode`, `RunWithTelemetryAsync`; `ShellIcon.GetJumboIconCore` with native resolvers injected.

## Documented native ceilings (kept + source-commented, not excluded)

Per the coverage-scope policy, genuinely un-runnable innermost native guards are documented in source rather than excluded:

- **ShellIcon.cs** — the `SHGetImageList` jumbo-image-list-failure guard (2 lines). The system jumbo image list is always present on a real desktop, so the branch is unreachable from a unit test without a broken shell. Deterministic branch coverage of the resolve/short-circuit/failure arms comes from the `GetJumboIconCore` seam tests; the public wrapper test asserts a usable icon or goes `Assert.Inconclusive` (never passes silently on null).
- **Program.cs** — the `XamlTriageRunner` internal-verb dispatch (2 lines), a heavy dbgeng child-process routine unsafe to invoke from a unit test.

No `[ExcludeFromCodeCoverage]` added anywhere; no dead code found to delete.

## Review

This branch was run through the repo's `pr-review` skill before opening. Findings addressed in the latest commit: a tautological `IsSystemLongPathEnabled` assertion replaced with seven real branch-driving tests (value 1/0/other-int/absent/wrong-type/reader-throws + a real-registry determinism check); the `ShellIcon` public-path smoke test made non-vacuous (inconclusive on null); and the duplicated `Program.Main` capture harness extracted into a shared `ProgramMainTestHarness`.

## Testing

- **9 new** test files (BannerHelper, ManifestHelper, PeHelper, Program, ProgressDisplay, ShellIcon, SystemDefaultsHelper, TextWriterLogger, VersionHelper) + **7 extended** (AtomicFile, AuthenticodeVerifier, LongPathHelper, OptionTypoValidator, PathSafety, PublisherDnHelper, ZipRangeExtractor). Every test asserts a real observable outcome.
- Debug build 0/0; Release (product + tests) **0 warnings / 0 errors** (warnings-as-errors).
- No edits to shared `BaseCommandTests` / `Fake*` fixtures.

> The pre-existing `EndToEndTests` failures (needing `src/winapp-npm/dist/cli.js`) and the single UIA console-window skip are environmental and present on `main` — unrelated to this change.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
