### PR TITLE
Test coverage: NuGet/update/install files reverted by #654 (issue #630)

### DIFF
--- a/src/winapp-CLI/WinApp.Cli.Tests/NugetServiceOfflineTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/NugetServiceOfflineTests.cs
@@ -30,6 +30,7 @@ public sealed class NugetServiceOfflineTests : BaseCommandTests
     private DirectoryInfo _nugetGlobal = null!;
     private NugetService _service = null!;
     private Func<string, CancellationToken, Task<HttpResponseMessage>> _originalGet = null!;
+    private Func<string> _originalUserProfile = null!;
     private string? _originalNugetPackages;
     private string? _originalCacheDir;
 
@@ -37,6 +38,7 @@ public sealed class NugetServiceOfflineTests : BaseCommandTests
     public void SetupOffline()
     {
         _originalGet = NugetService.HttpGetAsync;
+        _originalUserProfile = NugetService.GetUserProfileDirectory;
         _originalNugetPackages = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
         _originalCacheDir = Environment.GetEnvironmentVariable("WINAPP_CLI_CACHE_DIRECTORY");
 
@@ -50,6 +52,7 @@ public sealed class NugetServiceOfflineTests : BaseCommandTests
     public void CleanupOffline()
     {
         NugetService.HttpGetAsync = _originalGet;
+        NugetService.GetUserProfileDirectory = _originalUserProfile;
         Environment.SetEnvironmentVariable("NUGET_PACKAGES", _originalNugetPackages);
         Environment.SetEnvironmentVariable("WINAPP_CLI_CACHE_DIRECTORY", _originalCacheDir);
     }
@@ -391,8 +394,10 @@ public sealed class NugetServiceOfflineTests : BaseCommandTests
     [TestMethod]
     public async Task GetPackageDependenciesAsync_ReturnsDirectAndTransitive_ExcludesIgnoredPrefixes()
     {
-        // A -> B (+ ignored System.Text.Json); B -> C. Result should contain B and C but not the
-        // framework/System.* dependency.
+        // A -> B (+ ignored System.Text.Json); B -> C. B is declared as the range "[2.0.0, )" so this
+        // also proves the transitive walk normalizes the range to its minimum version before fetching
+        // B's nuspec (otherwise the malformed URL would 404 and C would be silently dropped). Result
+        // should contain B and C but not the framework/System.* dependency.
         StubNuspecFeed(
             ("a.pkg/1.0.0", NuspecXml("A.Pkg", ("B.Pkg", "[2.0.0, )"), ("System.Text.Json", "8.0.0"))),
             ("b.pkg/2.0.0", NuspecXml("B.Pkg", ("C.Pkg", "3.0.0"))),
@@ -483,17 +488,33 @@ public sealed class NugetServiceOfflineTests : BaseCommandTests
     }
 
     [TestMethod]
-    public void GetNuGetGlobalPackagesDir_NoOverrides_FallsBackToUserProfileNuget()
+    public void GetNuGetGlobalPackagesDir_NoOverrides_FallsBackToUserProfileNugetAndCreatesIt()
     {
         // IsTestOverride() false (WINAPP_CLI_CACHE_DIRECTORY set) and NUGET_PACKAGES cleared =>
-        // the default %USERPROFILE%\.nuget\packages location is returned.
+        // the default %USERPROFILE%\.nuget\packages location is returned. The user-profile lookup is
+        // redirected to a temp directory so the on-demand create-branch runs hermetically, without
+        // mutating the developer's (or CI runner's) real user profile.
         Environment.SetEnvironmentVariable("WINAPP_CLI_CACHE_DIRECTORY", _tempDirectory.FullName);
         Environment.SetEnvironmentVariable("NUGET_PACKAGES", null);
+        var fakeProfile = _tempDirectory.CreateSubdirectory("fakeprofile");
+        NugetService.GetUserProfileDirectory = () => fakeProfile.FullName;
 
         var dir = _service.GetNuGetGlobalPackagesDir();
 
-        var expectedSuffix = Path.Combine(".nuget", "packages");
-        StringAssert.EndsWith(dir.FullName, expectedSuffix, StringComparison.OrdinalIgnoreCase);
+        var expected = Path.Combine(fakeProfile.FullName, ".nuget", "packages");
+        Assert.AreEqual(expected, dir.FullName);
+        Assert.IsTrue(dir.Exists, "The default .nuget/packages directory should be created on demand.");
+    }
+
+    [TestMethod]
+    public void GetUserProfileDirectory_Default_ResolvesToWindowsUserProfile()
+    {
+        // Pins the seam's production default: with no override it must resolve to the real
+        // %USERPROFILE% so the computed NuGet global-packages path stays byte-for-byte the
+        // same as the pre-seam behavior. CleanupOffline restores the default before each test.
+        Assert.AreEqual(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            NugetService.GetUserProfileDirectory());
     }
 
     // ───────────────────────────────────── helpers ─────────────────────────────────────
@@ -508,14 +529,19 @@ public sealed class NugetServiceOfflineTests : BaseCommandTests
         File.WriteAllText(Path.Combine(dir, $"{lowerId}.nuspec"), nuspec);
     }
 
-    /// <summary>Serves each requested .nupkg by matching "<id>/<version>" in the flat-container URL.</summary>
+    /// <summary>
+    /// Serves each requested .nupkg by matching the slash-delimited <c>/&lt;id&gt;/&lt;version&gt;/</c>
+    /// path segment in the flat-container URL. Matching the surrounding slashes (rather than a bare
+    /// substring) means a malformed request such as <c>/pkg/1.2.3, /</c> — which a raw range that was
+    /// never normalized would produce — correctly misses and 404s instead of being silently served.
+    /// </summary>
     private static void StubNupkgFeed(params (string idVersionSegment, byte[] bytes)[] packages)
     {
         NugetService.HttpGetAsync = (url, _) =>
         {
             foreach (var (segment, bytes) in packages)
             {
-                if (url.Contains(segment, StringComparison.Ordinal))
+                if (url.Contains($"/{segment}/", StringComparison.Ordinal))
                 {
                     return Task.FromResult(BytesResponse(bytes));
                 }
@@ -524,14 +550,18 @@ public sealed class NugetServiceOfflineTests : BaseCommandTests
         };
     }
 
-    /// <summary>Serves each requested .nuspec by matching "<id>/<version>" in the flat-container URL.</summary>
+    /// <summary>
+    /// Serves each requested .nuspec by matching the slash-delimited <c>/&lt;id&gt;/&lt;version&gt;/</c>
+    /// path segment in the flat-container URL (see <see cref="StubNupkgFeed"/> for why the surrounding
+    /// slashes matter — an unnormalized range would build a malformed URL that must not match).
+    /// </summary>
     private static void StubNuspecFeed(params (string idVersionSegment, string nuspec)[] nuspecs)
     {
         NugetService.HttpGetAsync = (url, _) =>
         {
             foreach (var (segment, nuspec) in nuspecs)
             {
-                if (url.Contains(segment, StringComparison.Ordinal))
+                if (url.Contains($"/{segment}/", StringComparison.Ordinal))
                 {
                     return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                     {

--- a/src/winapp-CLI/WinApp.Cli.Tests/NugetServiceOfflineTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/NugetServiceOfflineTests.cs
@@ -1,0 +1,615 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using System.IO.Compression;
+using System.Net;
+using System.Text;
+using WinApp.Cli.Services;
+
+namespace WinApp.Cli.Tests;
+
+/// <summary>
+/// Offline, deterministic tests for <see cref="NugetService"/> that redirect the flat-container
+/// and registration HTTP GETs through the <see cref="NugetService.HttpGetAsync"/> seam to canned
+/// in-memory responses (a purpose-built <c>.nupkg</c>, <c>.nuspec</c>, and registration
+/// <c>index.json</c>). This exercises the package download/extraction, transitive dependency
+/// resolution, version-listing/paging/filtering, and cache-path logic without any network I/O.
+/// Only the seam's default delegate performs real network I/O.
+/// <para>
+/// Marked <c>[DoNotParallelize]</c> because it swaps the process-wide <see cref="NugetService.HttpGetAsync"/>
+/// seam and, for the cache-path tests, temporarily sets the <c>WINAPP_CLI_CACHE_DIRECTORY</c> /
+/// <c>NUGET_PACKAGES</c> environment variables; both are restored in cleanup.
+/// </para>
+/// </summary>
+[TestClass]
+[DoNotParallelize]
+public sealed class NugetServiceOfflineTests : BaseCommandTests
+{
+    private const string NuspecNs = "http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd";
+
+    private DirectoryInfo _nugetGlobal = null!;
+    private NugetService _service = null!;
+    private Func<string, CancellationToken, Task<HttpResponseMessage>> _originalGet = null!;
+    private string? _originalNugetPackages;
+    private string? _originalCacheDir;
+
+    [TestInitialize]
+    public void SetupOffline()
+    {
+        _originalGet = NugetService.HttpGetAsync;
+        _originalNugetPackages = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+        _originalCacheDir = Environment.GetEnvironmentVariable("WINAPP_CLI_CACHE_DIRECTORY");
+
+        // A throwaway global dir (not %USERPROFILE%\.winapp) so IsTestOverride() routes the real
+        // NugetService cache to <global>\packages, fully isolated from the developer's NuGet cache.
+        _nugetGlobal = _tempDirectory.CreateSubdirectory("nugetglobal");
+        _service = new NugetService(new StubWinappDirectoryService(_nugetGlobal));
+    }
+
+    [TestCleanup]
+    public void CleanupOffline()
+    {
+        NugetService.HttpGetAsync = _originalGet;
+        Environment.SetEnvironmentVariable("NUGET_PACKAGES", _originalNugetPackages);
+        Environment.SetEnvironmentVariable("WINAPP_CLI_CACHE_DIRECTORY", _originalCacheDir);
+    }
+
+    // ─────────────────────────────── InstallPackageAsync ───────────────────────────────
+
+    [TestMethod]
+    public async Task InstallPackageAsync_DownloadsExtractsAndResolvesTransitiveDependency()
+    {
+        // Root depends on Dep; Dep has no dependencies. Both should end up installed on disk.
+        var rootNupkg = BuildNupkg("root.pkg", NuspecXml("Root.Pkg", ("Dep.Pkg", "[2.0.0, )")));
+        var depNupkg = BuildNupkg("dep.pkg", NuspecXml("Dep.Pkg"));
+
+        StubNupkgFeed(("root.pkg/1.0.0", rootNupkg), ("dep.pkg/2.0.0", depNupkg));
+
+        var installed = await _service.InstallPackageAsync("Root.Pkg", "1.0.0", TestTaskContext, TestContext.CancellationToken);
+
+        Assert.AreEqual("1.0.0", installed["Root.Pkg"], "Main package should be recorded at the requested version.");
+        Assert.AreEqual("2.0.0", installed["Dep.Pkg"], "Transitive dependency should be resolved to its minimum version.");
+        Assert.IsTrue(File.Exists(Path.Combine(PackageDir("root.pkg", "1.0.0"), "root.pkg.nuspec")),
+            "The root package's nuspec should have been extracted to the cache.");
+        Assert.IsTrue(File.Exists(Path.Combine(PackageDir("dep.pkg", "2.0.0"), "dep.pkg.nuspec")),
+            "The dependency package should also have been downloaded and extracted.");
+    }
+
+    [TestMethod]
+    public async Task InstallPackageAsync_PackageAlreadyOnDisk_SkipsDownloadButStillInstallsMissingDependency()
+    {
+        // Pre-materialize Root on disk (with a nuspec that declares Dep) so the download path is
+        // skipped for Root, but Dep is missing and must still be fetched.
+        MaterializePackageOnDisk("root.pkg", "1.0.0", NuspecXml("Root.Pkg", ("Dep.Pkg", "[2.0.0, )")));
+        var depNupkg = BuildNupkg("dep.pkg", NuspecXml("Dep.Pkg"));
+
+        // If Root were (incorrectly) re-downloaded the seam would fail the test by throwing.
+        NugetService.HttpGetAsync = (url, _) =>
+        {
+            if (url.Contains("dep.pkg/2.0.0", StringComparison.Ordinal))
+            {
+                return Task.FromResult(BytesResponse(depNupkg));
+            }
+            Assert.Fail($"Unexpected download of an already-present package: {url}");
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        };
+
+        var installed = await _service.InstallPackageAsync("Root.Pkg", "1.0.0", TestTaskContext, TestContext.CancellationToken);
+
+        Assert.AreEqual("1.0.0", installed["Root.Pkg"]);
+        Assert.AreEqual("2.0.0", installed["Dep.Pkg"], "A missing dependency of an already-present package must still be installed.");
+    }
+
+    [TestMethod]
+    public async Task InstallPackageAsync_DownloadFails_ThrowsInvalidOperationWithStatusCode()
+    {
+        NugetService.HttpGetAsync = (_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+
+        var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(
+            () => _service.InstallPackageAsync("Missing.Pkg", "9.9.9", TestTaskContext, TestContext.CancellationToken));
+
+        StringAssert.Contains(ex.Message, "Missing.Pkg", StringComparison.Ordinal);
+        StringAssert.Contains(ex.Message, "NotFound", StringComparison.Ordinal);
+    }
+
+    [TestMethod]
+    public async Task InstallPackageAsync_MalformedNuspec_StillInstallsMainPackage()
+    {
+        // A nuspec that is not well-formed XML makes dependency resolution throw; that failure is
+        // non-fatal and the main package must remain installed.
+        const string malformed = "<package><metadata><id>Broken.Pkg</id><version>1.0.0"; // unterminated
+        var nupkg = BuildNupkg("broken.pkg", malformed);
+        StubNupkgFeed(("broken.pkg/1.0.0", nupkg));
+
+        var installed = await _service.InstallPackageAsync("Broken.Pkg", "1.0.0", TestTaskContext, TestContext.CancellationToken);
+
+        Assert.AreEqual("1.0.0", installed["Broken.Pkg"]);
+        Assert.HasCount(1, installed, "A malformed nuspec should yield no dependencies but must not fail the install.");
+    }
+
+    [TestMethod]
+    public async Task InstallPackageAsync_NuspecNotNamedForPackage_FallsBackToAnyNuspec()
+    {
+        // The nuspec inside the archive is NOT named "<id>.nuspec"; the reader must fall back to the
+        // first *.nuspec found and still resolve its declared dependency.
+        var rootNupkg = BuildNupkgWithNamedNuspec("differently-named.nuspec", NuspecXml("Root.Pkg", ("Dep.Pkg", "2.0.0")));
+        var depNupkg = BuildNupkg("dep.pkg", NuspecXml("Dep.Pkg"));
+        StubNupkgFeed(("root.pkg/1.0.0", rootNupkg), ("dep.pkg/2.0.0", depNupkg));
+
+        var installed = await _service.InstallPackageAsync("Root.Pkg", "1.0.0", TestTaskContext, TestContext.CancellationToken);
+
+        Assert.AreEqual("2.0.0", installed["Dep.Pkg"], "The fallback *.nuspec lookup should still surface dependencies.");
+    }
+
+    [TestMethod]
+    public async Task InstallPackageAsync_NoNuspecInPackage_InstallsWithoutDependencies()
+    {
+        // Archive contains no nuspec at all -> no dependencies, but the package still installs.
+        var nupkg = BuildNupkgRaw(zip => AddEntry(zip, "lib/net8.0/thing.dll", "binary"));
+        StubNupkgFeed(("bare.pkg/1.0.0", nupkg));
+
+        var installed = await _service.InstallPackageAsync("Bare.Pkg", "1.0.0", TestTaskContext, TestContext.CancellationToken);
+
+        Assert.HasCount(1, installed);
+        Assert.AreEqual("1.0.0", installed["Bare.Pkg"]);
+    }
+
+    [TestMethod]
+    public async Task InstallPackageAsync_NuspecWithoutNamespace_ResolvesDependencies()
+    {
+        var rootNuspec = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <package>
+              <metadata>
+                <id>Root.Pkg</id>
+                <version>1.0.0</version>
+                <dependencies>
+                  <dependency id="Dep.Pkg" version="2.0.0" />
+                </dependencies>
+              </metadata>
+            </package>
+            """;
+        var rootNupkg = BuildNupkg("root.pkg", rootNuspec);
+        var depNupkg = BuildNupkg("dep.pkg", NuspecXml("Dep.Pkg"));
+        StubNupkgFeed(("root.pkg/1.0.0", rootNupkg), ("dep.pkg/2.0.0", depNupkg));
+
+        var installed = await _service.InstallPackageAsync("Root.Pkg", "1.0.0", TestTaskContext, TestContext.CancellationToken);
+
+        Assert.AreEqual("2.0.0", installed["Dep.Pkg"], "Dependencies in a namespace-less nuspec must still be parsed.");
+    }
+
+    [TestMethod]
+    public async Task InstallPackageAsync_DependencyMissingVersionAttribute_IsSkipped()
+    {
+        // The dependency without a version attribute is ignored; the package still installs cleanly.
+        var nuspec = $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <package xmlns="{NuspecNs}">
+              <metadata>
+                <id>Root.Pkg</id>
+                <version>1.0.0</version>
+                <dependencies>
+                  <group targetFramework="net8.0">
+                    <dependency id="NoVersion.Pkg" />
+                  </group>
+                </dependencies>
+              </metadata>
+            </package>
+            """;
+        var nupkg = BuildNupkg("root.pkg", nuspec);
+        StubNupkgFeed(("root.pkg/1.0.0", nupkg));
+
+        var installed = await _service.InstallPackageAsync("Root.Pkg", "1.0.0", TestTaskContext, TestContext.CancellationToken);
+
+        Assert.HasCount(1, installed, "A dependency without a version must be skipped.");
+        Assert.IsFalse(installed.ContainsKey("NoVersion.Pkg"));
+    }
+
+    [TestMethod]
+    public async Task InstallPackageAsync_DiamondDependency_InstallsSharedDependencyOnce()
+    {
+        // Root -> A and B; both A and B depend on the same C. C must be installed once and the
+        // second encounter must hit the "already installed" short-circuit during resolution.
+        var root = BuildNupkg("diamond.root", NuspecXml("Diamond.Root", ("Diamond.A", "1.0.0"), ("Diamond.B", "1.0.0")));
+        var a = BuildNupkg("diamond.a", NuspecXml("Diamond.A", ("Diamond.C", "1.0.0")));
+        var b = BuildNupkg("diamond.b", NuspecXml("Diamond.B", ("Diamond.C", "1.0.0")));
+        var c = BuildNupkg("diamond.c", NuspecXml("Diamond.C"));
+        StubNupkgFeed(
+            ("diamond.root/1.0.0", root),
+            ("diamond.a/1.0.0", a),
+            ("diamond.b/1.0.0", b),
+            ("diamond.c/1.0.0", c));
+
+        var installed = await _service.InstallPackageAsync("Diamond.Root", "1.0.0", TestTaskContext, TestContext.CancellationToken);
+
+        Assert.HasCount(4, installed, "Root + A + B + shared C must each appear exactly once.");
+        Assert.AreEqual("1.0.0", installed["Diamond.C"], "The shared transitive dependency must be present.");
+    }
+
+    // ─────────────────────────── GetLatestVersionAsync / listing ───────────────────────────
+
+    [TestMethod]
+    public async Task GetLatestVersionAsync_InlineItems_ReturnsHighestListedStableVersion()
+    {
+        StubRegistration("some.pkg", InlinePage(
+            ("1.0.0", true),
+            ("2.0.0", true),
+            ("1.5.0", true),
+            ("3.0.0", false))); // unlisted -> excluded despite being highest
+
+        var latest = await _service.GetLatestVersionAsync("Some.Pkg", SdkInstallMode.Stable, TestContext.CancellationToken);
+
+        Assert.AreEqual("2.0.0", latest, "Should pick the highest *listed* stable version.");
+    }
+
+    [TestMethod]
+    public async Task GetLatestVersionAsync_PagedItems_FetchesPageByIdUrl()
+    {
+        // The registration index references a page by @id instead of inlining items.
+        const string pageUrl = "https://example.test/registration/some.pkg/page1.json";
+        var index = "{\"items\":[{\"@id\":\"" + pageUrl + "\"}]}";
+        var page = InlinePage(("1.0.0", true), ("4.2.0", true));
+
+        NugetService.HttpGetAsync = (url, _) => Task.FromResult(
+            url.Contains("page1.json", StringComparison.Ordinal) ? JsonResponse(page) : JsonResponse(index));
+
+        var latest = await _service.GetLatestVersionAsync("Some.Pkg", SdkInstallMode.Stable, TestContext.CancellationToken);
+
+        Assert.AreEqual("4.2.0", latest, "Versions from a separately-fetched registration page must be considered.");
+    }
+
+    [TestMethod]
+    public async Task GetLatestVersionAsync_PageWithoutIdOrItems_IsSkipped()
+    {
+        // First page has neither inline items nor an @id (skipped); second page carries the versions.
+        const string pageUrl = "https://example.test/registration/some.pkg/page2.json";
+        var index = "{\"items\":[{\"count\":0},{\"@id\":\"" + pageUrl + "\"}]}";
+        var page = InlinePage(("1.1.0", true));
+
+        NugetService.HttpGetAsync = (url, _) => Task.FromResult(
+            url.Contains("page2.json", StringComparison.Ordinal) ? JsonResponse(page) : JsonResponse(index));
+
+        var latest = await _service.GetLatestVersionAsync("Some.Pkg", SdkInstallMode.Stable, TestContext.CancellationToken);
+
+        Assert.AreEqual("1.1.0", latest);
+    }
+
+    [TestMethod]
+    public async Task GetLatestVersionAsync_PageWithEmptyIdString_IsSkipped()
+    {
+        // A page carries an @id that is an empty string; it must be skipped, not fetched.
+        var index = "{\"items\":[{\"@id\":\"\"},{" + "\"items\":" + InlineLeaves(("1.2.0", true)) + "}]}";
+
+        StubRegistrationRaw("some.pkg", index);
+
+        var latest = await _service.GetLatestVersionAsync("Some.Pkg", SdkInstallMode.Stable, TestContext.CancellationToken);
+
+        Assert.AreEqual("1.2.0", latest, "The page with a blank @id must be skipped and the inline page used.");
+    }
+
+    [TestMethod]
+    public async Task GetLatestVersionAsync_FetchedPageWithoutItems_IsSkipped()
+    {
+        // The referenced page is fetched but has no "items" array; it is skipped and the inline page wins.
+        const string pageUrl = "https://example.test/registration/some.pkg/empty-page.json";
+        var index = "{\"items\":[{\"@id\":\"" + pageUrl + "\"},{" + "\"items\":" + InlineLeaves(("1.3.0", true)) + "}]}";
+
+        NugetService.HttpGetAsync = (url, _) => Task.FromResult(
+            url.Contains("empty-page.json", StringComparison.Ordinal)
+                ? JsonResponse("{\"count\":0}")
+                : JsonResponse(index));
+
+        var latest = await _service.GetLatestVersionAsync("Some.Pkg", SdkInstallMode.Stable, TestContext.CancellationToken);
+
+        Assert.AreEqual("1.3.0", latest, "A fetched page without items must be skipped, leaving the inline version.");
+    }
+
+    [TestMethod]
+    public async Task GetLatestVersionAsync_LeavesWithoutCatalogEntryOrVersion_AreSkipped()
+    {
+        // A page whose leaves are missing catalogEntry / version / are blank, plus one good entry.
+        var page = "{\"items\":[{\"items\":[" +
+            "{\"foo\":\"bar\"}," +
+            "{\"catalogEntry\":{\"listed\":true}}," +
+            "{\"catalogEntry\":{\"version\":\"\",\"listed\":true}}," +
+            "{\"catalogEntry\":{\"version\":\"2.3.4\",\"listed\":true}}" +
+            "]}]}";
+        StubRegistrationRaw("some.pkg", page);
+
+        var latest = await _service.GetLatestVersionAsync("Some.Pkg", SdkInstallMode.Stable, TestContext.CancellationToken);
+
+        Assert.AreEqual("2.3.4", latest, "Malformed leaves must be skipped, leaving the one valid version.");
+    }
+
+    [TestMethod]
+    public async Task GetLatestVersionAsync_NoItemsProperty_Throws()
+    {
+        StubRegistrationRaw("some.pkg", "{\"count\":0}");
+
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(
+            () => _service.GetLatestVersionAsync("Some.Pkg", SdkInstallMode.Stable, TestContext.CancellationToken));
+    }
+
+    [TestMethod]
+    public async Task GetLatestVersionAsync_NoListedStableVersions_Throws()
+    {
+        // Only a prerelease exists; Stable mode filters it out, leaving an empty candidate set.
+        StubRegistration("some.pkg", InlinePage(("1.0.0-beta", true)));
+
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(
+            () => _service.GetLatestVersionAsync("Some.Pkg", SdkInstallMode.Stable, TestContext.CancellationToken));
+    }
+
+    [TestMethod]
+    public async Task GetLatestVersionAsync_WindowsAppSdk_StableMode_ExcludesPrerelease()
+    {
+        StubRegistration("microsoft.windowsappsdk", InlinePage(
+            ("1.5.0", true),
+            ("1.6.0-preview1", true),
+            ("1.6.0-experimental1", true)));
+
+        var latest = await _service.GetLatestVersionAsync("Microsoft.WindowsAppSDK", SdkInstallMode.Stable, TestContext.CancellationToken);
+
+        Assert.AreEqual("1.5.0", latest, "Stable mode must exclude preview/experimental SDK builds.");
+    }
+
+    [TestMethod]
+    public async Task GetLatestVersionAsync_WindowsAppSdk_PreviewMode_ReturnsPreviewOnly()
+    {
+        StubRegistration("microsoft.windowsappsdk", InlinePage(
+            ("1.5.0", true),
+            ("1.6.0-preview1", true),
+            ("1.6.0-experimental1", true)));
+
+        var latest = await _service.GetLatestVersionAsync("Microsoft.WindowsAppSDK", SdkInstallMode.Preview, TestContext.CancellationToken);
+
+        Assert.AreEqual("1.6.0-preview1", latest, "Preview mode must keep only -preview SDK builds.");
+    }
+
+    [TestMethod]
+    public async Task GetLatestVersionAsync_WindowsAppSdk_ExperimentalMode_ReturnsExperimentalOnly()
+    {
+        StubRegistration("microsoft.windowsappsdk", InlinePage(
+            ("1.5.0", true),
+            ("1.6.0-preview1", true),
+            ("1.6.0-experimental1", true)));
+
+        var latest = await _service.GetLatestVersionAsync("Microsoft.WindowsAppSDK", SdkInstallMode.Experimental, TestContext.CancellationToken);
+
+        Assert.AreEqual("1.6.0-experimental1", latest, "Experimental mode must keep only -experimental SDK builds.");
+    }
+
+    [TestMethod]
+    public async Task GetLatestVersionAsync_NoneMode_ThrowsArgumentException()
+    {
+        await Assert.ThrowsExactlyAsync<ArgumentException>(
+            () => _service.GetLatestVersionAsync("Some.Pkg", SdkInstallMode.None, TestContext.CancellationToken));
+    }
+
+    // ───────────────────────── GetPackageDependenciesAsync (offline) ─────────────────────────
+
+    [TestMethod]
+    public async Task GetPackageDependenciesAsync_ReturnsDirectAndTransitive_ExcludesIgnoredPrefixes()
+    {
+        // A -> B (+ ignored System.Text.Json); B -> C. Result should contain B and C but not the
+        // framework/System.* dependency.
+        StubNuspecFeed(
+            ("a.pkg/1.0.0", NuspecXml("A.Pkg", ("B.Pkg", "[2.0.0, )"), ("System.Text.Json", "8.0.0"))),
+            ("b.pkg/2.0.0", NuspecXml("B.Pkg", ("C.Pkg", "3.0.0"))),
+            ("c.pkg/3.0.0", NuspecXml("C.Pkg")));
+
+        var deps = await _service.GetPackageDependenciesAsync("A.Pkg", "1.0.0", TestContext.CancellationToken);
+
+        Assert.IsTrue(deps.ContainsKey("B.Pkg"), "Direct dependency B must be present.");
+        Assert.IsTrue(deps.ContainsKey("C.Pkg"), "Transitive dependency C must be present.");
+        Assert.IsFalse(deps.ContainsKey("System.Text.Json"), "System.* dependencies are filtered out.");
+    }
+
+    [TestMethod]
+    public async Task GetPackageDependenciesAsync_StripsVersionRangeBrackets()
+    {
+        StubNuspecFeed(
+            ("brk.pkg/1.0.0", NuspecXml("Brk.Pkg", ("Ranged.Pkg", "[1.2.3, )"))),
+            ("ranged.pkg/1.2.3", NuspecXml("Ranged.Pkg")));
+
+        var deps = await _service.GetPackageDependenciesAsync("Brk.Pkg", "1.0.0", TestContext.CancellationToken);
+
+        Assert.AreEqual("1.2.3, ", deps["Ranged.Pkg"], "Brackets/parentheses are stripped, the comma-form is preserved.");
+    }
+
+    [TestMethod]
+    public async Task GetPackageDependenciesAsync_CachesResult_SecondCallDoesNotHitFeed()
+    {
+        StubNuspecFeed(
+            ("cache.pkg/1.0.0", NuspecXml("Cache.Pkg", ("Only.Dep", "1.0.0"))),
+            ("only.dep/1.0.0", NuspecXml("Only.Dep")));
+
+        var first = await _service.GetPackageDependenciesAsync("Cache.Pkg", "1.0.0", TestContext.CancellationToken);
+        Assert.IsTrue(first.ContainsKey("Only.Dep"));
+
+        // Any subsequent HTTP call now throws; a cache hit must avoid it entirely.
+        NugetService.HttpGetAsync = (_, _) => throw new InvalidOperationException("feed must not be hit on a cache hit");
+
+        var second = await _service.GetPackageDependenciesAsync("Cache.Pkg", "1.0.0", TestContext.CancellationToken);
+        Assert.IsTrue(second.ContainsKey("Only.Dep"), "The cached dependency set should be returned without a network call.");
+    }
+
+    [TestMethod]
+    public async Task GetPackageDependenciesAsync_NuspecNotFound_ReturnsEmpty()
+    {
+        NugetService.HttpGetAsync = (_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+
+        var deps = await _service.GetPackageDependenciesAsync("Ghost.Pkg", "1.0.0", TestContext.CancellationToken);
+
+        Assert.IsEmpty(deps, "A missing nuspec yields an empty dependency set, not an error.");
+    }
+
+    // ───────────────────────────── cache path resolution ─────────────────────────────
+
+    [TestMethod]
+    public void GetNuGetGlobalPackagesDir_TestOverride_UsesPackagesSubdirectory()
+    {
+        // WINAPP_CLI_CACHE_DIRECTORY unset + a non-default global dir => test-override path.
+        Environment.SetEnvironmentVariable("WINAPP_CLI_CACHE_DIRECTORY", null);
+        var dir = _service.GetNuGetGlobalPackagesDir();
+
+        Assert.AreEqual(Path.Combine(_nugetGlobal.FullName, "packages"), dir.FullName);
+        Assert.IsTrue(dir.Exists, "The override packages directory should be created on demand.");
+    }
+
+    [TestMethod]
+    public void GetNuGetPackageDir_ComposesLowercasedIdAndVersionUnderCache()
+    {
+        Environment.SetEnvironmentVariable("WINAPP_CLI_CACHE_DIRECTORY", null);
+        var dir = _service.GetNuGetPackageDir("Contoso.Widgets", "1.2.3");
+
+        var expected = Path.Combine(_nugetGlobal.FullName, "packages", "contoso.widgets", "1.2.3");
+        Assert.AreEqual(expected, dir.FullName);
+    }
+
+    [TestMethod]
+    public void GetNuGetGlobalPackagesDir_NugetPackagesEnv_TakesPriority()
+    {
+        // Setting WINAPP_CLI_CACHE_DIRECTORY makes IsTestOverride() false, so the NUGET_PACKAGES
+        // environment variable becomes the source of truth.
+        Environment.SetEnvironmentVariable("WINAPP_CLI_CACHE_DIRECTORY", _tempDirectory.FullName);
+        var envTarget = Path.Combine(_tempDirectory.FullName, "nuget-packages-env");
+        Environment.SetEnvironmentVariable("NUGET_PACKAGES", envTarget);
+
+        var dir = _service.GetNuGetGlobalPackagesDir();
+
+        Assert.AreEqual(envTarget, dir.FullName);
+        Assert.IsTrue(dir.Exists, "The NUGET_PACKAGES directory should be created if missing.");
+    }
+
+    [TestMethod]
+    public void GetNuGetGlobalPackagesDir_NoOverrides_FallsBackToUserProfileNuget()
+    {
+        // IsTestOverride() false (WINAPP_CLI_CACHE_DIRECTORY set) and NUGET_PACKAGES cleared =>
+        // the default %USERPROFILE%\.nuget\packages location is returned.
+        Environment.SetEnvironmentVariable("WINAPP_CLI_CACHE_DIRECTORY", _tempDirectory.FullName);
+        Environment.SetEnvironmentVariable("NUGET_PACKAGES", null);
+
+        var dir = _service.GetNuGetGlobalPackagesDir();
+
+        var expectedSuffix = Path.Combine(".nuget", "packages");
+        StringAssert.EndsWith(dir.FullName, expectedSuffix, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ───────────────────────────────────── helpers ─────────────────────────────────────
+
+    private string PackageDir(string lowerId, string version)
+        => Path.Combine(_nugetGlobal.FullName, "packages", lowerId, version);
+
+    private void MaterializePackageOnDisk(string lowerId, string version, string nuspec)
+    {
+        var dir = PackageDir(lowerId, version);
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, $"{lowerId}.nuspec"), nuspec);
+    }
+
+    /// <summary>Serves each requested .nupkg by matching "<id>/<version>" in the flat-container URL.</summary>
+    private static void StubNupkgFeed(params (string idVersionSegment, byte[] bytes)[] packages)
+    {
+        NugetService.HttpGetAsync = (url, _) =>
+        {
+            foreach (var (segment, bytes) in packages)
+            {
+                if (url.Contains(segment, StringComparison.Ordinal))
+                {
+                    return Task.FromResult(BytesResponse(bytes));
+                }
+            }
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        };
+    }
+
+    /// <summary>Serves each requested .nuspec by matching "<id>/<version>" in the flat-container URL.</summary>
+    private static void StubNuspecFeed(params (string idVersionSegment, string nuspec)[] nuspecs)
+    {
+        NugetService.HttpGetAsync = (url, _) =>
+        {
+            foreach (var (segment, nuspec) in nuspecs)
+            {
+                if (url.Contains(segment, StringComparison.Ordinal))
+                {
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(nuspec, Encoding.UTF8, "application/xml"),
+                    });
+                }
+            }
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        };
+    }
+
+    private static void StubRegistration(string lowerId, string page)
+        => StubRegistrationRaw(lowerId, "{\"items\":[" + page + "]}");
+
+    private static void StubRegistrationRaw(string lowerId, string json)
+    {
+        NugetService.HttpGetAsync = (url, _) => Task.FromResult(
+            url.Contains(lowerId, StringComparison.Ordinal) ? JsonResponse(json) : new HttpResponseMessage(HttpStatusCode.NotFound));
+    }
+
+    /// <summary>Builds the JSON array of leaf entries: [ {catalogEntry...}, ... ].</summary>
+    private static string InlineLeaves(params (string version, bool listed)[] versions)
+        => "[" + string.Join(",", versions.Select(v =>
+            "{\"catalogEntry\":{\"version\":\"" + v.version + "\",\"listed\":" + (v.listed ? "true" : "false") + "}}")) + "]";
+
+    /// <summary>Builds one inline registration page object (the "{...}" that goes inside items[]).</summary>
+    private static string InlinePage(params (string version, bool listed)[] versions)
+        => "{\"items\":" + InlineLeaves(versions) + "}";
+
+    private static string NuspecXml(string id, params (string depId, string depVersion)[] deps)
+    {
+        var depXml = string.Join("\n", deps.Select(d => $"        <dependency id=\"{d.depId}\" version=\"{d.depVersion}\" />"));
+        return
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+            $"<package xmlns=\"{NuspecNs}\">\n" +
+            "  <metadata>\n" +
+            $"    <id>{id}</id>\n" +
+            "    <version>1.0.0</version>\n" +
+            "    <dependencies>\n" +
+            "      <group targetFramework=\"net8.0\">\n" +
+            depXml + "\n" +
+            "      </group>\n" +
+            "    </dependencies>\n" +
+            "  </metadata>\n" +
+            "</package>\n";
+    }
+
+    private static byte[] BuildNupkg(string lowerId, string nuspec)
+        => BuildNupkgWithNamedNuspec($"{lowerId}.nuspec", nuspec);
+
+    private static byte[] BuildNupkgWithNamedNuspec(string nuspecEntryName, string nuspec)
+        => BuildNupkgRaw(zip =>
+        {
+            AddEntry(zip, nuspecEntryName, nuspec);
+            AddEntry(zip, "lib/net8.0/placeholder.dll", "binary");
+        });
+
+    private static byte[] BuildNupkgRaw(Action<ZipArchive> fill)
+    {
+        using var ms = new MemoryStream();
+        using (var zip = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            fill(zip);
+        }
+        return ms.ToArray();
+    }
+
+    private static void AddEntry(ZipArchive zip, string path, string content)
+    {
+        var entry = zip.CreateEntry(path);
+        using var stream = entry.Open();
+        var bytes = Encoding.UTF8.GetBytes(content);
+        stream.Write(bytes, 0, bytes.Length);
+    }
+
+    private static HttpResponseMessage JsonResponse(string json)
+        => new(HttpStatusCode.OK) { Content = new StringContent(json, Encoding.UTF8, "application/json") };
+
+    private static HttpResponseMessage BytesResponse(byte[] bytes)
+        => new(HttpStatusCode.OK) { Content = new ByteArrayContent(bytes) };
+}

--- a/src/winapp-CLI/WinApp.Cli.Tests/NugetServiceOfflineTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/NugetServiceOfflineTests.cs
@@ -411,6 +411,37 @@ public sealed class NugetServiceOfflineTests : BaseCommandTests
     }
 
     [TestMethod]
+    public async Task GetPackageDependenciesAsync_OpenLowerBoundRange_KeepsDirectDep_AndSkipsMalformedTransitiveFetch()
+    {
+        // RangeRoot -> RangeChild declared with an open-lower-bound range "(,2.0.0]" (no concrete minimum
+        // version). ParseMinimumVersion yields empty for that range, so the transitive walk must SKIP
+        // RangeChild rather than requesting a malformed ".../rangechild.pkg//rangechild.pkg.nuspec". The
+        // direct dependency itself is still returned. A unique package id avoids the static DependencyCache
+        // colliding with other tests.
+        var requestedUrls = new List<string>();
+        NugetService.HttpGetAsync = (url, _) =>
+        {
+            requestedUrls.Add(url);
+            if (url.Contains("/rangeroot.pkg/1.0.0/", StringComparison.Ordinal))
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(NuspecXml("RangeRoot.Pkg", ("RangeChild.Pkg", "(,2.0.0]"))),
+                });
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        };
+
+        var deps = await _service.GetPackageDependenciesAsync("RangeRoot.Pkg", "1.0.0", TestContext.CancellationToken);
+
+        Assert.IsTrue(deps.ContainsKey("RangeChild.Pkg"), "The direct dependency must still be returned.");
+        Assert.IsFalse(
+            requestedUrls.Any(u => u.Contains("rangechild", StringComparison.OrdinalIgnoreCase)),
+            "An open-lower-bound range has no minimum version, so no (malformed) transitive nuspec fetch should be issued for it.");
+    }
+
+    [TestMethod]
     public async Task GetPackageDependenciesAsync_StripsVersionRangeBrackets()
     {
         StubNuspecFeed(

--- a/src/winapp-CLI/WinApp.Cli.Tests/PackageInstallationServiceTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/PackageInstallationServiceTests.cs
@@ -1,0 +1,357 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.Logging;
+using WinApp.Cli.ConsoleTasks;
+using WinApp.Cli.Models;
+using WinApp.Cli.Services;
+
+namespace WinApp.Cli.Tests;
+
+/// <summary>
+/// Behavior tests for <see cref="PackageInstallationService"/> driven entirely through a
+/// controllable in-memory <see cref="INugetService"/> fake, so no network or real NuGet cache is
+/// touched. Covers pinned-vs-latest version resolution, the "already present" transitive top-up
+/// paths (install-missing / already-on-disk / higher-version merge / KeyNotFound), and the
+/// <see cref="PackageInstallationService.EnsurePackageAsync"/> success/failure paths.
+/// </summary>
+[TestClass]
+public sealed class PackageInstallationServiceTests : BaseCommandTests
+{
+    private ControllableNugetService _nuget = null!;
+    private PackageInstallationService _service = null!;
+    private DirectoryInfo _cacheRoot = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _cacheRoot = _tempDirectory.CreateSubdirectory("nugetcache");
+        _nuget = new ControllableNugetService(_cacheRoot);
+        _service = new PackageInstallationService(
+            _configService,
+            _nuget,
+            GetRequiredService<ILogger<PackageInstallationService>>());
+    }
+
+    private void SaveConfig(params (string name, string version)[] pins)
+    {
+        var cfg = new WinappConfig();
+        foreach (var (name, version) in pins)
+        {
+            cfg.SetVersion(name, version);
+        }
+        _configService.Save(cfg);
+    }
+
+    // ───────────────────────────── InitializeWorkspace ─────────────────────────────
+
+    [TestMethod]
+    public void InitializeWorkspace_MissingDirectory_IsCreated()
+    {
+        var target = new DirectoryInfo(Path.Combine(_tempDirectory.FullName, "ws", Guid.NewGuid().ToString("N")));
+        Assert.IsFalse(target.Exists);
+
+        _service.InitializeWorkspace(target);
+
+        target.Refresh();
+        Assert.IsTrue(target.Exists, "InitializeWorkspace must create the root directory when it is missing.");
+    }
+
+    [TestMethod]
+    public void InitializeWorkspace_ExistingDirectory_LeftIntact()
+    {
+        var target = _tempDirectory.CreateSubdirectory("already-here");
+        var marker = Path.Combine(target.FullName, "keep.txt");
+        File.WriteAllText(marker, "x");
+
+        _service.InitializeWorkspace(target);
+
+        Assert.IsTrue(File.Exists(marker), "An existing workspace directory must not be recreated/cleared.");
+    }
+
+    // ───────────────────────────── InstallPackagesAsync: version resolution ─────────────────────────────
+
+    [TestMethod]
+    public async Task InstallPackagesAsync_NoConfig_InstallsLatestVersion()
+    {
+        _nuget.LatestVersions["Contoso.Pkg"] = "3.1.0";
+
+        var result = await _service.InstallPackagesAsync(
+            _tempDirectory, ["Contoso.Pkg"], TestTaskContext, cancellationToken: TestContext.CancellationToken);
+
+        Assert.AreEqual("3.1.0", result["Contoso.Pkg"]);
+        CollectionAssert.Contains(_nuget.LatestQueries, "Contoso.Pkg", "Latest version must be queried when no pin exists.");
+        Assert.AreEqual(1, _nuget.InstallCalls.Count);
+        Assert.AreEqual(("Contoso.Pkg", "3.1.0"), _nuget.InstallCalls[0]);
+    }
+
+    [TestMethod]
+    public async Task InstallPackagesAsync_PinnedVersion_UsesPinAndSkipsLatestLookup()
+    {
+        SaveConfig(("Contoso.Pkg", "2.0.5"));
+        _nuget.LatestVersions["Contoso.Pkg"] = "9.9.9"; // must NOT be chosen
+
+        var result = await _service.InstallPackagesAsync(
+            _tempDirectory, ["Contoso.Pkg"], TestTaskContext, cancellationToken: TestContext.CancellationToken);
+
+        Assert.AreEqual("2.0.5", result["Contoso.Pkg"], "The pinned version must win over latest.");
+        Assert.AreEqual(("Contoso.Pkg", "2.0.5"), _nuget.InstallCalls.Single());
+        CollectionAssert.DoesNotContain(_nuget.LatestQueries, "Contoso.Pkg", "A pinned package must not trigger a latest-version lookup.");
+    }
+
+    [TestMethod]
+    public async Task InstallPackagesAsync_ConfigExistsButPackageNotPinned_FallsBackToLatest()
+    {
+        SaveConfig(("Some.Other", "1.0.0")); // config exists, but not for the requested package
+        _nuget.LatestVersions["Contoso.Pkg"] = "4.2.0";
+
+        var result = await _service.InstallPackagesAsync(
+            _tempDirectory, ["Contoso.Pkg"], TestTaskContext, cancellationToken: TestContext.CancellationToken);
+
+        Assert.AreEqual("4.2.0", result["Contoso.Pkg"]);
+        CollectionAssert.Contains(_nuget.LatestQueries, "Contoso.Pkg", "An unpinned package in an existing config must still resolve latest.");
+    }
+
+    [TestMethod]
+    public async Task InstallPackagesAsync_IgnoreConfig_SkipsPinnedVersion()
+    {
+        SaveConfig(("Contoso.Pkg", "2.0.5"));
+        _nuget.LatestVersions["Contoso.Pkg"] = "7.0.0";
+
+        var result = await _service.InstallPackagesAsync(
+            _tempDirectory, ["Contoso.Pkg"], TestTaskContext, ignoreConfig: true, cancellationToken: TestContext.CancellationToken);
+
+        Assert.AreEqual("7.0.0", result["Contoso.Pkg"], "ignoreConfig=true must bypass the pinned version and install latest.");
+        CollectionAssert.Contains(_nuget.LatestQueries, "Contoso.Pkg");
+    }
+
+    // ───────────────────────────── InstallPackagesAsync: fresh install merge ─────────────────────────────
+
+    [TestMethod]
+    public async Task InstallPackagesAsync_FreshInstall_MergesHigherTransitiveVersions()
+    {
+        // Package A brings Shared 1.0.0 and Keep 5.0.0; package B brings Shared 2.0.0 (higher -> wins)
+        // and Keep 4.0.0 (lower -> must NOT overwrite the already-recorded 5.0.0).
+        _nuget.LatestVersions["A"] = "1.0.0";
+        _nuget.LatestVersions["B"] = "1.0.0";
+        _nuget.InstallReturns["A/1.0.0"] = new() { ["A"] = "1.0.0", ["Shared"] = "1.0.0", ["Keep"] = "5.0.0" };
+        _nuget.InstallReturns["B/1.0.0"] = new() { ["B"] = "1.0.0", ["Shared"] = "2.0.0", ["Keep"] = "4.0.0" };
+
+        var result = await _service.InstallPackagesAsync(
+            _tempDirectory, ["A", "B"], TestTaskContext, cancellationToken: TestContext.CancellationToken);
+
+        Assert.AreEqual("2.0.0", result["Shared"], "A higher transitive version must overwrite a lower one.");
+        Assert.AreEqual("5.0.0", result["Keep"], "A lower transitive version must NOT overwrite a higher recorded one.");
+        Assert.AreEqual("1.0.0", result["A"]);
+        Assert.AreEqual("1.0.0", result["B"]);
+    }
+
+    // ───────────────────────────── InstallPackagesAsync: already-present transitive top-up ─────────────────────────────
+
+    [TestMethod]
+    public async Task InstallPackagesAsync_AlreadyPresent_InstallsMissingTransitiveDependency()
+    {
+        _nuget.LatestVersions["Root"] = "1.0.0";
+        _nuget.MarkPresent("Root", "1.0.0");                       // main package already on disk
+        _nuget.DependencyMap["Root/1.0.0"] = new() { ["Dep"] = "2.0.0" };
+        // Dep is NOT present on disk -> must be installed.
+
+        var result = await _service.InstallPackagesAsync(
+            _tempDirectory, ["Root"], TestTaskContext, cancellationToken: TestContext.CancellationToken);
+
+        Assert.AreEqual("1.0.0", result["Root"], "The already-present main package must still be recorded.");
+        Assert.AreEqual("2.0.0", result["Dep"], "A missing transitive dependency must be installed and recorded.");
+        Assert.AreEqual(("Dep", "2.0.0"), _nuget.InstallCalls.Single(), "Only the missing dependency should be installed.");
+    }
+
+    [TestMethod]
+    public async Task InstallPackagesAsync_AlreadyPresent_TransitiveDependencyAlreadyOnDisk_NotReinstalled()
+    {
+        _nuget.LatestVersions["Root"] = "1.0.0";
+        _nuget.MarkPresent("Root", "1.0.0");
+        _nuget.DependencyMap["Root/1.0.0"] = new() { ["Dep"] = "2.0.0" };
+        _nuget.MarkPresent("Dep", "2.0.0");                        // dependency already on disk
+
+        var result = await _service.InstallPackagesAsync(
+            _tempDirectory, ["Root"], TestTaskContext, cancellationToken: TestContext.CancellationToken);
+
+        Assert.AreEqual("2.0.0", result["Dep"], "A present transitive dependency must be recorded without reinstalling.");
+        Assert.IsEmpty(_nuget.InstallCalls, "Nothing should be installed when the dependency is already cached.");
+    }
+
+    [TestMethod]
+    public async Task InstallPackagesAsync_AlreadyPresent_MergesHigherAndKeepsExistingHigherVersions()
+    {
+        // First package (fresh) records Low=3.0.0 and Mid=1.0.0. Second package is already present and
+        // declares on-disk deps Low=2.0.0 (lower -> keep 3.0.0) and Mid=2.0.0 (higher -> upgrade).
+        _nuget.LatestVersions["First"] = "1.0.0";
+        _nuget.LatestVersions["Second"] = "1.0.0";
+        _nuget.InstallReturns["First/1.0.0"] = new() { ["First"] = "1.0.0", ["Low"] = "3.0.0", ["Mid"] = "1.0.0" };
+        _nuget.MarkPresent("Second", "1.0.0");
+        _nuget.DependencyMap["Second/1.0.0"] = new() { ["Low"] = "2.0.0", ["Mid"] = "2.0.0" };
+        _nuget.MarkPresent("Low", "2.0.0");
+        _nuget.MarkPresent("Mid", "2.0.0");
+
+        var result = await _service.InstallPackagesAsync(
+            _tempDirectory, ["First", "Second"], TestTaskContext, cancellationToken: TestContext.CancellationToken);
+
+        Assert.AreEqual("3.0.0", result["Low"], "Existing higher version must be preserved against a lower present dep.");
+        Assert.AreEqual("2.0.0", result["Mid"], "A higher present dep version must upgrade the recorded version.");
+    }
+
+    [TestMethod]
+    public async Task InstallPackagesAsync_AlreadyPresent_InstalledDependencyMergesHigherVersion()
+    {
+        // Fresh First records X=1.0.0 and Y=5.0.0. Present Second must install missing Dep, whose install
+        // return also carries X=3.0.0 (higher -> upgrade) and Y=4.0.0 (lower -> keep 5.0.0).
+        _nuget.LatestVersions["First"] = "1.0.0";
+        _nuget.LatestVersions["Second"] = "1.0.0";
+        _nuget.InstallReturns["First/1.0.0"] = new() { ["First"] = "1.0.0", ["X"] = "1.0.0", ["Y"] = "5.0.0" };
+        _nuget.MarkPresent("Second", "1.0.0");
+        _nuget.DependencyMap["Second/1.0.0"] = new() { ["Dep"] = "2.0.0" };
+        // Dep missing -> installed; its transitive closure bumps X and reports a lower Y.
+        _nuget.InstallReturns["Dep/2.0.0"] = new() { ["Dep"] = "2.0.0", ["X"] = "3.0.0", ["Y"] = "4.0.0" };
+
+        var result = await _service.InstallPackagesAsync(
+            _tempDirectory, ["First", "Second"], TestTaskContext, cancellationToken: TestContext.CancellationToken);
+
+        Assert.AreEqual("2.0.0", result["Dep"]);
+        Assert.AreEqual("3.0.0", result["X"], "A newly installed dependency's higher version must win.");
+        Assert.AreEqual("5.0.0", result["Y"], "A newly installed dependency's lower version must not overwrite a higher one.");
+    }
+
+    [TestMethod]
+    public async Task InstallPackagesAsync_AlreadyPresent_DependencyWithUnparsableVersion_IsSkipped()
+    {
+        _nuget.LatestVersions["Root"] = "1.0.0";
+        _nuget.MarkPresent("Root", "1.0.0");
+        _nuget.DependencyMap["Root/1.0.0"] = new() { ["BadDep"] = "   " }; // ParseMinimumVersion -> empty
+
+        var result = await _service.InstallPackagesAsync(
+            _tempDirectory, ["Root"], TestTaskContext, cancellationToken: TestContext.CancellationToken);
+
+        Assert.HasCount(1, result, "A dependency whose version cannot be parsed must be skipped.");
+        Assert.IsFalse(result.ContainsKey("BadDep"));
+        Assert.IsEmpty(_nuget.InstallCalls);
+    }
+
+    [TestMethod]
+    public async Task InstallPackagesAsync_AlreadyPresent_DependencyLookupThrowsKeyNotFound_ContinuesWithMainPackage()
+    {
+        _nuget.LatestVersions["Root"] = "1.0.0";
+        _nuget.MarkPresent("Root", "1.0.0");
+        _nuget.ThrowKeyNotFoundFor.Add("Root"); // GetPackageDependenciesAsync throws KeyNotFoundException
+
+        var result = await _service.InstallPackagesAsync(
+            _tempDirectory, ["Root"], TestTaskContext, cancellationToken: TestContext.CancellationToken);
+
+        Assert.HasCount(1, result, "A KeyNotFound during dependency resolution must be swallowed, leaving the main package.");
+        Assert.AreEqual("1.0.0", result["Root"]);
+    }
+
+    // ───────────────────────────── EnsurePackageAsync ─────────────────────────────
+
+    [TestMethod]
+    public async Task EnsurePackageAsync_NewPackage_CreatesWorkspaceInstallsAndReturnsTrue()
+    {
+        var root = new DirectoryInfo(Path.Combine(_tempDirectory.FullName, "ensure-new", Guid.NewGuid().ToString("N")));
+        _nuget.LatestVersions["Contoso.Pkg"] = "5.0.0";
+
+        var ok = await _service.EnsurePackageAsync(
+            root, "Contoso.Pkg", TestTaskContext, cancellationToken: TestContext.CancellationToken);
+
+        Assert.IsTrue(ok);
+        root.Refresh();
+        Assert.IsTrue(root.Exists, "EnsurePackageAsync must initialize the workspace directory.");
+        Assert.AreEqual(("Contoso.Pkg", "5.0.0"), _nuget.InstallCalls.Single());
+    }
+
+    [TestMethod]
+    public async Task EnsurePackageAsync_ExplicitVersionAlreadyPresent_SkipsInstallReturnsTrue()
+    {
+        _nuget.MarkPresent("Contoso.Pkg", "1.5.0");
+
+        var ok = await _service.EnsurePackageAsync(
+            _tempDirectory, "Contoso.Pkg", TestTaskContext, version: "1.5.0", cancellationToken: TestContext.CancellationToken);
+
+        Assert.IsTrue(ok);
+        Assert.IsEmpty(_nuget.InstallCalls, "A package already present at the requested version must not be reinstalled.");
+        Assert.IsEmpty(_nuget.LatestQueries, "An explicit version must not trigger a latest-version lookup.");
+    }
+
+    [TestMethod]
+    public async Task EnsurePackageAsync_InstallFailure_ReturnsFalseAndLogsError()
+    {
+        _nuget.ThrowLatestFor.Add("Broken.Pkg"); // latest lookup throws -> install fails
+
+        var ok = await _service.EnsurePackageAsync(
+            _tempDirectory, "Broken.Pkg", TestTaskContext, cancellationToken: TestContext.CancellationToken);
+
+        Assert.IsFalse(ok, "A failure during installation must be reported as false, not thrown.");
+        CollectionAssert.Contains(_nuget.LatestQueries, "Broken.Pkg", "The failing operation must have actually been attempted.");
+        StringAssert.Contains(ConsoleStdErr.ToString(), "Broken.Pkg", StringComparison.Ordinal);
+    }
+}
+
+/// <summary>
+/// A fully controllable in-memory <see cref="INugetService"/> for driving
+/// <see cref="PackageInstallationService"/> branch-by-branch without any network or real cache.
+/// Package presence is backed by real directories under a temp cache root so that the
+/// <c>DirectoryInfo.Exists</c> checks in the product code behave exactly as in production.
+/// </summary>
+internal sealed class ControllableNugetService(DirectoryInfo cacheRoot) : INugetService
+{
+    public Dictionary<string, string> LatestVersions { get; } = new(StringComparer.OrdinalIgnoreCase);
+    public string FallbackLatest { get; set; } = "9.9.9";
+    public HashSet<string> ThrowLatestFor { get; } = new(StringComparer.OrdinalIgnoreCase);
+    public List<string> LatestQueries { get; } = [];
+    public List<SdkInstallMode> LatestModes { get; } = [];
+
+    public Dictionary<string, Dictionary<string, string>> DependencyMap { get; } = new(StringComparer.OrdinalIgnoreCase);
+    public HashSet<string> ThrowKeyNotFoundFor { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+    public Dictionary<string, Dictionary<string, string>> InstallReturns { get; } = new(StringComparer.OrdinalIgnoreCase);
+    public List<(string Id, string Version)> InstallCalls { get; } = [];
+
+    private static string Key(string id, string version) => $"{id}/{version}";
+
+    public Task<string> GetLatestVersionAsync(string packageName, SdkInstallMode sdkInstallMode, CancellationToken cancellationToken = default)
+    {
+        LatestQueries.Add(packageName);
+        LatestModes.Add(sdkInstallMode);
+        if (ThrowLatestFor.Contains(packageName))
+        {
+            throw new InvalidOperationException($"Simulated latest-version failure for {packageName}");
+        }
+        return Task.FromResult(LatestVersions.TryGetValue(packageName, out var v) ? v : FallbackLatest);
+    }
+
+    public Task<Dictionary<string, string>> InstallPackageAsync(string package, string version, TaskContext taskContext, CancellationToken cancellationToken = default)
+    {
+        InstallCalls.Add((package, version));
+        MarkPresent(package, version); // installing makes it present on disk, mirroring production
+        var result = InstallReturns.TryGetValue(Key(package, version), out var d)
+            ? new Dictionary<string, string>(d, StringComparer.OrdinalIgnoreCase)
+            : new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { [package] = version };
+        return Task.FromResult(result);
+    }
+
+    public Task<Dictionary<string, string>> GetPackageDependenciesAsync(string packageName, string version, CancellationToken cancellationToken = default)
+    {
+        if (ThrowKeyNotFoundFor.Contains(packageName))
+        {
+            throw new KeyNotFoundException($"{packageName} not found in cache");
+        }
+        return Task.FromResult(DependencyMap.TryGetValue(Key(packageName, version), out var d)
+            ? new Dictionary<string, string>(d, StringComparer.OrdinalIgnoreCase)
+            : new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
+    }
+
+    public DirectoryInfo GetNuGetGlobalPackagesDir() => cacheRoot;
+
+    public DirectoryInfo GetNuGetPackageDir(string packageName, string version)
+        => new(Path.Combine(cacheRoot.FullName, packageName.ToLowerInvariant(), version));
+
+    public void MarkPresent(string packageName, string version)
+        => Directory.CreateDirectory(GetNuGetPackageDir(packageName, version).FullName);
+}

--- a/src/winapp-CLI/WinApp.Cli.Tests/UpdateCommandTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/UpdateCommandTests.cs
@@ -1,0 +1,257 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.DependencyInjection;
+using WinApp.Cli.Commands;
+using WinApp.Cli.ConsoleTasks;
+using WinApp.Cli.Models;
+using WinApp.Cli.Services;
+
+namespace WinApp.Cli.Tests;
+
+/// <summary>
+/// Behavior tests for the <c>winapp update</c> command (<see cref="UpdateCommand.Handler"/>).
+/// The real <see cref="IStatusService"/> executes the handler body, while NuGet, package
+/// installation, build tools, and workspace setup are replaced with controllable fakes so the
+/// version-check / save / install / build-tools / runtime paths run without any network or disk SDK.
+/// </summary>
+[TestClass]
+public sealed class UpdateCommandTests : BaseCommandTests
+{
+    private ControllableNugetService _nuget = null!;
+    private FakePackageInstallationService _pkg = null!;
+    private FakeBuildToolsService _buildTools = null!;
+    private UpdateWorkspaceFake _workspace = null!;
+
+    private static readonly string[] PkgAB = ["Pkg.A", "Pkg.B"];
+
+    protected override IServiceCollection ConfigureServices(IServiceCollection services)
+    {
+        _nuget = new ControllableNugetService(new DirectoryInfo(Path.GetTempPath()));
+        _pkg = new FakePackageInstallationService();
+        _buildTools = new FakeBuildToolsService();
+        _workspace = new UpdateWorkspaceFake();
+        return services
+            .AddSingleton<INugetService>(_nuget)
+            .AddSingleton<IPackageInstallationService>(_pkg)
+            .AddSingleton<IBuildToolsService>(_buildTools)
+            .AddSingleton<IWorkspaceSetupService>(_workspace);
+    }
+
+    [TestInitialize]
+    public void Setup()
+    {
+        // Default to the happy path: build tools resolve successfully and no runtime MSIX is found.
+        _buildTools.BuildToolsResult = _tempDirectory;
+        _workspace.MsixDirectory = null;
+    }
+
+    private void SaveConfig(params (string name, string version)[] pins)
+    {
+        var cfg = new WinappConfig();
+        foreach (var (name, version) in pins)
+        {
+            cfg.SetVersion(name, version);
+        }
+        _configService.Save(cfg);
+    }
+
+    private UpdateCommand GetCommand() => GetRequiredService<UpdateCommand>();
+
+    // ───────────────────────────── command metadata ─────────────────────────────
+
+    [TestMethod]
+    public void UpdateCommand_ExposesNameShortDescriptionAndSetupSdksOption()
+    {
+        var command = GetCommand();
+
+        Assert.AreEqual("update", command.Name);
+        Assert.AreEqual("Update packages in winapp.yaml", command.ShortDescription);
+        Assert.Contains(InitCommand.SetupSdksOption, command.Options, "update must expose the --setup-sdks option.");
+    }
+
+    // ───────────────────────────── config discovery ─────────────────────────────
+
+    [TestMethod]
+    public async Task Update_NoConfig_SkipsPackageWork_ButEnsuresBuildTools()
+    {
+        var exit = await ParseAndInvokeWithCaptureAsync(GetCommand(), []);
+
+        Assert.AreEqual(0, exit);
+        Assert.IsEmpty(_pkg.InstallPackagesCalls, "No winapp.yaml means no package installation.");
+        Assert.IsEmpty(_nuget.LatestQueries, "No config means no version checks.");
+        Assert.HasCount(1, _buildTools.EnsureBuildToolsForceLatest);
+        Assert.IsTrue(_buildTools.EnsureBuildToolsForceLatest[0], "update must force-latest build tools.");
+    }
+
+    [TestMethod]
+    public async Task Update_ConfigWithNoPackages_SkipsPackageWork()
+    {
+        SaveConfig(); // writes an empty "packages:" section
+
+        var exit = await ParseAndInvokeWithCaptureAsync(GetCommand(), []);
+
+        Assert.AreEqual(0, exit);
+        Assert.IsEmpty(_pkg.InstallPackagesCalls);
+        Assert.IsEmpty(_nuget.LatestQueries, "An empty package list must not trigger version checks.");
+    }
+
+    // ───────────────────────────── version check / update ─────────────────────────────
+
+    [TestMethod]
+    public async Task Update_AllPackagesUpToDate_DoesNotSaveOrInstall()
+    {
+        SaveConfig(("Pkg.A", "1.0.0"), ("Pkg.B", "2.0.0"));
+        _nuget.LatestVersions["Pkg.A"] = "1.0.0";
+        _nuget.LatestVersions["Pkg.B"] = "2.0.0";
+
+        var exit = await ParseAndInvokeWithCaptureAsync(GetCommand(), []);
+
+        Assert.AreEqual(0, exit);
+        Assert.IsEmpty(_pkg.InstallPackagesCalls, "Nothing to install when everything is current.");
+        CollectionAssert.AreEquivalent(PkgAB, _nuget.LatestQueries, "Both packages must be checked.");
+
+        // The on-disk config must be unchanged.
+        var reloaded = _configService.Load();
+        Assert.AreEqual("1.0.0", reloaded.GetVersion("Pkg.A"));
+        Assert.AreEqual("2.0.0", reloaded.GetVersion("Pkg.B"));
+    }
+
+    [TestMethod]
+    public async Task Update_NewerVersionAvailable_SavesYamlAndInstalls()
+    {
+        SaveConfig(("Pkg.A", "1.0.0"), ("Pkg.B", "2.0.0"));
+        _nuget.LatestVersions["Pkg.A"] = "1.5.0"; // newer
+        _nuget.LatestVersions["Pkg.B"] = "2.0.0"; // same
+
+        var exit = await ParseAndInvokeWithCaptureAsync(GetCommand(), []);
+
+        Assert.AreEqual(0, exit);
+
+        // winapp.yaml must be rewritten with the upgraded version.
+        var reloaded = _configService.Load();
+        Assert.AreEqual("1.5.0", reloaded.GetVersion("Pkg.A"), "The upgraded version must be persisted.");
+        Assert.AreEqual("2.0.0", reloaded.GetVersion("Pkg.B"));
+
+        // The updated set of packages must be installed with ignoreConfig=false.
+        Assert.HasCount(1, _pkg.InstallPackagesCalls);
+        var call = _pkg.InstallPackagesCalls[0];
+        CollectionAssert.AreEquivalent(PkgAB, call.Packages);
+        Assert.IsFalse(call.IgnoreConfig, "update installs against the freshly-written config, so ignoreConfig must be false.");
+    }
+
+    [TestMethod]
+    public async Task Update_VersionCheckThrowsForOnePackage_KeepsItsCurrentVersion_AndUpgradesOthers()
+    {
+        SaveConfig(("Pkg.A", "1.0.0"), ("Pkg.B", "2.0.0"));
+        _nuget.ThrowLatestFor.Add("Pkg.A");        // transient failure for A -> keep current
+        _nuget.LatestVersions["Pkg.B"] = "2.5.0";  // B upgrades -> triggers save+install
+
+        var exit = await ParseAndInvokeWithCaptureAsync(GetCommand(), []);
+
+        Assert.AreEqual(0, exit);
+
+        var reloaded = _configService.Load();
+        Assert.AreEqual("1.0.0", reloaded.GetVersion("Pkg.A"), "A failed check must retain the current pinned version.");
+        Assert.AreEqual("2.5.0", reloaded.GetVersion("Pkg.B"), "B must be upgraded despite A's failure.");
+        Assert.HasCount(1, _pkg.InstallPackagesCalls, "The upgrade to B must still drive an install.");
+    }
+
+    [TestMethod]
+    public async Task Update_SetupSdksPreview_PropagatesPreviewModeToVersionChecks()
+    {
+        SaveConfig(("Pkg.A", "1.0.0"));
+        _nuget.LatestVersions["Pkg.A"] = "1.6.0-preview1";
+
+        var exit = await ParseAndInvokeWithCaptureAsync(GetCommand(), ["--setup-sdks", "preview"]);
+
+        Assert.AreEqual(0, exit);
+        Assert.IsNotEmpty(_nuget.LatestModes);
+        Assert.IsTrue(_nuget.LatestModes.TrueForAll(m => m == SdkInstallMode.Preview),
+            "The --setup-sdks preview option must flow through to the version lookup mode.");
+    }
+
+    // ───────────────────────────── build tools ─────────────────────────────
+
+    [TestMethod]
+    public async Task Update_BuildToolsFail_ReturnsOneAndSkipsRuntime()
+    {
+        _buildTools.BuildToolsResult = null; // EnsureBuildToolsAsync returns null => failure
+
+        var exit = await ParseAndInvokeWithCaptureAsync(GetCommand(), []);
+
+        Assert.AreEqual(1, exit, "A build-tools failure must surface as a non-zero exit code.");
+        Assert.IsEmpty(_workspace.InstallRuntimeCalls, "Runtime installation must be skipped when build tools fail.");
+        StringAssert.Contains(ConsoleStdErr.ToString(), "build tools", StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ───────────────────────────── runtime install ─────────────────────────────
+
+    [TestMethod]
+    public async Task Update_RuntimeMsixFound_InstallsWindowsAppRuntime()
+    {
+        var msixDir = _tempDirectory.CreateSubdirectory("msix");
+        _workspace.MsixDirectory = msixDir;
+        _workspace.InstallRuntimeResult = (2, 0);
+
+        var exit = await ParseAndInvokeWithCaptureAsync(GetCommand(), []);
+
+        Assert.AreEqual(0, exit);
+        Assert.HasCount(1, _workspace.InstallRuntimeCalls, "A discovered MSIX directory must trigger a runtime install.");
+        Assert.AreEqual(msixDir.FullName, _workspace.InstallRuntimeCalls[0].FullName);
+    }
+
+    [TestMethod]
+    public async Task Update_NoRuntimeMsix_SkipsRuntimeInstall()
+    {
+        _workspace.MsixDirectory = null;
+
+        var exit = await ParseAndInvokeWithCaptureAsync(GetCommand(), []);
+
+        Assert.AreEqual(0, exit);
+        Assert.IsEmpty(_workspace.InstallRuntimeCalls, "No MSIX directory means the runtime install is skipped.");
+    }
+
+    // ───────────────────────────── exception path ─────────────────────────────
+
+    [TestMethod]
+    public async Task Update_UnexpectedException_IsCaughtAndReturnsOne()
+    {
+        var msixDir = _tempDirectory.CreateSubdirectory("msix-throw");
+        _workspace.MsixDirectory = msixDir;
+        _workspace.InstallRuntimeException = new InvalidOperationException("boom during runtime install");
+
+        var exit = await ParseAndInvokeWithCaptureAsync(GetCommand(), []);
+
+        Assert.AreEqual(1, exit, "An unexpected exception must be caught and reported as exit code 1.");
+        StringAssert.Contains(ConsoleStdErr.ToString(), "boom during runtime install", StringComparison.Ordinal);
+    }
+}
+
+/// <summary>
+/// Test-local <see cref="IWorkspaceSetupService"/> that records runtime-install calls and can be
+/// told to throw, so the update command's runtime-install and top-level catch paths are reachable
+/// deterministically.
+/// </summary>
+internal sealed class UpdateWorkspaceFake : IWorkspaceSetupService
+{
+    public DirectoryInfo? MsixDirectory { get; set; }
+    public List<DirectoryInfo> InstallRuntimeCalls { get; } = [];
+    public (int InstalledCount, int ErrorCount) InstallRuntimeResult { get; set; } = (1, 0);
+    public Exception? InstallRuntimeException { get; set; }
+
+    public DirectoryInfo? FindWindowsAppSdkMsixDirectory(Dictionary<string, string>? usedVersions = null) => MsixDirectory;
+
+    public Task<int> SetupWorkspaceAsync(WorkspaceSetupOptions options, CancellationToken cancellationToken = default)
+        => Task.FromResult(0);
+
+    public Task<(int InstalledCount, int ErrorCount)> InstallWindowsAppRuntimeAsync(DirectoryInfo msixDir, TaskContext taskContext, CancellationToken cancellationToken)
+    {
+        InstallRuntimeCalls.Add(msixDir);
+        if (InstallRuntimeException != null)
+        {
+            throw InstallRuntimeException;
+        }
+        return Task.FromResult(InstallRuntimeResult);
+    }
+}

--- a/src/winapp-CLI/WinApp.Cli/Services/NugetService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/NugetService.cs
@@ -14,10 +14,32 @@ namespace WinApp.Cli.Services;
 internal partial class NugetService(IWinappDirectoryService winappDirectoryService) : INugetService
 {
     private static readonly HttpClient Http = new();
+
+    /// <summary>
+    /// Seam for the flat-container and registration HTTP GETs used by package download,
+    /// version resolution, and dependency parsing. Defaults to the shared <see cref="Http"/>
+    /// client so production behavior is byte-for-byte unchanged; tests replace it with canned
+    /// in-memory responses so those paths run without network I/O.
+    /// </summary>
+    /// <remarks>
+    /// The default delegate wraps the single real
+    /// <see cref="HttpClient.GetAsync(string?, System.Threading.CancellationToken)"/> network
+    /// boundary. That boundary itself is not unit-coverable without a live NuGet endpoint; see
+    /// issue #630. Only the default delegate performs network I/O.
+    /// </remarks>
+    internal static Func<string, CancellationToken, Task<HttpResponseMessage>> HttpGetAsync { get; set; }
+        = static (url, cancellationToken) => Http.GetAsync(url, cancellationToken);
+
     private const string FlatIndex = "https://api.nuget.org/v3-flatcontainer";
     private const string RegistrationIndex = "https://api.nuget.org/v3/registration5-semver1";
     private static readonly ConcurrentDictionary<string, Dictionary<string, string>> DependencyCache = new(StringComparer.OrdinalIgnoreCase);
 
+    /// <remarks>
+    /// The final fallback creates <c>%USERPROFILE%\.nuget\packages</c> when it does not already
+    /// exist. That directory-creation branch is not deterministically unit-coverable: the path comes
+    /// from <see cref="Environment.GetFolderPath(Environment.SpecialFolder)"/> (which ignores env-var
+    /// redirection), so exercising it would require mutating the real user profile. See issue #630.
+    /// </remarks>
     public DirectoryInfo GetNuGetGlobalPackagesDir()
     {
         // In test mode (cache override set), use a "packages" subdir of the override directory
@@ -99,6 +121,12 @@ internal partial class NugetService(IWinappDirectoryService winappDirectoryServi
     /// <summary>
     /// Downloads and extracts a NuGet package to the global packages cache, then recursively installs dependencies.
     /// </summary>
+    /// <remarks>
+    /// The leading <c>installed.ContainsKey(package)</c> short-circuit is a defensive guard: the public
+    /// entry point seeds an empty dictionary and <see cref="ResolveDependenciesAsync"/> already skips
+    /// dependencies that are present before recursing, so this branch is not reachable through the public
+    /// API and is intentionally left uncovered. See issue #630.
+    /// </remarks>
     private async Task InstallPackageRecursiveAsync(string package, string version, Dictionary<string, string> installed, TaskContext taskContext, CancellationToken cancellationToken)
     {
         // Already processed this package?
@@ -124,7 +152,7 @@ internal partial class NugetService(IWinappDirectoryService winappDirectoryServi
         var lowerVersion = version.ToLowerInvariant();
         var url = $"{FlatIndex}/{lowerId}/{lowerVersion}/{lowerId}.{lowerVersion}.nupkg";
 
-        using var resp = await Http.GetAsync(url, cancellationToken);
+        using var resp = await HttpGetAsync(url, cancellationToken);
         if (!resp.IsSuccessStatusCode)
         {
             throw new InvalidOperationException($"Failed to download {package} {version} from NuGet (HTTP {resp.StatusCode})");
@@ -304,7 +332,7 @@ internal partial class NugetService(IWinappDirectoryService winappDirectoryServi
     private static async Task<List<string>> GetListedVersionsAsync(string packageName, CancellationToken cancellationToken)
     {
         var url = $"{RegistrationIndex}/{packageName.ToLowerInvariant()}/index.json";
-        using var resp = await Http.GetAsync(url, cancellationToken);
+        using var resp = await HttpGetAsync(url, cancellationToken);
         resp.EnsureSuccessStatusCode();
         using var stream = await resp.Content.ReadAsStreamAsync(cancellationToken);
         using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
@@ -340,7 +368,7 @@ internal partial class NugetService(IWinappDirectoryService winappDirectoryServi
                     continue;
                 }
 
-                using var pageResp = await Http.GetAsync(pageUrl, cancellationToken);
+                using var pageResp = await HttpGetAsync(pageUrl, cancellationToken);
                 pageResp.EnsureSuccessStatusCode();
                 using var pageStream = await pageResp.Content.ReadAsStreamAsync(cancellationToken);
                 using var pageDoc = await JsonDocument.ParseAsync(pageStream, cancellationToken: cancellationToken);
@@ -418,7 +446,7 @@ internal partial class NugetService(IWinappDirectoryService winappDirectoryServi
         var ver = version.ToLowerInvariant();
         var nuspecUrl = $"{FlatIndex}/{id}/{ver}/{id}.nuspec";
 
-        using var resp = await Http.GetAsync(nuspecUrl, cancellationToken);
+        using var resp = await HttpGetAsync(nuspecUrl, cancellationToken);
         if (!resp.IsSuccessStatusCode)
         {
             return dependencies;

--- a/src/winapp-CLI/WinApp.Cli/Services/NugetService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/NugetService.cs
@@ -30,16 +30,20 @@ internal partial class NugetService(IWinappDirectoryService winappDirectoryServi
     internal static Func<string, CancellationToken, Task<HttpResponseMessage>> HttpGetAsync { get; set; }
         = static (url, cancellationToken) => Http.GetAsync(url, cancellationToken);
 
+    /// <summary>
+    /// Seam for the current user's profile directory, used to compute the default NuGet
+    /// global-packages location (<c>%USERPROFILE%\.nuget\packages</c>). Defaults to
+    /// <see cref="Environment.GetFolderPath(Environment.SpecialFolder)"/> so production behavior is
+    /// unchanged; tests point it at a temporary directory so the default create-branch runs
+    /// hermetically without mutating the developer's (or CI runner's) real user profile.
+    /// </summary>
+    internal static Func<string> GetUserProfileDirectory { get; set; }
+        = static () => Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
     private const string FlatIndex = "https://api.nuget.org/v3-flatcontainer";
     private const string RegistrationIndex = "https://api.nuget.org/v3/registration5-semver1";
     private static readonly ConcurrentDictionary<string, Dictionary<string, string>> DependencyCache = new(StringComparer.OrdinalIgnoreCase);
 
-    /// <remarks>
-    /// The final fallback creates <c>%USERPROFILE%\.nuget\packages</c> when it does not already
-    /// exist. That directory-creation branch is not deterministically unit-coverable: the path comes
-    /// from <see cref="Environment.GetFolderPath(Environment.SpecialFolder)"/> (which ignores env-var
-    /// redirection), so exercising it would require mutating the real user profile. See issue #630.
-    /// </remarks>
     public DirectoryInfo GetNuGetGlobalPackagesDir()
     {
         // In test mode (cache override set), use a "packages" subdir of the override directory
@@ -67,7 +71,7 @@ internal partial class NugetService(IWinappDirectoryService winappDirectoryServi
         }
 
         // Default: %USERPROFILE%/.nuget/packages
-        var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var userProfile = GetUserProfileDirectory();
         var nugetDir = new DirectoryInfo(Path.Combine(userProfile, ".nuget", "packages"));
         if (!nugetDir.Exists)
         {
@@ -426,7 +430,11 @@ internal partial class NugetService(IWinappDirectoryService winappDirectoryServi
         var allDeps = new Dictionary<string, string>(directDeps, StringComparer.OrdinalIgnoreCase);
         foreach (var (depId, depVersion) in directDeps)
         {
-            var transitiveDeps = await GetPackageDependenciesAsync(depId, depVersion, cancellationToken);
+            // Normalize the dependency's version range to its minimum version before recursing so the
+            // transitive nuspec URL is well-formed. FetchDirectDependenciesAsync only strips brackets
+            // (e.g. "[2.0.0, )" -> "2.0.0, "), which would otherwise build a malformed flat-container
+            // URL and silently drop transitive dependencies nested under a range-versioned package.
+            var transitiveDeps = await GetPackageDependenciesAsync(depId, ParseMinimumVersion(depVersion), cancellationToken);
             foreach (var (transitiveId, transitiveVersion) in transitiveDeps)
             {
                 allDeps.TryAdd(transitiveId, transitiveVersion);

--- a/src/winapp-CLI/WinApp.Cli/Services/NugetService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/NugetService.cs
@@ -434,7 +434,16 @@ internal partial class NugetService(IWinappDirectoryService winappDirectoryServi
             // transitive nuspec URL is well-formed. FetchDirectDependenciesAsync only strips brackets
             // (e.g. "[2.0.0, )" -> "2.0.0, "), which would otherwise build a malformed flat-container
             // URL and silently drop transitive dependencies nested under a range-versioned package.
-            var transitiveDeps = await GetPackageDependenciesAsync(depId, ParseMinimumVersion(depVersion), cancellationToken);
+            var depMinVersion = ParseMinimumVersion(depVersion);
+            if (string.IsNullOrEmpty(depMinVersion))
+            {
+                // An open-lower-bound or otherwise unparseable range (e.g. "(,2.0.0]") has no concrete
+                // minimum to form a flat-container URL from; the direct dependency is already in allDeps,
+                // so skip its transitive fetch instead of requesting a malformed ".../<id>//<id>.nuspec".
+                continue;
+            }
+
+            var transitiveDeps = await GetPackageDependenciesAsync(depId, depMinVersion, cancellationToken);
             foreach (var (transitiveId, transitiveVersion) in transitiveDeps)
             {
                 allDeps.TryAdd(transitiveId, transitiveVersion);


### PR DESCRIPTION
## What

Raises per-file test coverage to ≥95% for three files that PR #654 restored to their pre-migration state (issue #630):

| File | Before | After |
|------|-------:|------:|
| `Commands/UpdateCommand.cs` | 3.4% | **100%** |
| `Services/PackageInstallationService.cs` | 65.6% | **100%** |
| `Services/NugetService.cs` | 85.2% | **99.4%** |

`NugetService.cs`'s only remaining uncovered lines are a genuinely-unreachable defensive guard in `InstallPackageRecursiveAsync` (public entry seeds an empty dict and `ResolveDependenciesAsync` skips present deps before recursing), documented in-source with a `<remarks>` referencing #630. No `[ExcludeFromCodeCoverage]`, no `coverage.runsettings` edits.

## Product changes (minimal, behavior-preserving)

- **Two `internal static Func` test seams** on `NugetService`: `HttpGetAsync` (defaults to the shared `HttpClient.GetAsync` — the single real network boundary; tests inject canned in-memory responses) and `GetUserProfileDirectory` (defaults to `Environment.GetFolderPath(UserProfile)`; lets the default `%USERPROFILE%\.nuget\packages` create-branch be exercised hermetically against a temp dir instead of mutating the real user profile). Both default delegates are byte-for-byte the original behavior.
- **One correctness fix (called out separately):** `ResolveDependenciesAsync` now normalizes a dependency's version via `ParseMinimumVersion` before recursing into `GetPackageDependenciesAsync`. Previously the raw value from `FetchDirectDependenciesAsync` (which strips only brackets, `"[2.0.0, )"` → `"2.0.0, "`) built a malformed flat-container URL, silently **dropping transitive dependencies nested under a range-versioned package**. No-op for exact versions; the sibling on-disk path and the direct consumer already applied this normalization. The offline test fakes now match the slash-delimited `/<id>/<version>/` URL segment so this path genuinely 404s without the fix (the transitive test fails if the fix is reverted).

## Tests

- `NugetServiceOfflineTests` — restore/download/version-resolution/transitive+diamond-dedup, listed-version filtering, nuspec parsing, HTTP-error paths, the hermetic default-fallback create-branch, and the range-versioned transitive walk. `[DoNotParallelize]`; all process-wide seams + NuGet env vars saved/restored per test.
- `PackageInstallationServiceTests`, `UpdateCommandTests` — version resolution, already-present top-up merges, updates-found/all-up-to-date/preview, per-package + build-tools failure paths.

## Validation

- Debug solution + Release (both `WinApp.Cli` and `WinApp.Cli.Tests`, warnings-as-errors): **0 W / 0 E** each.
- Scoped coverage run: **97/97 passed**, deterministic.
- Reviewed with the repo `pr-review` skill (7 specialists + a GPT multi-model cross-check) before opening; the two accepted findings (real-profile mutation risk + a fake that masked the range-version bug) are fixed in this branch.

## ⚠️ Caveat

This wave re-covers the **pre-migration** NuGet client that #654 restored (#654 reverted the #629 migration + its #647 tests together). If maintainers re-attempt the migration, these three test files and the two seams will likely need rework. The `ParseMinimumVersion` correctness fix has standalone value while this code ships.
