### PR TITLE
Test coverage: UI touch/pen commands + pointer support (issue #630)

### DIFF
--- a/src/winapp-CLI/WinApp.Cli.Tests/BaseCommandTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/BaseCommandTests.cs
@@ -106,6 +106,37 @@ public abstract class BaseCommandTests(bool configPaths = true, LogLevel logLeve
     }
 
     /// <summary>
+    /// Invokes <paramref name="command"/> with the process-wide Spectre ambient console
+    /// (<see cref="AnsiConsole.Console"/>) temporarily redirected to a fresh <see cref="TestConsole"/>,
+    /// then always restores the previous ambient console — even on failure — so global console state
+    /// does not leak across tests. Use this to capture output written through the static ambient
+    /// console (e.g. Info/Warning log lines that do not route through the injected stderr writer).
+    /// </summary>
+    /// <remarks>
+    /// Callers must be <c>[DoNotParallelize]</c> because the ambient console is process-wide. The
+    /// command's own stdout/stderr are still captured via <see cref="ParseAndInvokeWithCaptureAsync(Command, string[])"/>
+    /// (into <see cref="TestAnsiConsole"/> / <see cref="ConsoleStdErr"/>); the returned string is the
+    /// text written to the swapped-in ambient console.
+    /// </remarks>
+    /// <returns>The command exit code and the text captured from the ambient console.</returns>
+    protected async Task<(int ExitCode, string AmbientOutput)> InvokeWithAmbientConsoleCaptureAsync(
+        Command command, string[] manifestArgs)
+    {
+        var previousAmbient = AnsiConsole.Console;
+        var ambient = new TestConsole();
+        AnsiConsole.Console = ambient;
+        try
+        {
+            int exitCode = await ParseAndInvokeWithCaptureAsync(command, manifestArgs);
+            return (exitCode, ambient.Output);
+        }
+        finally
+        {
+            AnsiConsole.Console = previousAmbient;
+        }
+    }
+
+    /// <summary>
     /// Invokes <see cref="Program.Main"/> with captured stdout/stderr.
     /// Writers are intentionally not disposed to avoid ObjectDisposedException from
     /// Spectre.Console's static AnsiConsole.Console which may reference them after return.

--- a/src/winapp-CLI/WinApp.Cli.Tests/PointerInputFrameTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/PointerInputFrameTests.cs
@@ -917,4 +917,103 @@ public class PointerInputFrameTests
         Assert.IsFalse(PointerInput.IsWin32ErrorNotReady(caught!),
             "The propagated exception must not be recognised as a Win32 error 21");
     }
+
+    // -------------------------------------------------------------------------
+    // Bucket 3 (issue #630) — coverage top-up for two residual InjectTouchStroke
+    // frame branches: (1) the best-effort finally lift that SUCCEEDS after a
+    // mid-stroke glide throw (complement to the ..._UpFailureSwallowed case), and
+    // (2) Interpolate's single-waypoint fast path, reached when one contact has a
+    // lone waypoint while another glides. Both use durationMs:0 so they run with
+    // no real-clock delays.
+    // -------------------------------------------------------------------------
+
+    [TestMethod]
+    public void InjectTouchStroke_GlideFrameThrows_BestEffortLiftSucceeds_OriginalExceptionPreserved()
+    {
+        // Complement to ..._UpFailureSwallowed: the mid-stroke glide throws, but the finally's
+        // best-effort UP lift SUCCEEDS. The original glide exception must still propagate unmasked,
+        // and a genuine UP frame must have been emitted during the unwind (best-effort cleanup).
+        var glideEx = new InvalidOperationException("glide frame failed");
+
+        int sendCount = 0;
+        bool glideAttempted = false;
+        bool upLiftSent = false;
+
+        PointerInput.TouchSender sender = contacts =>
+        {
+            sendCount++;
+            if (contacts.Any(c => c.pointerInfo.pointerFlags.HasFlag(POINTER_FLAGS.POINTER_FLAG_UP)))
+            {
+                upLiftSent = true; // best-effort lift in the finally succeeds (does NOT throw)
+                return;
+            }
+            if (contacts.Any(c => c.pointerInfo.pointerFlags.HasFlag(POINTER_FLAGS.POINTER_FLAG_UPDATE)))
+            {
+                glideAttempted = true;
+                throw glideEx;
+            }
+        };
+
+        // Single contact, two waypoints → exactly one immediate glide (UPDATE) frame, which throws
+        // and unwinds to the finally before the normal-path UP is reached.
+        var paths = new List<IReadOnlyList<PointerPoint>>
+        {
+            new List<PointerPoint> { new PointerPoint(0, 0), new PointerPoint(100, 0) }
+        };
+
+        InvalidOperationException? caught = null;
+        try
+        {
+            PointerInput.InjectTouchStroke(paths, holdMs: 0, durationMs: 0, sender);
+            Assert.Fail("Expected the glide exception to propagate");
+        }
+        catch (InvalidOperationException ex) { caught = ex; }
+
+        Assert.AreSame(glideEx, caught,
+            "The original glide exception must propagate even though the best-effort lift SUCCEEDED");
+        Assert.IsTrue(glideAttempted, "The glide (UPDATE) frame must have been attempted");
+        Assert.IsTrue(upLiftSent, "The finally must still emit a best-effort UP lift frame after the glide throw");
+        Assert.AreEqual(3, sendCount,
+            "Expected exactly three sends: DOWN, the throwing glide UPDATE, then the best-effort UP lift");
+    }
+
+    [TestMethod]
+    public void InjectTouchStroke_MixedWaypointCounts_SingleWaypointContactStaysPinned()
+    {
+        // One multi-waypoint contact drives the glide loop; a second, single-waypoint contact must
+        // stay pinned at its lone coordinate on every glide frame (Interpolate's Count==1 fast path),
+        // rather than drifting toward the moving contact.
+        var movingStart = new PointerPoint(0, 0);
+        var movingEnd = new PointerPoint(100, 0);
+        var pinned = new PointerPoint(500, 500);
+
+        var paths = new List<IReadOnlyList<PointerPoint>>
+        {
+            new List<PointerPoint> { movingStart, movingEnd }, // contact 0: two waypoints → glides
+            new List<PointerPoint> { pinned }                  // contact 1: one waypoint → pinned
+        };
+
+        var contact1Positions = new List<(int X, int Y)>();
+        var contact0Positions = new List<(int X, int Y)>();
+
+        PointerInput.TouchSender sender = contacts =>
+        {
+            if (contacts.Any(c => c.pointerInfo.pointerFlags.HasFlag(POINTER_FLAGS.POINTER_FLAG_UPDATE)))
+            {
+                var c0 = contacts[0];
+                var c1 = contacts[1];
+                contact0Positions.Add((c0.pointerInfo.ptPixelLocation.X, c0.pointerInfo.ptPixelLocation.Y));
+                contact1Positions.Add((c1.pointerInfo.ptPixelLocation.X, c1.pointerInfo.ptPixelLocation.Y));
+            }
+        };
+
+        PointerInput.InjectTouchStroke(paths, holdMs: 0, durationMs: 0, sender);
+
+        Assert.IsTrue(contact1Positions.Count > 1,
+            "A multi-waypoint contact must produce multiple glide (UPDATE) frames");
+        Assert.IsTrue(contact1Positions.All(p => p == (pinned.X, pinned.Y)),
+            "The single-waypoint contact must stay pinned at its lone coordinate across every glide frame");
+        Assert.IsTrue(contact0Positions.Any(p => p.X > movingStart.X && p.X <= movingEnd.X),
+            "The multi-waypoint contact must actually advance along its segment (sanity check the glide moved)");
+    }
 }

--- a/src/winapp-CLI/WinApp.Cli.Tests/PointerInputPressureTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/PointerInputPressureTests.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using WinApp.Cli.Helpers;
+
+namespace WinApp.Cli.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="PointerInput.MapPenPressure"/> — the pure float→Win32 (1..1024) pen
+/// pressure mapping extracted from <see cref="PointerInput.Pen"/> so it is coverable without the
+/// native synthetic-pointer device (issue #630). Verifies linear mapping, nearest-integer rounding,
+/// clamping at both bounds, and the non-zero-pressure guarantee that in-contact pen frames require.
+/// </summary>
+[TestClass]
+public class PointerInputPressureTests
+{
+    [TestMethod]
+    [DataRow(0.0f, 1u, "0.0 maps to 0, then the in-contact guarantee bumps it up to 1")]
+    [DataRow(0.0004f, 1u, "A fraction that rounds to 0 (0.0004*1024 ≈ 0.41) is bumped up to 1")]
+    [DataRow(0.25f, 256u, "Interior value maps linearly: 0.25 * 1024 = 256")]
+    [DataRow(0.5f, 512u, "Interior value maps linearly: 0.5 * 1024 = 512")]
+    [DataRow(1.0f, 1024u, "Full pressure maps to the max: 1.0 * 1024 = 1024")]
+    [DataRow(2.0f, 1024u, "Above-range pressure clamps down to the 1024 upper bound")]
+    [DataRow(-1.0f, 1u, "Below-range pressure clamps to 0, then is bumped up to 1")]
+    public void MapPenPressure_MapsAndClampsToWin32Range(float pressure, uint expected, string because)
+    {
+        Assert.AreEqual(expected, PointerInput.MapPenPressure(pressure), because);
+    }
+
+    [TestMethod]
+    public void MapPenPressure_RoundsToNearestInteger_NotTruncates()
+    {
+        // 0.7 * 1024 = 716.8 -> must round to nearest (717), not truncate toward zero (716).
+        Assert.AreEqual(717u, PointerInput.MapPenPressure(0.7f),
+            "0.7 * 1024 = 716.8 must round to the nearest integer (717), not truncate to 716");
+    }
+
+    [TestMethod]
+    public void MapPenPressure_NeverReturnsZero_SoInContactFramesStayInContact()
+    {
+        // Windows drops an in-contact pen frame that reports zero pressure, so any tiny or
+        // non-positive input must still yield at least 1 (the ==0 -> 1 guard).
+        Assert.AreEqual(1u, PointerInput.MapPenPressure(0.0f), "zero must not stay zero");
+        Assert.AreEqual(1u, PointerInput.MapPenPressure(0.00001f), "a sub-half-unit fraction must not stay zero");
+        Assert.AreEqual(1u, PointerInput.MapPenPressure(-5.0f), "a negative pressure clamps to 0 then bumps to 1");
+    }
+}

--- a/src/winapp-CLI/WinApp.Cli.Tests/UiCommandTests.Pen.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/UiCommandTests.Pen.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
 // Licensed under the MIT License.
 
+using Spectre.Console;
+using Spectre.Console.Testing;
 using WinApp.Cli.Commands;
 using WinApp.Cli.Helpers;
 using WinApp.Cli.Models;
@@ -435,5 +437,199 @@ public partial class UiCommandTests
         var result = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(TestAnsiConsole.Output);
         Assert.IsFalse(result.TryGetProperty("warnings", out _),
             "A local console session must not emit the remote-delivery warning");
+    }
+
+    // -------------------------------------------------------------------------
+    // Bucket 3 (issue #630) — coverage top-up: the remaining argument-validation
+    // branches, the selector-resolution failure guard, the non-JSON success/
+    // warning render path, and the COM / generic catch arms. Driven through the
+    // command handler with the existing fakes — no live injection.
+    // -------------------------------------------------------------------------
+
+    [TestMethod]
+    public void Pen_ShortDescription_NamesPenInput()
+    {
+        var description = GetRequiredService<UiPenCommand>().ShortDescription;
+        Assert.IsFalse(string.IsNullOrWhiteSpace(description));
+        StringAssert.Contains(description, "pen");
+    }
+
+    [TestMethod]
+    public async Task Pen_NegativeDuration_RejectedWithInvalidArguments()
+    {
+        // A negative --duration-ms is rejected by the lower-bound guard (distinct from the >Max guard).
+        var command = GetRequiredService<UiPenCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command,
+            ["-a", "TestApp", "--duration-ms", "-5", "--json"]);
+
+        Assert.AreEqual(1, exitCode);
+        Assert.AreEqual(0, _fakePointer.PenCalls.Count);
+        StringAssert.Contains(ConsoleStdErr.ToString(), "--duration-ms");
+    }
+
+    [TestMethod]
+    public async Task Pen_TiltOutOfRange_RejectedWithInvalidArguments()
+    {
+        // A parseable but out-of-range --tilt-x (>90) trips the handler's tilt range guard (distinct
+        // from the parse-time non-integer rejection already covered).
+        var command = GetRequiredService<UiPenCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command,
+            ["-a", "TestApp", "--at", "100,100", "--tilt-x", "200", "--json"]);
+
+        Assert.AreEqual(1, exitCode);
+        Assert.AreEqual(0, _fakePointer.PenCalls.Count);
+        StringAssert.Contains(ConsoleStdErr.ToString(), "tilt");
+    }
+
+    [TestMethod]
+    public async Task Pen_MalformedPath_RejectedWithInvalidArguments()
+    {
+        var command = GetRequiredService<UiPenCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command,
+            ["-a", "TestApp", "--path", "not-a-path", "--json"]);
+
+        Assert.AreEqual(1, exitCode);
+        Assert.AreEqual(0, _fakePointer.PenCalls.Count);
+        StringAssert.Contains(ConsoleStdErr.ToString(), "--path");
+    }
+
+    [TestMethod]
+    public async Task Pen_MalformedAtPoint_RejectedWithInvalidArguments()
+    {
+        var command = GetRequiredService<UiPenCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command,
+            ["-a", "TestApp", "--at", "nonsense", "--json"]);
+
+        Assert.AreEqual(1, exitCode);
+        Assert.AreEqual(0, _fakePointer.PenCalls.Count);
+        StringAssert.Contains(ConsoleStdErr.ToString(), "--at");
+    }
+
+    [TestMethod]
+    public async Task Pen_NoTarget_NoSelectorNoAtNoPath_RejectedWithInvalidArguments()
+    {
+        // Without a selector, --at, or --path there is no contact point to resolve.
+        var command = GetRequiredService<UiPenCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["-a", "TestApp", "--json"]);
+
+        Assert.AreEqual(1, exitCode);
+        Assert.AreEqual(0, _fakePointer.PenCalls.Count);
+        StringAssert.Contains(ConsoleStdErr.ToString(), "Provide a target");
+    }
+
+    [TestMethod]
+    public async Task Pen_MissingApp_NoAppNoWindow_ReturnsMissingApp()
+    {
+        // A valid selector but no --app/--window: the missing-app guard fires after all argument
+        // validation (so it yields missing_app, not invalid_arguments).
+        var command = GetRequiredService<UiPenCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["canvas-1", "--json"]);
+
+        Assert.AreEqual(1, exitCode);
+        Assert.AreEqual(0, _fakePointer.PenCalls.Count);
+        StringAssert.Contains(ConsoleStdErr.ToString(), "Target app required");
+    }
+
+    [TestMethod]
+    public async Task Pen_SelectorNotFound_ReturnsElementNotFound_NoInjection()
+    {
+        // A bare selector that resolves to no element: ResolvePointAsync reports element_not_found and
+        // returns not-Ok, so the command aborts before injection (covers the !target.Ok guard in the
+        // selector branch). FindSingleResult stays null by default.
+        _fakeSession.SessionResult.WindowHandle = 6100;
+
+        var command = GetRequiredService<UiPenCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["ghost-element", "-a", "TestApp", "--json"]);
+
+        Assert.AreEqual(1, exitCode);
+        Assert.AreEqual(0, _fakePointer.PenCalls.Count);
+        StringAssert.Contains(ConsoleStdErr.ToString(), "No element found");
+    }
+
+    [TestMethod]
+    [DoNotParallelize] // swaps the process-wide ambient AnsiConsole to capture non-error logger output
+    public async Task Pen_NonJson_LocalSession_LogsSuccessWithoutWarning()
+    {
+        // The non-JSON render path logs a human success line and, for a local session, no delivery
+        // warning. Info/Warning route through the static ambient console, so we swap it to capture.
+        _fakeSession.SessionResult.WindowHandle = 8400;
+        _fakeForeground.IsRemoteSessionResult = false;
+
+        var command = GetRequiredService<UiPenCommand>();
+        var previousAmbient = AnsiConsole.Console;
+        var ambient = new TestConsole();
+        AnsiConsole.Console = ambient;
+        int exitCode;
+        try
+        {
+            exitCode = await ParseAndInvokeWithCaptureAsync(command, ["-a", "TestApp", "--at", "120,130"]);
+        }
+        finally
+        {
+            AnsiConsole.Console = previousAmbient;
+        }
+
+        Assert.AreEqual(0, exitCode);
+        Assert.AreEqual(1, _fakePointer.PenCalls.Count);
+        Assert.IsFalse(TestAnsiConsole.Output.Contains('{'), "Non-JSON path must not emit a JSON envelope");
+        StringAssert.Contains(ambient.Output, "pen", "Success line must name the pen action");
+        Assert.IsFalse(ambient.Output.Contains("remote", StringComparison.OrdinalIgnoreCase),
+            "A local session must not emit the remote-delivery warning");
+    }
+
+    [TestMethod]
+    [DoNotParallelize] // swaps the process-wide ambient AnsiConsole to capture non-error logger output
+    public async Task Pen_NonJson_RemoteSession_LogsSuccessAndDeliveryWarning()
+    {
+        _fakeSession.SessionResult.WindowHandle = 8401;
+        _fakeForeground.IsRemoteSessionResult = true;
+
+        var command = GetRequiredService<UiPenCommand>();
+        var previousAmbient = AnsiConsole.Console;
+        var ambient = new TestConsole();
+        AnsiConsole.Console = ambient;
+        int exitCode;
+        try
+        {
+            exitCode = await ParseAndInvokeWithCaptureAsync(command, ["-a", "TestApp", "--at", "120,130"]);
+        }
+        finally
+        {
+            AnsiConsole.Console = previousAmbient;
+        }
+
+        Assert.AreEqual(0, exitCode, "The remote warning is advisory; injection still succeeds");
+        Assert.AreEqual(1, _fakePointer.PenCalls.Count);
+        StringAssert.Contains(ambient.Output, "remote", "Remote session must surface the delivery-uncertainty warning");
+    }
+
+    [TestMethod]
+    public async Task Pen_ComException_ReturnsStaleElement_NoInjection()
+    {
+        // A COMException surfacing during resolution is a stale-element signal; the command maps it to
+        // the stale envelope and never injects.
+        _fakeUia.FindSingleElementThrowException = new System.Runtime.InteropServices.COMException("UIA stale (test)");
+
+        var command = GetRequiredService<UiPenCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["canvas-1", "-a", "TestApp", "--json"]);
+
+        Assert.AreEqual(1, exitCode);
+        Assert.AreEqual(0, _fakePointer.PenCalls.Count);
+        StringAssert.Contains(ConsoleStdErr.ToString(), "no longer accessible");
+    }
+
+    [TestMethod]
+    public async Task Pen_GenericException_ReturnsInternalError_NoInjection()
+    {
+        // A non-COM, non-app-not-found, non-IOE exception during session resolution falls through to
+        // the catch-all generic handler and is reported (not swallowed or crashed).
+        _fakeSession.ResolveThrow = new TimeoutException("boom (test)");
+
+        var command = GetRequiredService<UiPenCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["canvas-1", "-a", "TestApp", "--json"]);
+
+        Assert.AreEqual(1, exitCode);
+        Assert.AreEqual(0, _fakePointer.PenCalls.Count);
+        StringAssert.Contains(ConsoleStdErr.ToString(), "boom (test)");
     }
 }

--- a/src/winapp-CLI/WinApp.Cli.Tests/UiCommandTests.Pen.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/UiCommandTests.Pen.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
 // Licensed under the MIT License.
 
-using Spectre.Console;
-using Spectre.Console.Testing;
 using WinApp.Cli.Commands;
 using WinApp.Cli.Helpers;
 using WinApp.Cli.Models;
@@ -556,24 +554,13 @@ public partial class UiCommandTests
         _fakeForeground.IsRemoteSessionResult = false;
 
         var command = GetRequiredService<UiPenCommand>();
-        var previousAmbient = AnsiConsole.Console;
-        var ambient = new TestConsole();
-        AnsiConsole.Console = ambient;
-        int exitCode;
-        try
-        {
-            exitCode = await ParseAndInvokeWithCaptureAsync(command, ["-a", "TestApp", "--at", "120,130"]);
-        }
-        finally
-        {
-            AnsiConsole.Console = previousAmbient;
-        }
+        var (exitCode, ambientOutput) = await InvokeWithAmbientConsoleCaptureAsync(command, ["-a", "TestApp", "--at", "120,130"]);
 
         Assert.AreEqual(0, exitCode);
         Assert.AreEqual(1, _fakePointer.PenCalls.Count);
         Assert.IsFalse(TestAnsiConsole.Output.Contains('{'), "Non-JSON path must not emit a JSON envelope");
-        StringAssert.Contains(ambient.Output, "pen", "Success line must name the pen action");
-        Assert.IsFalse(ambient.Output.Contains("remote", StringComparison.OrdinalIgnoreCase),
+        StringAssert.Contains(ambientOutput, "pen", "Success line must name the pen action");
+        Assert.IsFalse(ambientOutput.Contains("remote", StringComparison.OrdinalIgnoreCase),
             "A local session must not emit the remote-delivery warning");
     }
 
@@ -585,22 +572,11 @@ public partial class UiCommandTests
         _fakeForeground.IsRemoteSessionResult = true;
 
         var command = GetRequiredService<UiPenCommand>();
-        var previousAmbient = AnsiConsole.Console;
-        var ambient = new TestConsole();
-        AnsiConsole.Console = ambient;
-        int exitCode;
-        try
-        {
-            exitCode = await ParseAndInvokeWithCaptureAsync(command, ["-a", "TestApp", "--at", "120,130"]);
-        }
-        finally
-        {
-            AnsiConsole.Console = previousAmbient;
-        }
+        var (exitCode, ambientOutput) = await InvokeWithAmbientConsoleCaptureAsync(command, ["-a", "TestApp", "--at", "120,130"]);
 
         Assert.AreEqual(0, exitCode, "The remote warning is advisory; injection still succeeds");
         Assert.AreEqual(1, _fakePointer.PenCalls.Count);
-        StringAssert.Contains(ambient.Output, "remote", "Remote session must surface the delivery-uncertainty warning");
+        StringAssert.Contains(ambientOutput, "remote", "Remote session must surface the delivery-uncertainty warning");
     }
 
     [TestMethod]

--- a/src/winapp-CLI/WinApp.Cli.Tests/UiCommandTests.Pen.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/UiCommandTests.Pen.cs
@@ -592,6 +592,7 @@ public partial class UiCommandTests
         Assert.AreEqual(1, exitCode);
         Assert.AreEqual(0, _fakePointer.PenCalls.Count);
         StringAssert.Contains(ConsoleStdErr.ToString(), "no longer accessible");
+        AssertJsonErrorCode(UiJsonError.CodeStaleElement);
     }
 
     [TestMethod]
@@ -607,5 +608,6 @@ public partial class UiCommandTests
         Assert.AreEqual(1, exitCode);
         Assert.AreEqual(0, _fakePointer.PenCalls.Count);
         StringAssert.Contains(ConsoleStdErr.ToString(), "boom (test)");
+        AssertJsonErrorCode(UiJsonError.CodeInternalError);
     }
 }

--- a/src/winapp-CLI/WinApp.Cli.Tests/UiCommandTests.Touch.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/UiCommandTests.Touch.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
 // Licensed under the MIT License.
 
-using Spectre.Console;
-using Spectre.Console.Testing;
 using WinApp.Cli.Commands;
 using WinApp.Cli.Helpers;
 using WinApp.Cli.Models;
@@ -745,24 +743,13 @@ public partial class UiCommandTests
         _fakeForeground.IsRemoteSessionResult = false;
 
         var command = GetRequiredService<UiTouchCommand>();
-        var previousAmbient = AnsiConsole.Console;
-        var ambient = new TestConsole();
-        AnsiConsole.Console = ambient;
-        int exitCode;
-        try
-        {
-            exitCode = await ParseAndInvokeWithCaptureAsync(command, ["-a", "TestApp", "--at", "150,160"]);
-        }
-        finally
-        {
-            AnsiConsole.Console = previousAmbient;
-        }
+        var (exitCode, ambientOutput) = await InvokeWithAmbientConsoleCaptureAsync(command, ["-a", "TestApp", "--at", "150,160"]);
 
         Assert.AreEqual(0, exitCode);
         Assert.AreEqual(1, _fakePointer.TouchCalls.Count);
         Assert.IsFalse(TestAnsiConsole.Output.Contains('{'), "Non-JSON path must not emit a JSON envelope");
-        StringAssert.Contains(ambient.Output, "tap", "Success line must name the gesture");
-        Assert.IsFalse(ambient.Output.Contains("remote", StringComparison.OrdinalIgnoreCase),
+        StringAssert.Contains(ambientOutput, "tap", "Success line must name the gesture");
+        Assert.IsFalse(ambientOutput.Contains("remote", StringComparison.OrdinalIgnoreCase),
             "A local session must not emit the remote-delivery warning");
     }
 
@@ -776,22 +763,11 @@ public partial class UiCommandTests
         _fakeForeground.IsRemoteSessionResult = true;
 
         var command = GetRequiredService<UiTouchCommand>();
-        var previousAmbient = AnsiConsole.Console;
-        var ambient = new TestConsole();
-        AnsiConsole.Console = ambient;
-        int exitCode;
-        try
-        {
-            exitCode = await ParseAndInvokeWithCaptureAsync(command, ["-a", "TestApp", "--at", "150,160"]);
-        }
-        finally
-        {
-            AnsiConsole.Console = previousAmbient;
-        }
+        var (exitCode, ambientOutput) = await InvokeWithAmbientConsoleCaptureAsync(command, ["-a", "TestApp", "--at", "150,160"]);
 
         Assert.AreEqual(0, exitCode, "The remote warning is advisory; injection still succeeds");
         Assert.AreEqual(1, _fakePointer.TouchCalls.Count);
-        StringAssert.Contains(ambient.Output, "remote", "Remote session must surface the delivery-uncertainty warning");
+        StringAssert.Contains(ambientOutput, "remote", "Remote session must surface the delivery-uncertainty warning");
     }
 
     [TestMethod]

--- a/src/winapp-CLI/WinApp.Cli.Tests/UiCommandTests.Touch.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/UiCommandTests.Touch.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
 // Licensed under the MIT License.
 
+using Spectre.Console;
+using Spectre.Console.Testing;
 using WinApp.Cli.Commands;
 using WinApp.Cli.Helpers;
 using WinApp.Cli.Models;
@@ -551,5 +553,274 @@ public partial class UiCommandTests
         Assert.IsNotNull(msg);
         StringAssert.Contains(msg, "touch", "Warning must name the input kind");
         StringAssert.Contains(msg, "remote", "Warning must name the remote caveat");
+    }
+
+    // -------------------------------------------------------------------------
+    // Bucket 3 (issue #630) — coverage top-up: the remaining argument-validation
+    // branches, selector-resolution failures (via PointerCommandSupport), the
+    // non-JSON success/warning render path, and the COM / generic catch arms.
+    // All driven through the command handler with the existing fakes — no live
+    // injection. LogError output routes to the captured stderr; non-error logger
+    // output (Info/Warning) routes through the static ambient console, so those
+    // tests swap it to capture and are marked [DoNotParallelize].
+    // -------------------------------------------------------------------------
+
+    [TestMethod]
+    public void Touch_ShortDescription_NamesTouchGestures()
+    {
+        var description = GetRequiredService<UiTouchCommand>().ShortDescription;
+        Assert.IsFalse(string.IsNullOrWhiteSpace(description));
+        StringAssert.Contains(description, "touch");
+    }
+
+    [TestMethod]
+    public async Task Touch_FingersZero_RejectedWithInvalidArguments_NoInjection()
+    {
+        // --fingers 0 trips the `fingers < 1` lower-bound guard (distinct from the >MaxContacts
+        // upper-bound already covered). Rejected up front, before any window resolution.
+        var command = GetRequiredService<UiTouchCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command,
+            ["-a", "TestApp", "--at", "100,100", "--fingers", "0", "--json"]);
+
+        Assert.AreEqual(1, exitCode);
+        Assert.AreEqual(0, _fakePointer.TouchCalls.Count);
+        Assert.AreEqual(0, _fakeUia.WindowRectCalls.Count);
+        StringAssert.Contains(ConsoleStdErr.ToString(), "--fingers");
+    }
+
+    [TestMethod]
+    public async Task Touch_InvalidDirectionValue_RejectedWithInvalidArguments()
+    {
+        // A --direction value outside {right,left,up,down} is rejected by the up-front value check.
+        // Using a swipe means the ONLY reason to reject is the invalid direction value itself.
+        var command = GetRequiredService<UiTouchCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command,
+            ["-a", "TestApp", "--at", "100,100", "--gesture", "swipe", "--direction", "diagonal", "--distance", "50", "--json"]);
+
+        Assert.AreEqual(1, exitCode);
+        Assert.AreEqual(0, _fakePointer.TouchCalls.Count);
+        StringAssert.Contains(ConsoleStdErr.ToString(), "--direction");
+    }
+
+    [TestMethod]
+    public async Task Touch_MalformedAtPoint_RejectedWithInvalidArguments()
+    {
+        var command = GetRequiredService<UiTouchCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command,
+            ["-a", "TestApp", "--at", "not-a-point", "--json"]);
+
+        Assert.AreEqual(1, exitCode);
+        Assert.AreEqual(0, _fakePointer.TouchCalls.Count);
+        StringAssert.Contains(ConsoleStdErr.ToString(), "--at");
+    }
+
+    [TestMethod]
+    public async Task Touch_MalformedToPoint_OnSwipe_RejectedWithInvalidArguments()
+    {
+        // --to-point is only parsed on a swipe (the non-swipe guard fires earlier otherwise), so a
+        // malformed value must reach the point-parse failure branch.
+        var command = GetRequiredService<UiTouchCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command,
+            ["-a", "TestApp", "--gesture", "swipe", "--to-point", "junk", "--json"]);
+
+        Assert.AreEqual(1, exitCode);
+        Assert.AreEqual(0, _fakePointer.TouchCalls.Count);
+        StringAssert.Contains(ConsoleStdErr.ToString(), "--to-point");
+    }
+
+    [TestMethod]
+    public async Task Touch_NoTarget_NoSelectorNoAt_RejectedWithInvalidArguments()
+    {
+        // Neither a selector nor --at: the command cannot resolve a point to touch.
+        var command = GetRequiredService<UiTouchCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["-a", "TestApp", "--json"]);
+
+        Assert.AreEqual(1, exitCode);
+        Assert.AreEqual(0, _fakePointer.TouchCalls.Count);
+        StringAssert.Contains(ConsoleStdErr.ToString(), "Provide a target");
+    }
+
+    [TestMethod]
+    public async Task Touch_Pinch_WithoutDistance_RejectedWithInvalidArguments()
+    {
+        // Pinch/stretch require an explicit --distance (finger spread). Without it, distance defaults
+        // to 0 and the gesture is rejected before injection.
+        var command = GetRequiredService<UiTouchCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command,
+            ["-a", "TestApp", "--at", "100,100", "--gesture", "pinch", "--json"]);
+
+        Assert.AreEqual(1, exitCode);
+        Assert.AreEqual(0, _fakePointer.TouchCalls.Count);
+        StringAssert.Contains(ConsoleStdErr.ToString(), "distance");
+    }
+
+    [TestMethod]
+    public async Task Touch_Swipe_WithoutToPointOrDistance_RejectedWithInvalidArguments()
+    {
+        // A swipe needs either --to-point or --distance to compute an end point; with neither it is
+        // rejected rather than degenerating into a zero-length swipe.
+        var command = GetRequiredService<UiTouchCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command,
+            ["-a", "TestApp", "--at", "100,100", "--gesture", "swipe", "--json"]);
+
+        Assert.AreEqual(1, exitCode);
+        Assert.AreEqual(0, _fakePointer.TouchCalls.Count);
+        StringAssert.Contains(ConsoleStdErr.ToString(), "swipe requires");
+    }
+
+    [TestMethod]
+    public async Task Touch_MissingApp_NoAppNoWindow_ReturnsMissingApp()
+    {
+        // With valid arguments but no --app/--window, the missing-app guard fires AFTER all argument
+        // validation (so a valid selector + no app yields missing_app, not invalid_arguments).
+        var command = GetRequiredService<UiTouchCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["btn-ok", "--json"]);
+
+        Assert.AreEqual(1, exitCode);
+        Assert.AreEqual(0, _fakePointer.TouchCalls.Count);
+        StringAssert.Contains(ConsoleStdErr.ToString(), "Target app required");
+    }
+
+    [TestMethod]
+    public async Task Touch_SelectorNotFound_ReturnsElementNotFound_NoInjection()
+    {
+        // A bare selector that resolves to no element: ResolvePointAsync reports element_not_found and
+        // returns not-Ok, so the command aborts before injection (covers the null-element branch of
+        // PointerCommandSupport and the !target.Ok guard). FindSingleResult stays null by default.
+        _fakeSession.SessionResult.WindowHandle = 6100;
+
+        var command = GetRequiredService<UiTouchCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["ghost-element", "-a", "TestApp", "--json"]);
+
+        Assert.AreEqual(1, exitCode);
+        Assert.AreEqual(0, _fakePointer.TouchCalls.Count);
+        StringAssert.Contains(ConsoleStdErr.ToString(), "No element found");
+    }
+
+    [TestMethod]
+    public async Task Touch_SelectorZeroSizeElement_ReturnsZeroSize_NoInjection()
+    {
+        // A resolved element with zero width/height cannot supply a usable center point.
+        _fakeUia.FindSingleResult = new UiElement
+        {
+            Id = "e0", Type = "Button", Selector = "flat-btn",
+            X = 100, Y = 100, Width = 0, Height = 20, WindowHandle = 6200
+        };
+
+        var command = GetRequiredService<UiTouchCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["flat-btn", "-a", "TestApp", "--json"]);
+
+        Assert.AreEqual(1, exitCode);
+        Assert.AreEqual(0, _fakePointer.TouchCalls.Count);
+        StringAssert.Contains(ConsoleStdErr.ToString(), "zero size");
+    }
+
+    [TestMethod]
+    public async Task Touch_SelectorTargetVanishesBeforeInjection_ReturnsTargetMoved_NoInjection()
+    {
+        // The selector resolves initially, but the pre-injection stable re-resolve finds it gone — the
+        // command refuses rather than injecting at a stale coordinate (covers the TryReport-false arm of
+        // PointerCommandSupport.ResolvePointAsync).
+        const string sel = "vanishing-btn";
+        var seq = new Queue<UiElement?>();
+        seq.Enqueue(new UiElement { Id = "e0", Type = "Button", Selector = sel, X = 100, Y = 100, Width = 40, Height = 20, WindowHandle = 6300 });
+        seq.Enqueue(null); // gone on the stability re-read
+        _fakeUia.MovingResults[sel] = seq;
+
+        var command = GetRequiredService<UiTouchCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, [sel, "-a", "TestApp", "--json"]);
+
+        Assert.AreEqual(1, exitCode);
+        Assert.AreEqual(0, _fakePointer.TouchCalls.Count);
+        StringAssert.Contains(ConsoleStdErr.ToString(), "could not be re-resolved");
+    }
+
+    [TestMethod]
+    [DoNotParallelize] // swaps the process-wide ambient AnsiConsole to capture non-error logger output
+    public async Task Touch_NonJson_LocalSession_LogsSuccessWithoutWarning()
+    {
+        // The non-JSON render path logs a human success line and, for a local session, no delivery
+        // warning. Info/Warning route through the static ambient console, so we swap it to capture.
+        _fakeSession.SessionResult.WindowHandle = 8300;
+        _fakeForeground.IsRemoteSessionResult = false;
+
+        var command = GetRequiredService<UiTouchCommand>();
+        var previousAmbient = AnsiConsole.Console;
+        var ambient = new TestConsole();
+        AnsiConsole.Console = ambient;
+        int exitCode;
+        try
+        {
+            exitCode = await ParseAndInvokeWithCaptureAsync(command, ["-a", "TestApp", "--at", "150,160"]);
+        }
+        finally
+        {
+            AnsiConsole.Console = previousAmbient;
+        }
+
+        Assert.AreEqual(0, exitCode);
+        Assert.AreEqual(1, _fakePointer.TouchCalls.Count);
+        Assert.IsFalse(TestAnsiConsole.Output.Contains('{'), "Non-JSON path must not emit a JSON envelope");
+        StringAssert.Contains(ambient.Output, "tap", "Success line must name the gesture");
+        Assert.IsFalse(ambient.Output.Contains("remote", StringComparison.OrdinalIgnoreCase),
+            "A local session must not emit the remote-delivery warning");
+    }
+
+    [TestMethod]
+    [DoNotParallelize] // swaps the process-wide ambient AnsiConsole to capture non-error logger output
+    public async Task Touch_NonJson_RemoteSession_LogsSuccessAndDeliveryWarning()
+    {
+        // Remote (RDP) session: the non-JSON path still injects (exit 0) but appends an advisory
+        // delivery-uncertainty warning to the human output.
+        _fakeSession.SessionResult.WindowHandle = 8301;
+        _fakeForeground.IsRemoteSessionResult = true;
+
+        var command = GetRequiredService<UiTouchCommand>();
+        var previousAmbient = AnsiConsole.Console;
+        var ambient = new TestConsole();
+        AnsiConsole.Console = ambient;
+        int exitCode;
+        try
+        {
+            exitCode = await ParseAndInvokeWithCaptureAsync(command, ["-a", "TestApp", "--at", "150,160"]);
+        }
+        finally
+        {
+            AnsiConsole.Console = previousAmbient;
+        }
+
+        Assert.AreEqual(0, exitCode, "The remote warning is advisory; injection still succeeds");
+        Assert.AreEqual(1, _fakePointer.TouchCalls.Count);
+        StringAssert.Contains(ambient.Output, "remote", "Remote session must surface the delivery-uncertainty warning");
+    }
+
+    [TestMethod]
+    public async Task Touch_ComException_ReturnsStaleElement_NoInjection()
+    {
+        // A COMException surfacing during resolution is a stale-element signal (the element vanished
+        // mid-flight); the command maps it to the stale envelope and never injects.
+        _fakeUia.FindSingleElementThrowException = new System.Runtime.InteropServices.COMException("UIA stale (test)");
+
+        var command = GetRequiredService<UiTouchCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["btn-ok", "-a", "TestApp", "--json"]);
+
+        Assert.AreEqual(1, exitCode);
+        Assert.AreEqual(0, _fakePointer.TouchCalls.Count);
+        StringAssert.Contains(ConsoleStdErr.ToString(), "no longer accessible");
+    }
+
+    [TestMethod]
+    public async Task Touch_GenericException_ReturnsInternalError_NoInjection()
+    {
+        // A non-COM, non-app-not-found, non-IOE exception during session resolution falls through to
+        // the catch-all generic handler and is reported (not swallowed or crashed).
+        _fakeSession.ResolveThrow = new TimeoutException("boom (test)");
+
+        var command = GetRequiredService<UiTouchCommand>();
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["btn-ok", "-a", "TestApp", "--json"]);
+
+        Assert.AreEqual(1, exitCode);
+        Assert.AreEqual(0, _fakePointer.TouchCalls.Count);
+        StringAssert.Contains(ConsoleStdErr.ToString(), "boom (test)");
     }
 }

--- a/src/winapp-CLI/WinApp.Cli.Tests/UiCommandTests.Touch.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/UiCommandTests.Touch.cs
@@ -783,6 +783,7 @@ public partial class UiCommandTests
         Assert.AreEqual(1, exitCode);
         Assert.AreEqual(0, _fakePointer.TouchCalls.Count);
         StringAssert.Contains(ConsoleStdErr.ToString(), "no longer accessible");
+        AssertJsonErrorCode(UiJsonError.CodeStaleElement);
     }
 
     [TestMethod]
@@ -798,5 +799,6 @@ public partial class UiCommandTests
         Assert.AreEqual(1, exitCode);
         Assert.AreEqual(0, _fakePointer.TouchCalls.Count);
         StringAssert.Contains(ConsoleStdErr.ToString(), "boom (test)");
+        AssertJsonErrorCode(UiJsonError.CodeInternalError);
     }
 }

--- a/src/winapp-CLI/WinApp.Cli/Commands/UiPenCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/UiPenCommand.cs
@@ -278,7 +278,7 @@ internal class UiPenCommand : Command, IShortDescription
             catch (System.Runtime.InteropServices.COMException comEx)
             {
                 logger.LogDebug("COM error: {HResult} {StackTrace}", comEx.HResult, comEx.StackTrace);
-                UiErrors.StaleElement(logger, json);
+                UiErrors.StaleElement(logger, json, parseResult.InvocationConfiguration.Error);
                 return 1;
             }
             catch (AppNotFoundException ioEx)
@@ -304,7 +304,7 @@ internal class UiPenCommand : Command, IShortDescription
             }
             catch (Exception ex)
             {
-                UiErrors.GenericError(logger, ex, json);
+                UiErrors.GenericError(logger, ex, json, parseResult.InvocationConfiguration.Error);
                 return 1;
             }
 

--- a/src/winapp-CLI/WinApp.Cli/Commands/UiTouchCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/UiTouchCommand.cs
@@ -353,7 +353,7 @@ internal class UiTouchCommand : Command, IShortDescription
             catch (System.Runtime.InteropServices.COMException comEx)
             {
                 logger.LogDebug("COM error: {HResult} {StackTrace}", comEx.HResult, comEx.StackTrace);
-                UiErrors.StaleElement(logger, json);
+                UiErrors.StaleElement(logger, json, parseResult.InvocationConfiguration.Error);
                 return 1;
             }
             catch (AppNotFoundException ioEx)
@@ -379,7 +379,7 @@ internal class UiTouchCommand : Command, IShortDescription
             }
             catch (Exception ex)
             {
-                UiErrors.GenericError(logger, ex, json);
+                UiErrors.GenericError(logger, ex, json, parseResult.InvocationConfiguration.Error);
                 return 1;
             }
 

--- a/src/winapp-CLI/WinApp.Cli/Helpers/PointerInput.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/PointerInput.cs
@@ -449,15 +449,32 @@ internal static class PointerInput
         }
     }
 
+    /// <summary>
+    /// Maps a normalized pen pressure (0..1, where 0 is barely touching and 1 is full force) onto the
+    /// Win32 synthetic-pointer pressure range (1..<see cref="PenPressureMax"/>). The value is clamped
+    /// into range and rounded to the nearest integer; because in-contact pen frames require a non-zero
+    /// pressure, a mapped value of 0 is bumped to 1.
+    /// </summary>
+    /// <remarks>
+    /// Pure arithmetic extracted from <see cref="Pen"/> so it is unit-testable without the native
+    /// synthetic-pointer device (issue #630); see PointerInputPressureTests.
+    /// </remarks>
+    internal static uint MapPenPressure(float pressure)
+    {
+        uint mapped = (uint)Math.Clamp((int)Math.Round(pressure * PenPressureMax), 0, (int)PenPressureMax);
+        return mapped == 0 ? 1u : mapped; // in-contact frames need non-zero pressure
+    }
+
     /// <summary>Injects a synthetic pen/stylus stroke (tap or ink path) with pressure and tilt.</summary>
     /// <remarks>
     /// Coverage ceiling (issue #630): the native device path
     /// (<c>CreateSyntheticPointerDevice(PT_PEN)</c> → inject → <c>DestroySyntheticPointerDevice</c>)
     /// requires Windows 10 1809+ and an unlocked interactive desktop and cannot run in the shared
-    /// CI/test environment without live input injection. The pressure-mapping and frame-ordering logic
-    /// is covered deterministically through the injectable <see cref="PenFrameSender"/> seam on
-    /// <see cref="InjectPenStroke"/> (see PointerInputFrameTests); only the OS injection calls are
-    /// un-coverable here.
+    /// CI/test environment without live input injection. The pressure mapping is covered directly by
+    /// <see cref="MapPenPressure"/> unit tests, and the frame-ordering logic through the injectable
+    /// <see cref="PenFrameSender"/> seam on <see cref="InjectPenStroke"/> (see PointerInputFrameTests
+    /// and PointerInputPressureTests); only the OS injection calls (device create / inject / destroy)
+    /// remain un-coverable here.
     /// </remarks>
     public static void Pen(
         IReadOnlyList<PointerPoint> path,
@@ -479,11 +496,7 @@ internal static class PointerInput
 
         try
         {
-            uint mappedPressure = (uint)Math.Clamp((int)Math.Round(pressure * PenPressureMax), 0, (int)PenPressureMax);
-            if (mappedPressure == 0)
-            {
-                mappedPressure = 1; // in-contact frames need non-zero pressure
-            }
+            uint mappedPressure = MapPenPressure(pressure);
 
             InjectPenStroke(path, mappedPressure, durationMs,
                 (x, y, p, flags) => SendPen(device, x, y, p, tiltX, tiltY, eraser, flags));

--- a/src/winapp-CLI/WinApp.Cli/Helpers/PointerInput.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/PointerInput.cs
@@ -57,6 +57,13 @@ internal static class PointerInput
     /// OS only allows a single successful <c>InitializeTouchInjection</c> per process. On failure the
     /// actual Win32 error is surfaced so callers can tell "unsupported" from "locked desktop".
     /// </summary>
+    /// <remarks>
+    /// Coverage ceiling (issue #630): the <c>InitializeTouchInjection</c> P/Invoke and its Win32
+    /// failure branch require a touch-capable, unlocked interactive desktop and cannot be exercised in
+    /// the shared CI/test environment without live input injection. The logic that drives this path is
+    /// covered deterministically through the injectable <see cref="TouchSender"/> seam
+    /// (see PointerInputFrameTests); only the native call is un-coverable here.
+    /// </remarks>
     private static void EnsureTouchInitialized()
     {
         if (_touchInitialized)
@@ -86,12 +93,29 @@ internal static class PointerInput
     }
 
     /// <summary>Formats a Win32 error code into its system message for honest diagnostics.</summary>
+    /// <remarks>
+    /// Coverage ceiling (issue #630): only reached from the native injection error branches
+    /// (<c>InitializeTouchInjection</c> / <c>InjectTouchInput</c> / <c>InjectSyntheticPointerInput</c>
+    /// failures), which require a real interactive desktop and live input injection to trigger, so this
+    /// helper is transitively un-coverable in the shared CI/test environment.
+    /// </remarks>
     private static string Win32Message(int error)
     {
         try { return new Win32Exception(error).Message; }
         catch { return "unknown error"; }
     }
 
+    /// <summary>Injects a synthetic touch gesture, preferring the modern synthetic-pointer device and
+    /// falling back to the legacy <c>InjectTouchInput</c> API when it is unavailable.</summary>
+    /// <remarks>
+    /// Coverage ceiling (issue #630): the native device path
+    /// (<c>CreateSyntheticPointerDevice</c> → inject → <c>DestroySyntheticPointerDevice</c>) and the
+    /// legacy fallback both require a touch-capable, unlocked interactive desktop and cannot run in the
+    /// shared CI/test environment without live input injection. The gesture-planning and frame-ordering
+    /// logic is covered deterministically through the injectable <see cref="TouchSender"/> seam on
+    /// <see cref="InjectTouchStroke"/> (see PointerInputFrameTests); only the OS injection calls are
+    /// un-coverable here.
+    /// </remarks>
     public static void Touch(
         TouchGesture gesture,
         IReadOnlyList<IReadOnlyList<PointerPoint>> contactPaths,
@@ -366,6 +390,12 @@ internal static class PointerInput
     }
 
     /// <summary>Submits one frame of touch contacts via the legacy <c>InjectTouchInput</c> API.</summary>
+    /// <remarks>
+    /// Coverage ceiling (issue #630): the <c>InjectTouchInput</c> P/Invoke and its Win32 failure branch
+    /// require an unlocked interactive desktop and live touch injection, so this native sender is
+    /// un-coverable in the shared CI/test environment. The frames it would submit are validated via the
+    /// injectable <see cref="TouchSender"/> seam (see PointerInputFrameTests).
+    /// </remarks>
     private static void SendLegacyTouch(POINTER_TOUCH_INFO[] contacts)
     {
         unsafe
@@ -388,6 +418,12 @@ internal static class PointerInput
     /// Submits one frame of touch contacts via the synthetic-pointer device
     /// (<c>InjectSyntheticPointerInput</c>) — the modern path shared with pen injection.
     /// </summary>
+    /// <remarks>
+    /// Coverage ceiling (issue #630): the <c>InjectSyntheticPointerInput</c> P/Invoke and its Win32
+    /// failure branch require a live synthetic-pointer device on an unlocked interactive desktop, so
+    /// this native sender is un-coverable in the shared CI/test environment. The frames it would submit
+    /// are validated via the injectable <see cref="TouchSender"/> seam (see PointerInputFrameTests).
+    /// </remarks>
     private static void SendSyntheticTouch(HSYNTHETICPOINTERDEVICE device, POINTER_TOUCH_INFO[] contacts)
     {
         var infos = new POINTER_TYPE_INFO[contacts.Length];
@@ -413,6 +449,16 @@ internal static class PointerInput
         }
     }
 
+    /// <summary>Injects a synthetic pen/stylus stroke (tap or ink path) with pressure and tilt.</summary>
+    /// <remarks>
+    /// Coverage ceiling (issue #630): the native device path
+    /// (<c>CreateSyntheticPointerDevice(PT_PEN)</c> → inject → <c>DestroySyntheticPointerDevice</c>)
+    /// requires Windows 10 1809+ and an unlocked interactive desktop and cannot run in the shared
+    /// CI/test environment without live input injection. The pressure-mapping and frame-ordering logic
+    /// is covered deterministically through the injectable <see cref="PenFrameSender"/> seam on
+    /// <see cref="InjectPenStroke"/> (see PointerInputFrameTests); only the OS injection calls are
+    /// un-coverable here.
+    /// </remarks>
     public static void Pen(
         IReadOnlyList<PointerPoint> path,
         float pressure,
@@ -561,6 +607,14 @@ internal static class PointerInput
         }
     }
 
+    /// <summary>Submits one pen frame via the synthetic-pointer device (<c>InjectSyntheticPointerInput</c>).</summary>
+    /// <remarks>
+    /// Coverage ceiling (issue #630): the <c>InjectSyntheticPointerInput</c> P/Invoke and its Win32
+    /// failure branch require a live synthetic pen device on an unlocked interactive desktop, so this
+    /// native sender is un-coverable in the shared CI/test environment. The <see cref="ComputePenFlags"/>
+    /// bitmask logic it applies per frame is covered directly, and the frames it would submit are
+    /// validated via the injectable <see cref="PenFrameSender"/> seam (see PointerInputFrameTests).
+    /// </remarks>
     private static void SendPen(
         HSYNTHETICPOINTERDEVICE device, int x, int y, uint pressure, int tiltX, int tiltY, bool eraser, POINTER_FLAGS flags)
     {

--- a/src/winapp-CLI/WinApp.Cli/Helpers/RealPointerInput.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/RealPointerInput.cs
@@ -7,6 +7,15 @@ namespace WinApp.Cli.Helpers;
 /// Production implementation — delegates to the <see cref="PointerInput"/> static P/Invoke helpers
 /// that drive the Windows touch- and pen-injection APIs.
 /// </summary>
+/// <remarks>
+/// Coverage ceiling (issue #630): this adapter is a one-line pass-through to the native
+/// <see cref="PointerInput.Touch"/> / <see cref="PointerInput.Pen"/> P/Invoke helpers, so exercising
+/// its two delegating bodies would perform real OS input injection on an unlocked interactive desktop.
+/// In the default (headless/shared-CI) test run the DI container substitutes a fake
+/// <see cref="IPointerInput"/> so command behavior is asserted without live injection; the live native
+/// path is exercised only on a dedicated interactive lane (see the WINAPP_UI_INJECTION_LIVE-gated
+/// tests). These two members therefore remain un-coverable in the default run by design.
+/// </remarks>
 internal class RealPointerInput : IPointerInput
 {
     public void Touch(TouchGesture gesture, IReadOnlyList<IReadOnlyList<PointerPoint>> contactPaths, int holdMs, int durationMs)

--- a/src/winapp-CLI/WinApp.Cli/Helpers/UiErrors.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/UiErrors.cs
@@ -34,11 +34,11 @@ internal static class UiErrors
         UiJsonError.Emit(json, UiJsonError.CodeElementNotFound, $"No element found matching '{selector}'", selector);
     }
 
-    public static void StaleElement(ILogger logger, bool json = false)
+    public static void StaleElement(ILogger logger, bool json = false, TextWriter? errorOut = null)
     {
         const string msg = "Element is no longer accessible — the app may have navigated or the element was removed. Re-run 'winapp ui inspect' to refresh the element tree. Prefer targeting by AutomationId — these are stable across layout changes.";
         logger.LogError("{Symbol} {Message}", UiSymbols.Error, msg);
-        UiJsonError.Emit(json, UiJsonError.CodeStaleElement, "Element is no longer accessible");
+        UiJsonError.Emit(json, UiJsonError.CodeStaleElement, "Element is no longer accessible", errorOut: errorOut);
     }
 
     public static void AmbiguousSelector(ILogger logger, string message, bool json = false)
@@ -47,10 +47,10 @@ internal static class UiErrors
         UiJsonError.Emit(json, UiJsonError.CodeAmbiguousSelector, message);
     }
 
-    public static void GenericError(ILogger logger, Exception ex, bool json = false)
+    public static void GenericError(ILogger logger, Exception ex, bool json = false, TextWriter? errorOut = null)
     {
         logger.LogDebug("Stack trace: {StackTrace}", ex.StackTrace);
         logger.LogError("{Symbol} {Message}", UiSymbols.Error, ex.Message);
-        UiJsonError.Emit(json, UiJsonError.CodeInternalError, ex.Message, details: ex.GetType().Name);
+        UiJsonError.Emit(json, UiJsonError.CodeInternalError, ex.Message, details: ex.GetType().Name, errorOut: errorOut);
     }
 }


### PR DESCRIPTION
## What

Raises per-file test coverage to 100% for the UI touch/pen command logic and pointer support (issue #630):

| File | Before | After |
|------|-------:|------:|
| `Commands/UiTouchCommand.cs` | 85.3% | **100%** |
| `Commands/UiPenCommand.cs` | 87.4% | **100%** |
| `Helpers/PointerCommandSupport.cs` | 85.9% | **100%** |
| `Helpers/PointerInput.cs` | 61.7% | 64.1% (documented native ceiling) |
| `Helpers/RealPointerInput.cs` | 0% | 0% (documented native ceiling) |

`PointerInput.cs` / `RealPointerInput.cs` remain below 95% by design: their `CreateSyntheticPointerDevice` / `InjectSyntheticPointerInput` / `InjectTouchInput` calls require a touch/pen-capable, unlocked interactive desktop and cannot run in the shared CI lane. The frame-planning and ordering logic that feeds them **is** covered deterministically via the injectable `TouchSender` / `PenFrameSender` seams; the native boundaries carry in-source `<remarks>` ceilings referencing #630. No `[ExcludeFromCodeCoverage]`, no `coverage.runsettings` edits.

## Product changes (minimal, behavior-preserving)

- Extracted `PointerInput.MapPenPressure(float)` — the pure `0..1 → Win32 1..1024` pressure mapping — out of `PointerInput.Pen()` so the arithmetic (linear scale, nearest-integer rounding, clamping, and the non-zero-pressure guarantee that keeps in-contact frames in contact) is unit-testable without the native synthetic-pointer device. `Pen()` now calls it; logic is byte-for-byte identical. The `Pen()` ceiling `<remarks>` was narrowed accordingly.

## Tests

- `PointerInputPressureTests` — data-driven coverage of `MapPenPressure`: interior linear values, both clamp bounds, round-not-truncate, and the `==0 → 1` in-contact guarantee.
- `UiCommandTests.Touch` / `.Pen` — argument validation, injection-count assertions via the pointer fake, human error/success/warning strings, JSON envelopes, remote-session advisory warning, and out-of-window rejection.
- New shared `BaseCommandTests.InvokeWithAmbientConsoleCaptureAsync` helper replaces a 4×-duplicated ambient-`AnsiConsole` swap harness with one `try/finally`-guarded method (callers stay `[DoNotParallelize]`).

## Validation

- Debug solution + Release (both `WinApp.Cli` and `WinApp.Cli.Tests`, warnings-as-errors): **0 W / 0 E** each.
- Scoped coverage run: **504 passed / 0 failed / 3 skipped** (the skips are the `WINAPP_UI_INJECTION_LIVE` live-injection and `WINAPP_RECORD_INTERACTIVE_TESTS` gated tests, not relied on in the default lane).
- Reviewed with the repo `pr-review` skill (7 specialists + a GPT multi-model cross-check) before opening; the two accepted MEDIUM findings (pressure-mapping hidden behind the native ceiling; the copy-pasted console-swap harness) are fixed in this branch. New tests assert stable observable behavior (exit codes, injection counts, message substrings), so they are unaffected by the pending out-of-window reject→warn change in the open pointer PRs.
