### PR TITLE
Fix DbgEng symbol test crash (0xC0000005) on ADO from malformed dummy PDB

### DIFF
--- a/src/winapp-CLI/WinApp.Cli.Tests/CrashDumpServiceWorkflowTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/CrashDumpServiceWorkflowTests.cs
@@ -314,13 +314,25 @@ public sealed class CrashDumpServiceWorkflowTests
 
         try
         {
-            // Stub the symbol-server boundary: pretend every PDB is available (small dummy payload) so
-            // the "downloaded > 0 -> reload and re-run with symbols" branch runs without any network.
+            // Stub the symbol-server boundary: pretend every PDB is available so the
+            // "downloaded > 0 -> reload and re-run with symbols" branch runs without any network.
             CrashDumpService.SymbolFileDownloader = (url, destPath) =>
             {
                 requestedUrls.Add(url);
                 Directory.CreateDirectory(Path.GetDirectoryName(destPath)!);
-                File.WriteAllBytes(destPath, [0x4D, 0x69, 0x63]); // drop a dummy PDB at the cache path
+                // Drop a benign, deliberately-invalid PDB at the module's expected cache path. The
+                // product's `.reload /f` (in AnalyzeWithDbgEng) force-loads whatever file lives here,
+                // so the payload must NOT begin with the "Microsoft C/C++ MSF 7.00" magic and must be
+                // large enough that dbghelp rejects it at the signature check WITHOUT reading past the
+                // end of the file. A prior 3-byte payload ([0x4D,0x69,0x63] = "Mic") matched the magic's
+                // prefix, causing some dbghelp versions to over-read the truncated MSF superblock and
+                // fault with an access violation (0xC0000005) during `.reload /f` — a native crash that
+                // took down the whole test host on Azure DevOps 1ES agents (GitHub-hosted runners and
+                // local dev machines happened to tolerate/reject the same bytes). dbghelp rejects this
+                // file cleanly as "not a PDB"; the test still drives the download seam with msdl URLs.
+                var dummyPdb = new byte[8192];
+                "winapp-test-fixture-not-a-real-pdb\n"u8.CopyTo(dummyPdb);
+                File.WriteAllBytes(destPath, dummyPdb);
                 return true;
             };
 


### PR DESCRIPTION
## Description

The test `AnalyzeWithDbgEng_ValidNativeDumpWithSymbols_DrivesSymbolDownloadSeamWithoutNetwork` was crashing the test host with a native access violation (`0xC0000005`) **only on Azure DevOps CI** — it passed locally and on GitHub Actions.

Root cause was in the test's `SymbolFileDownloader` stub, not the product code. The stub wrote a 3-byte dummy PDB (`[0x4D, 0x69, 0x63]` = `"Mic"`) to each module's symbol cache path. `"Mic"` is the start of the PDB 7.0 MSF magic (`"Microsoft C/C++ MSF 7.00..."`), so when `AnalyzeWithDbgEng(useSymbols: true)` runs `.reload /f` to force-load symbols, dbghelp compares its 32-byte signature against the 3-byte buffer and reads past end-of-file. On the ADO agent's dbghelp this over-read faults; local/GitHub dbghelp happens to tolerate it.

The fix replaces the toxic payload with an 8 KB, non-magic payload whose first byte (`0x77` = `'w'`) fails the MSF magic check at byte 0, driving dbghelp down its well-defined "not a PDB → reject" path. Two safeguards: non-magic content (clean rejection) and ≥32 bytes (signature comparison stays in bounds even on a lenient reader). This is a test-only change; product behavior and the test's existing assertions are unchanged.

## Related Issue

N/A

## Type of Change

- 🐛 Bug fix
- 🧪 Test update

## Checklist

- [x] Tested locally on Windows

## Additional Notes

- Failure was ADO-only; the sibling `AnalyzeWithDbgEng_ValidNativeDumpNoSymbols_ProducesNativeStack` passed because it never downloads dummies or runs `.reload /f`.
- Verified locally: solution builds clean (0 warnings / 0 errors), and `CrashDumpServiceWorkflowTests` passes (18/18, including all 3 DbgEng tests).
- A separate stub (`DownloadSymbolsForModules_DownloadsThenServesSecondPassFromCache`) still writes the 3-byte payload but only does a `File.Exists` cache-hit check — no `.reload`/dbghelp parse — so it is intentionally left unchanged.

## AI Description

<!-- ai-description-start -->
This pull request fixes a crash during the test `AnalyzeWithDbgEng_ValidNativeDumpWithSymbols_DrivesSymbolDownloadSeamWithoutNetwork` caused by a malformed dummy PDB file leading to an access violation on Azure DevOps CI. The payload has been updated from a 3-byte buffer to an 8 KB benign, deliberately-invalid PDB, which prevents the issue by ensuring that the signature check does not read past the end of the file. This change is solely within the test code and does not affect product behavior.
<!-- ai-description-end -->