### PR TITLE
Render build metrics (incl. coverage) into the CI job summary

### DIFF
--- a/.github/actions/collect-metrics/action.yml
+++ b/.github/actions/collect-metrics/action.yml
@@ -1,5 +1,5 @@
 name: Collect Build Metrics
-description: Measure artifact sizes, test results, and CLI startup time
+description: Measure artifact sizes, test results, coverage, and CLI startup time, and render them to the run's job summary
 
 inputs:
   solution-path:
@@ -139,3 +139,79 @@ runs:
         $startup | ConvertTo-Json | Set-Content "${{ inputs.artifacts-path }}/startup-time.json"
 
         Write-Host "CLI startup time (--version): ${median}ms median (samples: $($times -join ', ')ms)"
+
+    # Render the collected metrics into the run's job summary so every build
+    # (including pushes to main, which never get a PR comment) surfaces its
+    # coverage/tests/startup/sizes on the run page without digging into logs.
+    - name: Write metrics job summary
+      if: ${{ !cancelled() }}
+      shell: pwsh
+      run: |
+        $artifacts = "${{ inputs.artifacts-path }}"
+        $summaryPath = $env:GITHUB_STEP_SUMMARY
+        if (-not $summaryPath) {
+          Write-Host "GITHUB_STEP_SUMMARY not set; skipping job summary"
+          exit 0
+        }
+
+        function Read-JsonOrNull($path) {
+          if (Test-Path $path) {
+            try { return Get-Content $path -Raw | ConvertFrom-Json } catch { return $null }
+          }
+          return $null
+        }
+
+        $coverage = Read-JsonOrNull "$artifacts/coverage-summary.json"
+        $tests    = Read-JsonOrNull "$artifacts/test-summary.json"
+        $startup  = Read-JsonOrNull "$artifacts/startup-time.json"
+        $sizes    = Read-JsonOrNull "$artifacts/binary-sizes.json"
+
+        $md = New-Object System.Collections.Generic.List[string]
+        $md.Add('## Build Metrics')
+        $md.Add('')
+
+        # Coverage first — this is the value that has no other surface on main.
+        $lineCov   = if ($coverage -and $null -ne $coverage.lineCoverage)   { "$($coverage.lineCoverage)%" }   else { 'n/a' }
+        $branchCov = if ($coverage -and $null -ne $coverage.branchCoverage) { "$($coverage.branchCoverage)%" } else { 'n/a' }
+        $md.Add('### Test Coverage')
+        $md.Add('')
+        $md.Add('| Metric | Value |')
+        $md.Add('| --- | --- |')
+        $md.Add("| Line coverage | $lineCov |")
+        $md.Add("| Branch coverage | $branchCov |")
+        $md.Add('')
+
+        if ($tests) {
+          $durSec = [math]::Round(([double]$tests.durationMs) / 1000, 1)
+          $md.Add('### Test Results')
+          $md.Add('')
+          $md.Add('| Total | Passed | Failed | Skipped | Duration |')
+          $md.Add('| --- | --- | --- | --- | --- |')
+          $md.Add("| $($tests.total) | $($tests.passed) | $($tests.failed) | $($tests.skipped) | ${durSec}s |")
+          $md.Add('')
+        }
+
+        if ($startup -and $startup.medianMs) {
+          $md.Add('### CLI Startup Time')
+          $md.Add('')
+          $md.Add("Median: **$($startup.medianMs) ms** (x64, " + '`winapp --version`' + ')')
+          $md.Add('')
+        }
+
+        if ($sizes) {
+          $sizeProps = @($sizes.PSObject.Properties | Sort-Object Name)
+          if ($sizeProps.Count -gt 0) {
+            $md.Add('### Binary Sizes')
+            $md.Add('')
+            $md.Add('| Artifact | Size |')
+            $md.Add('| --- | --- |')
+            foreach ($p in $sizeProps) {
+              $mb = [math]::Round([double]$p.Value / 1MB, 2)
+              $md.Add("| $($p.Name) | $mb MB |")
+            }
+            $md.Add('')
+          }
+        }
+
+        ($md -join "`n") | Add-Content -Path $summaryPath -Encoding utf8
+        Write-Host "Wrote build metrics to job summary"

--- a/.github/actions/collect-metrics/action.yml
+++ b/.github/actions/collect-metrics/action.yml
@@ -181,7 +181,7 @@ runs:
         $md.Add("| Branch coverage | $branchCov |")
         $md.Add('')
 
-        if ($tests) {
+        if ($tests -and $tests.total -gt 0) {
           $durSec = [math]::Round(([double]$tests.durationMs) / 1000, 1)
           $md.Add('### Test Results')
           $md.Add('')


### PR DESCRIPTION
## What & why

On pushes to `main`, code coverage is not surfaced anywhere convenient. The **Build Metrics Report** PR comment (`post-metrics-comment.yml`) is gated to `pull_request` events, and `report-metrics` only caches the numbers as the baseline cache for future PRs. Today the only way to see a `main` commit's coverage is to open its `build-and-package` run and read the `Parse coverage results` step log.

This adds a final **Write metrics job summary** step to the `collect-metrics` composite action that renders the metrics it *already computes* into the run's **job summary** (`$GITHUB_STEP_SUMMARY`), so every run — including pushes to `main` — shows coverage (plus tests, CLI startup, binary sizes) on the run's summary page without digging into logs.

## Details

- Reads only the four JSON files `collect-metrics` already writes (`coverage-summary.json`, `test-summary.json`, `startup-time.json`, `binary-sizes.json`) — no new data collection, no new dependencies, no new permissions.
- Runs on every build (main + PR + `workflow_dispatch`). On PRs it complements the existing PR comment; on `main` it is the primary surface.
- Degrades gracefully: coverage shows `n/a` when missing, and sections are skipped when their metric is absent (e.g. `medianMs = 0`, empty sizes).
- Section headings match the PR comment (`Test Coverage` / `Test Results` / `CLI Startup Time` / `Binary Sizes`) so the two surfaces don't drift in naming.

## Sample output

```
## Build Metrics
### Test Coverage
| Metric | Value |
| --- | --- |
| Line coverage | 93.6% |
| Branch coverage | 78.1% |
### Test Results
| Total | Passed | Failed | Skipped | Duration |
| 3428 | 3423 | 0 | 5 | 42.4s |
### CLI Startup Time
Median: **121 ms** (x64, `winapp --version`)
### Binary Sizes
| cli-win-x64 | 74.5 MB | ...
```

## Testing

- Validated the PowerShell rendering locally against realistic and degraded inputs (full metrics render; null coverage -> `n/a`; `medianMs = 0` skipped; empty `{}` sizes skipped).
- Confirmed `action.yml` parses as valid YAML.
- Reviewed with the repo `pr-review` skill (security / correctness / packaging / alternative-solution / cli-ux / test-coverage / docs / multi-model cross-check): no blocking findings; addressed the one medium by aligning section headings with the PR-comment renderer to reduce naming drift.

CI-only change: no CLI/product code touched, and no docs reference the metrics pipeline.
