### PR TITLE
docs(electron): correct #winapp/bindings setup and ground Electron guides against 0.5.0

### DIFF
--- a/docs/fragments/skills/winapp-cli/setup.md
+++ b/docs/fragments/skills/winapp-cli/setup.md
@@ -62,6 +62,8 @@ When JS bindings are enabled (via `--add-js-bindings` or by answering yes in int
 - `.winapp/bindings/` — generated JS bindings for Windows App SDK APIs (npm-only, Node / Electron)
 - `package.json` update — adds the `winapp.jsBindings` namespace and `@microsoft/dynwinrt` dependency (npm-only)
 
+Import the generated classes with the `#winapp/bindings` specifier (e.g. `require('#winapp/bindings')`). `winapp init --add-js-bindings` adds the matching subpath `imports` map to `package.json`. If `require('#winapp/bindings')` fails with `ERR_MODULE_NOT_FOUND`, add the map manually (or import `.winapp/bindings/index.js` by a relative path). See [Enable the `#winapp/bindings` import](https://github.com/microsoft/WinAppCli/blob/main/docs/guides/electron/setup.md#enable-the-winappbindings-import).
+
 ### Restore after cloning
 
 ```powershell

--- a/docs/guides/electron/index.md
+++ b/docs/guides/electron/index.md
@@ -37,7 +37,7 @@ First, you'll set up your development environment with the necessary tools and S
 
 ### 2. Call Windows APIs from JavaScript
 
-If you enabled JS bindings during setup, `.winapp/bindings/` contains generated `.js` wrapper classes and matching `.d.ts` declarations for Windows App SDK APIs. Import `#winapp/bindings` to access all exported classes. The `#winapp/bindings` package import requires `@microsoft/dynwinrt-codegen` ≥ `0.1.0-preview.8`; older projects can keep a path relative to the importing file (for example, `require('../.winapp/bindings/index.js')` from `src/index.js`) or upgrade with `npm i -D @microsoft/dynwinrt-codegen@latest && npx winapp init --add-js-bindings`.
+If you enabled JS bindings during setup, `.winapp/bindings/` contains generated `.js` wrapper classes and matching `.d.ts` declarations for Windows App SDK APIs. Import `#winapp/bindings` to access all exported classes. `winapp init --add-js-bindings` wires this specifier into your `package.json` `imports` map. If `require('#winapp/bindings')` ever fails with `ERR_MODULE_NOT_FOUND`, follow [Enable the `#winapp/bindings` import](setup.md#enable-the-winappbindings-import) to add it, or import the generated `index.js` by a path relative to the importing file (for example `require('../.winapp/bindings/index.js')` from `src/index.js`).
 
 - **[Show a Notification from JavaScript →](js-notification.md)** — call the same Windows App SDK notification surface without a native addon.
 - **[Call Windows APIs from JavaScript →](js-file-picker.md)** — pick a file with Windows App SDK and inspect it with Windows SDK imaging APIs.

--- a/docs/guides/electron/index.md
+++ b/docs/guides/electron/index.md
@@ -31,13 +31,20 @@ First, you'll set up your development environment with the necessary tools and S
 - Creating or configuring an Electron app
 - Installing winapp CLI
 - Initializing Windows SDKs and required assets
+- **Generating JS bindings** so you can call Windows APIs from JavaScript
 - Setting up your build pipeline
 
 [Get Started with Setup →](setup.md)
 
 ### 2. Call Windows APIs from JavaScript
 
-If you enabled JS bindings during setup, `.winapp/bindings/` contains generated `.js` wrapper classes and matching `.d.ts` declarations for Windows App SDK APIs. Import `#winapp/bindings` to access all exported classes. `winapp init --add-js-bindings` wires this specifier into your `package.json` `imports` map. If `require('#winapp/bindings')` ever fails with `ERR_MODULE_NOT_FOUND`, follow [Enable the `#winapp/bindings` import](setup.md#enable-the-winappbindings-import) to add it, or import the generated `index.js` by a path relative to the importing file (for example `require('../.winapp/bindings/index.js')` from `src/index.js`).
+Setup generated `.winapp/bindings/` — `.js` wrapper classes with matching `.d.ts` declarations for Windows App SDK APIs — and wired the `#winapp/bindings` specifier into your `package.json`. Import it to reach every exported class:
+
+```js
+const { FileOpenPicker } = require('#winapp/bindings');
+```
+
+If `require('#winapp/bindings')` ever fails with `ERR_MODULE_NOT_FOUND`, see [Enable the `#winapp/bindings` import](setup.md#enable-the-winappbindings-import).
 
 - **[Show a Notification from JavaScript →](js-notification.md)** — call the same Windows App SDK notification surface without a native addon.
 - **[Call Windows APIs from JavaScript →](js-file-picker.md)** — pick a file with Windows App SDK and inspect it with Windows SDK imaging APIs.

--- a/docs/guides/electron/js-file-picker.md
+++ b/docs/guides/electron/js-file-picker.md
@@ -61,7 +61,7 @@ npx winapp node generate-bindings
 
 All generated classes are exported through `#winapp/bindings`:
 
-> **Requires `@microsoft/dynwinrt-codegen` ≥ `0.1.0-preview.8`** — see [Get started with Electron](index.md#2-call-windows-apis-from-javascript) for older-project fallbacks.
+> `winapp init --add-js-bindings` wires the `#winapp/bindings` specifier into `package.json`. If `require('#winapp/bindings')` fails with `ERR_MODULE_NOT_FOUND`, see [Enable the `#winapp/bindings` import](setup.md#enable-the-winappbindings-import).
 
 ```js
 // src/index.js (Electron main, CommonJS)

--- a/docs/guides/electron/js-notification.md
+++ b/docs/guides/electron/js-notification.md
@@ -12,7 +12,7 @@ Before starting this guide, make sure you've:
 
 Import the generated bindings through the `#winapp/bindings` package import, build an app notification, and show it with the default notification manager:
 
-> **Requires `@microsoft/dynwinrt-codegen` ≥ `0.1.0-preview.8`.** Older projects can either upgrade with `npm i -D @microsoft/dynwinrt-codegen@latest && npx winapp init --add-js-bindings` to have `winapp init` wire the `#winapp/bindings` imports map, or keep the relative form `require('../.winapp/bindings/index.js')` (path is relative to `src/index.js`; adjust it if your entry file lives elsewhere).
+> `winapp init --add-js-bindings` wires the `#winapp/bindings` specifier into `package.json`. If `require('#winapp/bindings')` fails with `ERR_MODULE_NOT_FOUND`, see [Enable the `#winapp/bindings` import](setup.md#enable-the-winappbindings-import) — or use the relative form `require('../.winapp/bindings/index.js')` (path relative to `src/index.js`; adjust it if your entry file lives elsewhere).
 
 ```js
 // src/index.js (Electron main, CommonJS)

--- a/docs/guides/electron/js-phi-silica.md
+++ b/docs/guides/electron/js-phi-silica.md
@@ -30,7 +30,7 @@ npx winapp node add-electron-debug-identity
 
 Import the generated bindings through `#winapp/bindings`, create a `TextSummarizer`, and call it at the end of `createWindow()` to verify everything works:
 
-> **Requires `@microsoft/dynwinrt-codegen` ≥ `0.1.0-preview.8`** — see [Get started with Electron](index.md#2-call-windows-apis-from-javascript) for older-project fallbacks.
+> `winapp init --add-js-bindings` wires the `#winapp/bindings` specifier into `package.json`. If `require('#winapp/bindings')` fails with `ERR_MODULE_NOT_FOUND`, see [Enable the `#winapp/bindings` import](setup.md#enable-the-winappbindings-import).
 
 ```js
 // src/index.js (Electron main, CommonJS)

--- a/docs/guides/electron/js-winml.md
+++ b/docs/guides/electron/js-winml.md
@@ -21,13 +21,13 @@ npm install onnxruntime-node@1.24.3
 
 The Windows App SDK transitively depends on `Microsoft.WindowsAppSDK.ML`, so the WinML APIs are already in your generated bindings. Verify:
 
-> **Requires `@microsoft/dynwinrt-codegen` ≥ `0.1.0-preview.8`** — see [Get started with Electron](index.md#2-call-windows-apis-from-javascript) for older-project fallbacks.
+> `winapp init --add-js-bindings` wires the `#winapp/bindings` specifier into `package.json`. If `require('#winapp/bindings')` fails with `ERR_MODULE_NOT_FOUND`, see [Enable the `#winapp/bindings` import](setup.md#enable-the-winappbindings-import).
 
 ```bash
 node -e "console.log(Object.keys(require('#winapp/bindings')).filter(k => k.startsWith('ExecutionProvider')))"
 ```
 
-You should see `[ 'ExecutionProvider', 'ExecutionProviderCatalog', 'ExecutionProviderReadyState' ]`.
+You should see `[ 'ExecutionProvider', 'ExecutionProviderCatalog', 'ExecutionProviderCertification', 'ExecutionProviderReadyResult', 'ExecutionProviderReadyResultState', 'ExecutionProviderReadyState' ]` (the exact list depends on your Windows App SDK version). If the array is empty, the ML APIs weren't emitted — re-run `npx winapp node generate-bindings`.
 
 ## Step 2: Download the model via Model Catalog (main process)
 

--- a/docs/guides/electron/setup.md
+++ b/docs/guides/electron/setup.md
@@ -21,11 +21,22 @@ npm create electron-app@latest my-windows-app
 cd my-windows-app
 ```
 
-When prompted by Electron Forge:
-- **Bundler**: Select **None** (recommended — native addons work without extra configuration)
-- **Language**: Select **JavaScript** (this guide uses JS; TypeScript works too)
-- **Electron version**: Select **latest**
-- **Initialize git**: Your preference
+`create-electron-app` is non-interactive — it scaffolds with its default template rather than prompting you. The default is exactly what this guide wants:
+- **No bundler** — native addons and the generated JS bindings work without extra bundler configuration.
+- **JavaScript** — this guide uses JS (TypeScript works too).
+
+It also installs the current `latest` Electron version and initializes a git repository. To customize, pass flags after a `--` separator (npm forwards them to `create-electron-app`), for example:
+
+```bash
+# Use a bundler and/or TypeScript (optional):
+npm create electron-app@latest my-windows-app -- --template=webpack
+npm create electron-app@latest my-windows-app -- --template=vite-typescript
+
+# Pin a specific Electron version, or skip git init:
+npm create electron-app@latest my-windows-app -- --electron-version=38.3.0 --skip-git
+```
+
+The official Forge templates are `webpack`, `webpack-typescript`, `vite`, and `vite-typescript`. Run `npx create-electron-app@latest --help` to see all flags.
 
 Verify the app runs:
 
@@ -88,6 +99,7 @@ This command sets up everything you need for Windows development:
    - Adds `@microsoft/dynwinrt-codegen` to `devDependencies` — the build-time tool that produces the bindings (pinned to the registry's `latest` version on first run, then left alone)
    - Adds `@microsoft/dynwinrt` to `dependencies` — the runtime that the generated bindings import at execution time (version is chosen by the installed codegen to guarantee ABI compatibility)
    - Generates JS bindings for Windows App SDK APIs into `.winapp/bindings/`
+   - Adds the `#winapp/bindings` imports map to `package.json` so `require('#winapp/bindings')` resolves (see [Enable the `#winapp/bindings` import](#enable-the-winappbindings-import) below)
 
 > [!NOTE]
 > The `.winapp/` folder is automatically added to `.gitignore` and should not be checked in to source.
@@ -102,6 +114,43 @@ You can open `Package.appxmanifest` to further customize properties like the dis
 > - **[Windows App SDK](https://learn.microsoft.com/windows/apps/windows-app-sdk/)** - A new development platform that lets you build modern desktop apps that can be installed across Windows versions (down to Windows 10 1809). It provides a convenient, OS-decoupled abstraction around the rich catalogue of Windows OS APIs. The Windows App SDK includes WinUI 3 and provides access to modern features like AI capabilities (Phi Silica), notifications, window management, and more that receive regular updates independent of Windows OS releases.
 >
 > Learn more: [What's the difference between the Windows App SDK and the Windows SDK?](https://learn.microsoft.com/windows/apps/get-started/windows-developer-faq#what-s-the-difference-between-the-windows-app-sdk-and-the-windows-sdk)
+
+### Enable the `#winapp/bindings` import
+
+`winapp init` generates the bindings into `.winapp/bindings/` (an `index.js` + `index.mjs` + `index.d.ts`, plus one file per emitted class). The rest of these guides import them with the clean `#winapp/bindings` specifier:
+
+```js
+const { FileOpenPicker } = require('#winapp/bindings');
+```
+
+That specifier only resolves if your `package.json` has a matching [subpath `imports`](https://nodejs.org/api/packages.html#subpath-imports) map. **`winapp init --add-js-bindings` writes this map for you** — you'll see `Added "#winapp/bindings" package imports to package.json` in the init output. If it's ever missing (for example, `require('#winapp/bindings')` fails with `ERR_MODULE_NOT_FOUND`), add it yourself:
+
+```jsonc
+// package.json
+{
+  "imports": {
+    "#winapp/bindings": {
+      "types": "./.winapp/bindings/index.d.ts",
+      "import": "./.winapp/bindings/index.mjs",
+      "require": "./.winapp/bindings/index.js",
+      "default": "./.winapp/bindings/index.js"
+    },
+    "#winapp/bindings/*": {
+      "types": "./.winapp/bindings/*.d.ts",
+      "default": "./.winapp/bindings/*.js"
+    }
+  }
+}
+```
+
+Confirm it resolves:
+
+```bash
+node -e "console.log(Object.keys(require('#winapp/bindings')).length + ' Windows classes available')"
+```
+
+> [!NOTE]
+> The paths are relative to `package.json` (the folder that also holds `.winapp/`), so they're the same no matter where your entry file lives. If you'd rather not add an `imports` map, you can instead import the generated `index.js` by a path relative to the importing file — for example `require('../.winapp/bindings/index.js')` from `src/index.js`.
 
 ## Step 4: Add Restore to Your Build Pipeline
 

--- a/docs/guides/electron/setup.md
+++ b/docs/guides/electron/setup.md
@@ -21,22 +21,24 @@ npm create electron-app@latest my-windows-app
 cd my-windows-app
 ```
 
-`create-electron-app` is non-interactive — it scaffolds with its default template rather than prompting you. The default is exactly what this guide wants:
-- **No bundler** — native addons and the generated JS bindings work without extra bundler configuration.
-- **JavaScript** — this guide uses JS (TypeScript works too).
+`create-electron-app` is non-interactive: it scaffolds its **default template — no bundler + JavaScript**, which is exactly what these guides use (native addons and the generated JS bindings work without extra bundler configuration). It also installs the current `latest` Electron version and initializes a git repository.
 
-It also installs the current `latest` Electron version and initializes a git repository. To customize, pass flags after a `--` separator (npm forwards them to `create-electron-app`), for example:
+<details>
+<summary>Use a bundler, TypeScript, or a specific Electron version</summary>
+
+Pass flags after a `--` separator (npm forwards them to `create-electron-app`):
 
 ```bash
-# Use a bundler and/or TypeScript (optional):
+# Bundler and/or TypeScript:
 npm create electron-app@latest my-windows-app -- --template=webpack
 npm create electron-app@latest my-windows-app -- --template=vite-typescript
 
-# Pin a specific Electron version, or skip git init:
+# Pin an Electron version, or skip git init:
 npm create electron-app@latest my-windows-app -- --electron-version=38.3.0 --skip-git
 ```
 
 The official Forge templates are `webpack`, `webpack-typescript`, `vite`, and `vite-typescript`. Run `npx create-electron-app@latest --help` to see all flags.
+</details>
 
 Verify the app runs:
 
@@ -54,57 +56,51 @@ The Electron workflow requires the **npm package** (`@microsoft/winappcli`) rath
 npm install --save-dev @microsoft/winappcli
 ```
 
-## Step 3: Initialize the project for Windows development
+## Step 3: Initialize for Windows and generate your JS bindings
 
-The `winapp init` command sets up everything you need in one go: app manifest, assets, and SDKs.
-
-Run the following command and follow the prompts:
+`winapp init` sets up everything your Electron app needs to call Windows APIs from JavaScript — the Windows SDK and Windows App SDK, the `Package.appxmanifest` and `Assets/`, `winapp.yaml`, the Windows App SDK runtime, and the **JS bindings** you import as `#winapp/bindings`:
 
 ```bash
-npx winapp init .
+npx winapp init . --add-js-bindings --use-defaults
 ```
 
-When prompted:
-- **Package name**: Press Enter to accept the default (my-windows-app)
-- **Publisher name**: Press Enter to accept the default or enter your name
-- **Version**: Press Enter to accept 1.0.0.0
-- **Entry point**: Press Enter to accept the default (my-windows-app.exe)
-- **Setup SDKs**: Select "Stable SDKs"
-- **Add JS/TypeScript bindings**: Press Enter to accept the default (**Yes**) to generate JS bindings for Windows App SDK APIs
+When it finishes you'll see `Generated JS bindings → .winapp/bindings` and `Added "#winapp/bindings" package imports to package.json`. Confirm you can import Windows APIs from JavaScript:
+
+```bash
+node -e "console.log(Object.keys(require('#winapp/bindings')).length + ' Windows classes available')"
+```
+
+That's the whole setup — you're ready to [call Windows APIs from JavaScript](js-file-picker.md). The command uses sensible defaults for app identity; customize them anytime by editing `Package.appxmanifest`.
 
 > [!NOTE]
-> `--use-defaults` and non-interactive init skip JS bindings unless you pass `--add-js-bindings`. Run interactive `npx winapp init .` to opt in at the prompt, or use `npx winapp init . --use-defaults --add-js-bindings` for automation.
+> The `.winapp/` folder is added to `.gitignore` and shouldn't be checked in — `winapp restore` regenerates it (see [Step 4](#step-4-add-restore-to-your-build-pipeline)).
 
-### What Does `winapp init` Do?
+<details>
+<summary>Prefer to set package name, publisher, and version interactively?</summary>
 
-This command sets up everything you need for Windows development:
+Run `npx winapp init .` with no flags and follow the prompts:
+- **Package name / Publisher / Version / Entry point** — press Enter to accept the defaults, or type your own
+- **Setup SDKs** — select **Stable SDKs**
+- **Add JS/TypeScript bindings** — accept the default **Yes**
 
-1. **Creates `.winapp/` folder** containing:
-   - Headers and libraries from the **Windows SDK**
-   - Headers and libraries from the **Windows App SDK**
-   - NuGet packages with the required binaries
+Interactive init opts into bindings at that prompt. The non-interactive `--use-defaults` path skips bindings unless you also pass `--add-js-bindings` (as shown above).
+</details>
 
-2. **Generates `Package.appxmanifest`** - The app manifest required for app identity and MSIX packaging
+<details>
+<summary>What did <code>winapp init</code> set up?</summary>
 
-3. **Creates `Assets/` folder** - Contains app icons and visual assets for your app
+1. **`.winapp/`** — headers and libraries from the Windows SDK and Windows App SDK, plus the required NuGet binaries (and your generated JS bindings)
+2. **`Package.appxmanifest`** — app manifest required for app identity and MSIX packaging
+3. **`Assets/`** — app icons and visual assets
+4. **`winapp.yaml`** — tracks SDK versions and project configuration
+5. **Windows App SDK runtime** — required runtime components for modern APIs
+6. **Developer Mode** — enabled in Windows for debugging
+7. **JS bindings** — generated into `.winapp/bindings/`, with the `winapp.jsBindings` block and the `#winapp/bindings` imports map added to `package.json` (see [Enable the `#winapp/bindings` import](#enable-the-winappbindings-import) below), plus two dependencies:
+   - `@microsoft/dynwinrt-codegen` (devDependency) — build-time codegen, pinned to the registry's `latest` on first run
+   - `@microsoft/dynwinrt` (dependency) — the runtime the bindings import, version chosen by codegen for ABI compatibility
 
-4. **Creates `winapp.yaml`** - Tracks SDK versions and project configuration
-
-5. **Installs Windows App SDK runtime** - Required runtime components for modern APIs
-
-6. **Enables Developer Mode in Windows** - Required for debugging our application
-
-7. **Generates JS bindings** - When you opt in, it:
-   - Writes the `winapp.jsBindings` block to `package.json`
-   - Adds `@microsoft/dynwinrt-codegen` to `devDependencies` — the build-time tool that produces the bindings (pinned to the registry's `latest` version on first run, then left alone)
-   - Adds `@microsoft/dynwinrt` to `dependencies` — the runtime that the generated bindings import at execution time (version is chosen by the installed codegen to guarantee ABI compatibility)
-   - Generates JS bindings for Windows App SDK APIs into `.winapp/bindings/`
-   - Adds the `#winapp/bindings` imports map to `package.json` so `require('#winapp/bindings')` resolves (see [Enable the `#winapp/bindings` import](#enable-the-winappbindings-import) below)
-
-> [!NOTE]
-> The `.winapp/` folder is automatically added to `.gitignore` and should not be checked in to source.
-
-You can open `Package.appxmanifest` to further customize properties like the display name, publisher, and capabilities.
+Open `Package.appxmanifest` anytime to customize the display name, publisher, and capabilities.
+</details>
 
 > [!TIP]
 > **About the Windows SDKs:**
@@ -117,13 +113,16 @@ You can open `Package.appxmanifest` to further customize properties like the dis
 
 ### Enable the `#winapp/bindings` import
 
-`winapp init` generates the bindings into `.winapp/bindings/` (an `index.js` + `index.mjs` + `index.d.ts`, plus one file per emitted class). The rest of these guides import them with the clean `#winapp/bindings` specifier:
+`winapp init --add-js-bindings` already wired the `#winapp/bindings` specifier into your `package.json` `imports` map — the confirm command above verifies it. It's how every JavaScript guide imports Windows APIs:
 
 ```js
 const { FileOpenPicker } = require('#winapp/bindings');
 ```
 
-That specifier only resolves if your `package.json` has a matching [subpath `imports`](https://nodejs.org/api/packages.html#subpath-imports) map. **`winapp init --add-js-bindings` writes this map for you** — you'll see `Added "#winapp/bindings" package imports to package.json` in the init output. If it's ever missing (for example, `require('#winapp/bindings')` fails with `ERR_MODULE_NOT_FOUND`), add it yourself:
+<details>
+<summary><code>require('#winapp/bindings')</code> fails with <code>ERR_MODULE_NOT_FOUND</code>, or you skipped bindings during init?</summary>
+
+The specifier resolves through a [subpath `imports`](https://nodejs.org/api/packages.html#subpath-imports) map in `package.json`. If it's missing, add it:
 
 ```jsonc
 // package.json
@@ -143,14 +142,8 @@ That specifier only resolves if your `package.json` has a matching [subpath `imp
 }
 ```
 
-Confirm it resolves:
-
-```bash
-node -e "console.log(Object.keys(require('#winapp/bindings')).length + ' Windows classes available')"
-```
-
-> [!NOTE]
-> The paths are relative to `package.json` (the folder that also holds `.winapp/`), so they're the same no matter where your entry file lives. If you'd rather not add an `imports` map, you can instead import the generated `index.js` by a path relative to the importing file — for example `require('../.winapp/bindings/index.js')` from `src/index.js`.
+The paths are relative to `package.json` (the folder that also holds `.winapp/`), so they work no matter where your entry file lives. Prefer not to add an `imports` map? Import the generated `index.js` by a path relative to the importing file — for example `require('../.winapp/bindings/index.js')` from `src/index.js`.
+</details>
 
 ## Step 4: Add Restore to Your Build Pipeline
 


### PR DESCRIPTION
## What & why

Audit + correction of the Electron **dynwinrt / JS-bindings** guides so they match what the current CLI (0.5.0) actually does. Grounded by building the CLI from source and running a **real** `winapp init --add-js-bindings` end-to-end, not just reading the docs.

The guides all import Windows APIs via the `#winapp/bindings` specifier, but the docs didn't explain how that specifier is wired (the `package.json` subpath `imports` map), and a few other steps had drifted from reality.

## Changes

- **`setup.md`**
  - Rewrote the `create-electron-app` step - the current CLI is **non-interactive** (flag-driven), not the old "when prompted, pick Bundler/Language/version" flow. Documents the real flags (`--template`, `--electron-version`, `--skip-git`) and the default (no bundler + JS). Dropped an inaccurate "latest **stable**" claim (the default resolves to the `latest` dist-tag).
  - Added an **"Enable the `#winapp/bindings` import"** section: explains that `winapp init --add-js-bindings` writes the imports map for you, shows the exact map, and gives a one-line confirm command + fallback.
  - Noted the imports-map write in the "What does `winapp init` do?" list.
- **`index.md` + `js-notification.md` / `js-file-picker.md` / `js-phi-silica.md` / `js-winml.md`** - reframed the binding-import notes around init auto-wiring the map, with an `ERR_MODULE_NOT_FOUND` fallback (manual map or relative `require`).
- **`js-winml.md`** - corrected Step 1's expected output to the **six** `ExecutionProvider*` classes actually emitted.
- **`docs/fragments/skills/winapp-cli/setup.md`** - documented the `#winapp/bindings` specifier + imports map.

## How it was verified

Built the CLI JS wrapper from this repo's source (identical to the `v0.5.0` tag) and ran a real `winapp init --add-js-bindings`:

- init prints `Added "#winapp/bindings" package imports to package.json`
- `package.json` gets the exact `imports` map
- `require('#winapp/bindings')` resolves out of the box (603 classes); subpath `#winapp/bindings/FileOpenPicker` works
- `create-electron-app` flags confirmed via `--help`

Docs-only change; no source modified.
