### PR TITLE
Offer a one-command build install in the PR metrics comment

### DIFF
--- a/.github/workflows/post-metrics-comment.yml
+++ b/.github/workflows/post-metrics-comment.yml
@@ -333,6 +333,30 @@ jobs:
               body += '\n';
             }
 
+            // --- Try this build ---
+            // Only prNumber (resolved from the trusted head_sha and verified above) and
+            // context.repo are interpolated here; nothing from the artifact reaches this text.
+            if (artifactLinks['msix-x64'] || artifactLinks['msix-arm64']) {
+              const bootstrapUrl = `https://raw.githubusercontent.com/${context.repo.owner}/${context.repo.repo}/main/scripts/winapp-pr.ps1`;
+              const pr = Number(prNumber);
+              body += '\n### Try This Build\n\n';
+              body += 'Installs the MSIX for your architecture, replacing any previously installed build. Needs the [GitHub CLI](https://cli.github.com) — the command offers to install it and sign you in if it is missing.\n\n';
+              body += '```powershell\n';
+              body += `& ([scriptblock]::Create((irm ${bootstrapUrl}))) ${pr}\n`;
+              body += '```\n\n';
+              body += '<details><summary>Switching between builds often?</summary>\n\n';
+              body += 'Put the tool on your PATH once:\n\n';
+              body += '```powershell\n';
+              body += `& ([scriptblock]::Create((irm ${bootstrapUrl}))) -AddToPath\n`;
+              body += '```\n\n';
+              body += 'Then this build is just:\n\n';
+              body += '```powershell\n';
+              body += `winapp-pr ${pr}\n`;
+              body += '```\n\n';
+              body += 'Run `winapp-pr` with no arguments to pick from a list of open PRs.\n';
+              body += '</details>\n';
+            }
+
             // --- Footer (uses TRUSTED head_sha + source run id) ---
             const timestamp = new Date().toISOString().replace('T', ' ').replace(/\.[0-9]+Z$/, ' UTC');
             const shortSha = trustedHeadSha.substring(0, 7);


### PR DESCRIPTION
The build metrics comment already links the MSIX artifacts, but actually using one still means downloading a zip, unpacking it, trusting a certificate, and removing the previously installed package. `winapp-pr` does all of that from a PR number, so the comment now offers the command directly.

Appended to the comment when the run produced an `msix-packages` artifact:

---

### Try This Build

Installs the MSIX for your architecture, replacing any previously installed build. Needs the [GitHub CLI](https://cli.github.com) — the command offers to install it and sign you in if it is missing.

```powershell
& ([scriptblock]::Create((irm https://raw.githubusercontent.com/microsoft/winappCli/main/scripts/winapp-pr.ps1))) 697
```

<details><summary>Switching between builds often?</summary>

Put the tool on your PATH once:

```powershell
& ([scriptblock]::Create((irm https://raw.githubusercontent.com/microsoft/winappCli/main/scripts/winapp-pr.ps1))) -AddToPath
```

Then this build is just:

```powershell
winapp-pr 697
```

Run `winapp-pr` with no arguments to pick from a list of open PRs.
</details>

---

The headline command runs the tool straight from the web, so trying a PR needs no prior setup at all — the right shape for a reviewer who wants to look at one build once. Putting it on PATH is a collapsed aside for people switching between builds repeatedly.

The GitHub CLI is genuinely required, because GitHub serves run and artifact metadata anonymously but returns 401 for the artifact zip itself. #700 makes `winapp-pr` offer to install and sign in to `gh` rather than just failing, which is what the wording above refers to; that PR is worth merging first so the sentence is accurate.

## Security

This workflow treats the `metrics-data` artifact as attacker-controlled and allowlists everything rendered into Markdown. The new block keeps to that: it interpolates only `prNumber` — resolved from the trusted `head_sha` and verified against the PR's current head, then coerced with `Number()` — and `context.repo`. No artifact-derived value reaches it, and no branch or title text is echoed.

## Validation

Rendered the comment locally by extracting the real script from the workflow and running it against stubbed APIs and fixture metrics, confirming the section appears with the correct PR number and that it is omitted when no `msix-packages` artifact exists. YAML parses and the embedded JavaScript passes `node --check` under the same async wrapper `actions/github-script` uses.
