### PR TITLE
ci: make sample-test Pester install resilient to PSGallery flake

### DIFF
--- a/.github/workflows/test-samples.yml
+++ b/.github/workflows/test-samples.yml
@@ -145,15 +145,44 @@ jobs:
 
     # --- Run the sample's self-contained Pester test ---
 
+    # Hosted Windows images ship Pester 5.x, so this normally short-circuits.
+    # When it does need to install, PSGallery registration/download is a known
+    # flake ("Missing option value for: '-source'"), so retry before failing.
     - name: Install Pester
       if: steps.check.outputs.skip != 'true'
       shell: pwsh
       run: |
-        if (-not (Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) {
-          Register-PSRepository -Default
+        function Get-Pester5 {
+          Get-Module -Name Pester -ListAvailable |
+            Where-Object { $_.Version.Major -ge 5 } |
+            Sort-Object Version -Descending |
+            Select-Object -First 1
         }
-        Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
-        Install-Module -Name Pester -Force -SkipPublisherCheck -Scope CurrentUser -MinimumVersion 5.0 -Repository PSGallery
+
+        $pester = Get-Pester5
+        if (-not $pester) {
+          foreach ($attempt in 1..3) {
+            try {
+              if (-not (Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) {
+                Register-PSRepository -Default -ErrorAction Stop
+              }
+              Set-PSRepository -Name PSGallery -InstallationPolicy Trusted -ErrorAction Stop
+              Install-Module -Name Pester -Force -SkipPublisherCheck -Scope CurrentUser -MinimumVersion 5.0 -Repository PSGallery -ErrorAction Stop
+            } catch {
+              Write-Host "::warning::Pester install attempt $attempt failed: $($_.Exception.Message)"
+            }
+
+            $pester = Get-Pester5
+            if ($pester) { break }
+            if ($attempt -lt 3) { Start-Sleep -Seconds (10 * $attempt) }
+          }
+        }
+
+        if (-not $pester) {
+          Write-Error "Pester 5.x is not available after 3 install attempts"
+          exit 1
+        }
+        Write-Host "Using Pester $($pester.Version)"
 
     - name: Run ${{ matrix.sample }} test
       if: steps.check.outputs.skip != 'true'


### PR DESCRIPTION
## The flake

The `Install Pester` step in `.github/workflows/test-samples.yml` fails intermittently on GitHub-hosted Windows runners:

```
Missing option value for: '-source'
NuGet.Commands.CommandException: Missing option value for: '-source'
   at NuGet.CommandLine.CommandLineParser.ExtractOptions(...)
Set-PSRepository: No repository with the name 'PSGallery' was found.
##[error]Process completed with exit code 1.
```

`Register-PSRepository -Default` hits a transient error inside the bundled NuGet provider, so PSGallery never gets registered. The next line then fails because the repository doesn't exist and the step exits 1 — the sample test never runs.

## Evidence it's a flake, not a real break

- It fails in CI setup, before any repo code executes.
- Observed on run `30570937690`, job `winui-app`. All 11 other sample matrix jobs passed on the same commit, same runner image, same step.
- Re-running just that job succeeded with no code change.

## Approach

Two changes to the one step (it appears once in the YAML — the matrix duplicates it at runtime, so no composite action is needed):

1. **Check first, install only if missing.** Hosted Windows images ship Pester 5.x, so the PSGallery dance is skipped entirely in the common case — which removes the flake's window altogether. Uses the same detection idiom already in `scripts/test-samples.ps1` and `scripts/build-cli.ps1`.
2. **Retry acquisition** up to 3 times with backoff (10s, 20s) when Pester genuinely isn't present. Failed attempts surface as `::warning::` so the flake stays visible rather than being silently swallowed.

The failure signal is preserved: if Pester 5.x still isn't available after all attempts, the step `Write-Error`s and exits 1.

## Verification

- YAML parses cleanly.
- Extracted the step body and ran it locally across all three paths:
  - Pester already present → short-circuits, `Using Pester 5.7.1`, exit 0
  - Install fails on attempt 1, succeeds on attempt 2 → warning emitted, exit 0
  - Install fails all 3 attempts → 3 warnings + `Write-Error`, exit 1