### PR TITLE
Add winapp-pr -Update, -Help, and build freshness in the picker

### DIFF
--- a/scripts/winapp-pr.ps1
+++ b/scripts/winapp-pr.ps1
@@ -77,6 +77,7 @@ $GhExe = 'gh'
 $ToolHome     = Join-Path $env:LOCALAPPDATA 'winapp-dev'
 $CacheRoot    = Join-Path $ToolHome 'cache'
 $StateFile    = Join-Path $ToolHome 'current.json'
+$TrustedFile  = Join-Path $ToolHome 'trusted-certs.json'
 $InstallDir   = Join-Path $env:LOCALAPPDATA 'Programs\winapp-dev'
 
 function Write-Step   { param([string]$m) Write-Host "`n>> $m" -ForegroundColor Cyan }
@@ -689,6 +690,22 @@ function Read-P7xCertificate {
     }
 }
 
+function Get-TrackedCerts {
+    <#
+        Thumbprints this tool has trusted. TrustedPeople is a shared store holding unrelated
+        anchors, so cleanup is driven by what we added rather than by matching on subject.
+    #>
+    if (-not (Test-Path $TrustedFile)) { return @() }
+    try { return @(Get-Content $TrustedFile -Raw | ConvertFrom-Json) } catch { return @() }
+}
+
+function Set-TrackedCerts {
+    param([string[]]$Thumbprints)
+
+    New-Item -ItemType Directory -Path $ToolHome -Force | Out-Null
+    ,@($Thumbprints) | ConvertTo-Json | Set-Content -Path $TrustedFile -Encoding UTF8
+}
+
 function Get-PackageCertificate {
     param([string]$PackagePath)
 
@@ -717,10 +734,15 @@ function Grant-CertificateTrust {
     <# Imports the cert into LocalMachine\TrustedPeople, elevating only for that step. #>
     param([System.Security.Cryptography.X509Certificates.X509Certificate2]$Certificate)
 
+    $tracked = Get-TrackedCerts
+
     $already = Get-ChildItem Cert:\LocalMachine\TrustedPeople |
         Where-Object { $_.Thumbprint -eq $Certificate.Thumbprint }
     if ($already) {
         Write-Ok "Certificate already trusted ($($Certificate.Thumbprint.Substring(0,12))...)"
+        if ($tracked -notcontains $Certificate.Thumbprint) {
+            Set-TrackedCerts -Thumbprints (@($tracked) + $Certificate.Thumbprint)
+        }
         return
     }
 
@@ -730,8 +752,20 @@ function Grant-CertificateTrust {
     Write-Detail "Trusting $($Certificate.Subject) ($($Certificate.Thumbprint.Substring(0,12))...)"
     Write-Detail 'Approve the elevation prompt to add it to LocalMachine\TrustedPeople.'
 
-    $command = "Import-Certificate -FilePath '$cerPath' -CertStoreLocation Cert:\LocalMachine\TrustedPeople | Out-Null"
-    $encoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($command))
+    # Retire the certs we trusted for earlier builds in the same elevated step, so cleanup
+    # never costs an extra prompt. Removing one does not affect an already-installed package.
+    $retire = @($tracked | Where-Object { $_ -and $_ -ne $Certificate.Thumbprint })
+    if ($retire) {
+        Write-Detail "Also retiring $($retire.Count) certificate(s) from earlier installs."
+    }
+
+    $statements = @(
+        "Import-Certificate -FilePath '$cerPath' -CertStoreLocation Cert:\LocalMachine\TrustedPeople | Out-Null"
+    ) + @($retire | ForEach-Object {
+        "Remove-Item 'Cert:\LocalMachine\TrustedPeople\$_' -Force -ErrorAction SilentlyContinue"
+    })
+
+    $encoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($statements -join '; '))
     $shell = if (Get-Command pwsh -ErrorAction SilentlyContinue) { 'pwsh' } else { 'powershell' }
 
     try {
@@ -754,6 +788,7 @@ function Grant-CertificateTrust {
     if (-not $verify) {
         Fail 'Certificate import reported success but the certificate is not in the store.'
     }
+    Set-TrackedCerts -Thumbprints @($Certificate.Thumbprint)
     Write-Ok 'Certificate trusted'
 }
 
@@ -779,6 +814,7 @@ function Remove-StaleCertificates {
         foreach ($cert in $stale) {
             Remove-Item "Cert:\LocalMachine\TrustedPeople\$($cert.Thumbprint)" -Force
         }
+        Set-TrackedCerts -Thumbprints @(Get-TrackedCerts | Where-Object { $_ -eq $KeepThumbprint })
         Write-Ok "Removed $($stale.Count) certificate(s)"
         return
     }
@@ -794,6 +830,7 @@ function Remove-StaleCertificates {
     if ($proc.ExitCode -ne 0) {
         Fail "Certificate cleanup failed with exit code $($proc.ExitCode)."
     }
+    Set-TrackedCerts -Thumbprints @(Get-TrackedCerts | Where-Object { $_ -eq $KeepThumbprint })
     Write-Ok "Removed $($stale.Count) certificate(s)"
 }
 
@@ -834,6 +871,7 @@ COMMANDS
   -Status                   show the installed build and where it came from
   -List                     list recent builds for the target
   -PruneCerts               remove trusted CI certificates from past installs
+                            (installs retire their own automatically)
   -AddToPath                install winapp-pr itself onto your PATH
   -UpdateTool               update winapp-pr itself
   -Help                     show this
@@ -1083,7 +1121,7 @@ Name what you want instead, for example:
         Write-Warn "'winapp --version' failed; open a new terminal and try again."
     }
 
-    Write-Host "`nDone. Run 'winapp-pr -PruneCerts' occasionally to clear old CI certificates.`n" -ForegroundColor Green
+    Write-Host "`nDone.`n" -ForegroundColor Green
 }
 
 $exitCode = 0

--- a/scripts/winapp-pr.ps1
+++ b/scripts/winapp-pr.ps1
@@ -676,18 +676,40 @@ function Get-CachedMsixPackage {
 
 # ── Certificate trust ────────────────────────────────────────────────────────
 
+function Test-Thumbprint {
+    <# Thumbprints get interpolated into an elevated command, so treat them as untrusted input. #>
+    param([string]$Value)
+    return ($Value -match '^[0-9A-Fa-f]{40}$')
+}
+
 function Read-P7xCertificate {
     param([string]$Path)
 
     if (-not (Test-Path $Path)) { return $null }
     try {
+        $bytes = [System.IO.File]::ReadAllBytes($Path)
+        # AppxSignature.p7x is a PKCS#7 blob behind a 4-byte 'PKCX' magic; SignedCms rejects it.
+        if ($bytes.Length -gt 4 -and
+            $bytes[0] -eq 0x50 -and $bytes[1] -eq 0x4B -and $bytes[2] -eq 0x43 -and $bytes[3] -eq 0x58) {
+            $bytes = $bytes[4..($bytes.Length - 1)]
+        }
         $cms = New-Object System.Security.Cryptography.Pkcs.SignedCms
-        $cms.Decode([System.IO.File]::ReadAllBytes($Path))
+        $cms.Decode($bytes)
         return $cms.Certificates[0]
     }
     catch {
         return $null
     }
+}
+
+function Get-InstalledCertThumbprint {
+    <# The signing certificate of the installed package. CI mints one per run, so it is unique. #>
+    param([object]$Package)
+
+    if (-not $Package -or -not $Package.InstallLocation) { return '' }
+    $cert = Read-P7xCertificate -Path (Join-Path $Package.InstallLocation 'AppxSignature.p7x')
+    if ($cert) { return $cert.Thumbprint }
+    return ''
 }
 
 function Get-TrackedCerts {
@@ -696,14 +718,22 @@ function Get-TrackedCerts {
         anchors, so cleanup is driven by what we added rather than by matching on subject.
     #>
     if (-not (Test-Path $TrustedFile)) { return @() }
-    try { return @(Get-Content $TrustedFile -Raw | ConvertFrom-Json) } catch { return @() }
+    try {
+        $values = @(Get-Content $TrustedFile -Raw | ConvertFrom-Json)
+    }
+    catch {
+        return @()
+    }
+    # This file is user-writable and its values are interpolated into an elevated command.
+    return @($values | Where-Object { Test-Thumbprint -Value $_ })
 }
 
 function Set-TrackedCerts {
     param([string[]]$Thumbprints)
 
     New-Item -ItemType Directory -Path $ToolHome -Force | Out-Null
-    ,@($Thumbprints) | ConvertTo-Json | Set-Content -Path $TrustedFile -Encoding UTF8
+    $clean = @($Thumbprints | Where-Object { Test-Thumbprint -Value $_ })
+    ,$clean | ConvertTo-Json | Set-Content -Path $TrustedFile -Encoding UTF8
 }
 
 function Get-PackageCertificate {
@@ -754,9 +784,13 @@ function Grant-CertificateTrust {
 
     # Retire the certs we trusted for earlier builds in the same elevated step, so cleanup
     # never costs an extra prompt. Removing one does not affect an already-installed package.
-    $retire = @($tracked | Where-Object { $_ -and $_ -ne $Certificate.Thumbprint })
+    $retire = @($tracked | Where-Object { $_ -and $_ -ne $Certificate.Thumbprint -and (Test-Thumbprint -Value $_) })
     if ($retire) {
         Write-Detail "Also retiring $($retire.Count) certificate(s) from earlier installs."
+    }
+
+    if (-not (Test-Thumbprint -Value $Certificate.Thumbprint)) {
+        Fail "Refusing to trust a certificate with an unexpected thumbprint format."
     }
 
     $statements = @(
@@ -819,7 +853,7 @@ function Remove-StaleCertificates {
         return
     }
 
-    $removals = ($stale | ForEach-Object {
+    $removals = ($stale | Where-Object { Test-Thumbprint -Value $_.Thumbprint } | ForEach-Object {
         "Remove-Item 'Cert:\LocalMachine\TrustedPeople\$($_.Thumbprint)' -Force -ErrorAction SilentlyContinue"
     }) -join '; '
     $encoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($removals))
@@ -909,8 +943,16 @@ function Test-StateMatchesInstall {
     param([object]$State, [object]$Package)
 
     if (-not $State -or -not $Package) { return $false }
+
+    # Prefer the signing certificate: dev versions are a commit count, so unrelated branches at
+    # the same depth produce identical name/version/architecture and would compare equal.
+    $installedThumb = Get-InstalledCertThumbprint -Package $Package
+    if ($installedThumb) {
+        return ($installedThumb -eq $State.Thumbprint)
+    }
+
+    # Signature unreadable: fall back to the weaker check rather than refusing to work.
     if ($State.Version -ne $Package.Version) { return $false }
-    # Records written before Arch was tracked can't be checked on it; version alone will do.
     if ($State.Arch -and $State.Arch -ne (Get-InstalledArch -Package $Package)) { return $false }
     return $true
 }

--- a/scripts/winapp-pr.ps1
+++ b/scripts/winapp-pr.ps1
@@ -18,67 +18,10 @@
         & ([scriptblock]::Create((irm https://raw.githubusercontent.com/microsoft/winappCli/main/scripts/winapp-pr.ps1))) -AddToPath
 
     From a clone, run with -AddToPath instead. Either way the script is copied to a directory
-    on your user PATH so `winapp-pr` works from anywhere; -Update refreshes it later.
+    on your user PATH so `winapp-pr` works from anywhere; -UpdateTool refreshes it later.
 
-.PARAMETER Target
-    A PR number (690) or a branch name (main, zt/new-command). Omit it to choose interactively.
+    Run `winapp-pr -Help` for the full list of commands and options.
 
-.PARAMETER Repo
-    Repository to pull builds from, as owner/name. Defaults to $env:WINAPP_PR_REPO, then
-    microsoft/winappCli. Use this to install from a private fork.
-
-.PARAMETER Run
-    Install from an explicit workflow run ID, bypassing PR/branch resolution.
-
-.PARAMETER Arch
-    Package architecture: x64 or arm64. Defaults to this machine's architecture.
-
-.PARAMETER List
-    Show recent candidate runs for the target instead of installing.
-
-.PARAMETER Status
-    Show the currently installed winapp package and exit.
-
-.PARAMETER PruneCerts
-    Remove trusted CI dev certificates left behind by previous installs, keeping the one the
-    installed package needs. Requires admin.
-
-.PARAMETER AddToPath
-    Copy this script to %LOCALAPPDATA%\Programs\winapp-dev, add it to the user PATH, and exit.
-
-.PARAMETER Update
-    Download the latest winapp-pr from main and reinstall it to the user PATH.
-
-.PARAMETER NonInteractive
-    Skip the picker when no target is given and use the current git branch instead.
-
-.PARAMETER Force
-    Re-download the artifact even if a cached copy exists.
-
-.EXAMPLE
-    & ([scriptblock]::Create((irm https://raw.githubusercontent.com/microsoft/winappCli/main/scripts/winapp-pr.ps1))) -AddToPath
-
-    Install winapp-pr on a machine that has no clone of the repo. Requires the GitHub CLI.
-
-.EXAMPLE
-    winapp-pr
-    Pick an open PR (or the default branch) from a list and install it.
-
-.EXAMPLE
-    winapp-pr 690
-    Install the latest build for PR 690.
-
-.EXAMPLE
-    winapp-pr main
-    Install the latest build from main.
-
-.EXAMPLE
-    winapp-pr 42 -Repo contoso/winappCli-private
-    Install PR 42 from a private fork.
-
-.EXAMPLE
-    winapp-pr -List
-    Show recent runs for the current branch without installing.
 #>
 
 [CmdletBinding(DefaultParameterSetName = 'Install')]
@@ -99,11 +42,15 @@ param(
 
     [switch]$PruneCerts,
 
-    [switch]$AddToPath,
-
     [switch]$Update,
 
+    [switch]$AddToPath,
+
+    [switch]$UpdateTool,
+
     [switch]$NonInteractive,
+
+    [switch]$Help,
 
     [switch]$Force
 )
@@ -228,8 +175,24 @@ Install the GitHub CLI, then re-run:
     }
     $script:GhExe = $ghPath
 
-    & $script:GhExe auth status *> $null
+    # Scoped to the active github.com account: a bare `gh auth status` fails when ANY configured
+    # account on any host is stale, which would send people with a second account into sign-in.
+    & $script:GhExe auth status --active --hostname github.com *> $null
     if ($LASTEXITCODE -eq 0) { return }
+
+    # gh refuses to store credentials while an env token is set, so offering login would dead-end.
+    $envTokenName = @('GH_TOKEN', 'GITHUB_TOKEN') |
+        Where-Object { [Environment]::GetEnvironmentVariable($_) } |
+        Select-Object -First 1
+    if ($envTokenName) {
+        Fail @"
+GitHub rejected the token in `$env:$envTokenName.
+
+Update it, or clear it and sign in interactively:
+  Remove-Item Env:\$envTokenName
+  gh auth login
+"@
+    }
 
     Write-Warn 'The GitHub CLI is installed but not signed in.'
     if (-not (Confirm-Action '   Sign in now?')) {
@@ -241,7 +204,7 @@ Sign in, then re-run:
 
     # gh drives its own prompts here, so let it own the console.
     & $script:GhExe auth login
-    & $script:GhExe auth status *> $null
+    & $script:GhExe auth status --active --hostname github.com *> $null
     if ($LASTEXITCODE -ne 0) {
         Fail 'Still not signed in. Run gh auth login manually, then re-run.'
     }
@@ -427,6 +390,27 @@ function Get-MenuItems {
     $state = Get-InstallState
     $localBranch = Get-LocalBranch
 
+    # Only claim a build is installed when the record still describes the installed package and
+    # came from the repo being listed; branch names collide across forks.
+    $installedBranch = ''
+    $installedIsCurrent = $true
+    $liveState = Test-StateMatchesInstall -State $state -Package (Get-InstalledWinapp | Select-Object -First 1)
+    if ($liveState -and $state.Branch -and $state.Repo -eq $RepoName) {
+        $installedBranch = $state.Branch
+        $newest = Get-MsixArtifact -RepoName $RepoName -Quiet `
+            -Runs (Get-BranchRuns -RepoName $RepoName -Branch $installedBranch -HeadRepo $state.HeadRepo)
+        if ($newest -and $newest.Run.id -ne $state.RunId) { $installedIsCurrent = $false }
+    }
+
+    function Get-Marker {
+        param([string]$Branch)
+        if ($installedBranch -and $installedBranch -eq $Branch) {
+            return $(if ($installedIsCurrent) { '*' } else { '^' })
+        }
+        if ($localBranch -and $localBranch -eq $Branch) { return '.' }
+        return ' '
+    }
+
     $items = foreach ($pr in @($prs)) {
         $meta = @($pr.author, (Get-RelativeAge ([datetime]$pr.updated)))
         if ($pr.draft) { $meta = @($pr.author, 'draft', (Get-RelativeAge ([datetime]$pr.updated))) }
@@ -436,9 +420,7 @@ function Get-MenuItems {
             Name   = "#$($pr.number)"
             Title  = $pr.title
             Meta   = ($meta -join ' - ')
-            Marker = if ($state -and $state.Branch -eq $pr.branch) { '*' }
-                     elseif ($localBranch -eq $pr.branch) { '.' }
-                     else { ' ' }
+            Marker = Get-Marker -Branch $pr.branch
         }
     }
 
@@ -448,7 +430,7 @@ function Get-MenuItems {
         Name   = $defaultBranch
         Title  = 'latest build from the default branch'
         Meta   = ''
-        Marker = if ($state -and $state.Branch -eq $defaultBranch) { '*' } else { ' ' }
+        Marker = Get-Marker -Branch $defaultBranch
     }
 
     return @($items)
@@ -555,7 +537,7 @@ function Select-InstallTarget {
     $items = Get-MenuItems -RepoName $RepoName
     if (-not $items) { Fail "No open pull requests or branches found in $RepoName." }
 
-    Write-Host "   * installed   . current branch   (Up/Down, Enter to install, Esc to cancel)`n" -ForegroundColor DarkGray
+    Write-Host "   * installed   ^ newer build available   . current branch   (Up/Down, Enter to install, Esc to cancel)`n" -ForegroundColor DarkGray
 
     $canDrawMenu = -not ([Console]::IsInputRedirected -or [Console]::IsOutputRedirected)
     $choice = if ($canDrawMenu) {
@@ -576,13 +558,20 @@ function Select-InstallTarget {
 }
 
 function Get-BranchRuns {
-    param([string]$RepoName, [string]$Branch)
+    param([string]$RepoName, [string]$Branch, [string]$HeadRepo)
 
     $encoded = [uri]::EscapeDataString($Branch)
     $runs = Invoke-Gh @('api', "repos/$RepoName/actions/runs?branch=$encoded&per_page=50",
         '--jq', '.workflow_runs')
-    return @($runs | Where-Object { $_.name -eq $WorkflowName } |
-        Sort-Object { [datetime]$_.created_at } -Descending)
+    $runs = @($runs | Where-Object { $_.name -eq $WorkflowName })
+
+    # Fork PRs run in the base repo and can share a branch name with another fork -- "main"
+    # especially -- so pin to the head repository when the caller knows which one it wants.
+    if ($HeadRepo) {
+        $runs = @($runs | Where-Object { $_.head_repository.full_name -eq $HeadRepo })
+    }
+
+    return @($runs | Sort-Object { [datetime]$_.created_at } -Descending)
 }
 
 function Get-CandidateRuns {
@@ -591,11 +580,11 @@ function Get-CandidateRuns {
         head commit come first, then older builds of the same branch so an in-progress or
         artifact-less newest run degrades to the previous good build instead of failing.
     #>
-    param([string]$RepoName, [string]$TargetSpec)
+    param([string]$RepoName, [string]$TargetSpec, [string]$HeadRepo)
 
     if ($TargetSpec -notmatch '^\d+$') {
         Write-Detail "Branch: $TargetSpec"
-        return Get-BranchRuns -RepoName $RepoName -Branch $TargetSpec
+        return Get-BranchRuns -RepoName $RepoName -Branch $TargetSpec -HeadRepo $HeadRepo
     }
 
     $pr = Invoke-Gh @('api', "repos/$RepoName/pulls/$TargetSpec",
@@ -604,6 +593,7 @@ function Get-CandidateRuns {
     Write-Detail "Branch: $($pr.branch)  @ $($pr.sha.Substring(0,8))"
 
     $script:TargetHeadSha = $pr.sha
+    $script:TargetPr = $TargetSpec
 
     $headRuns = Invoke-Gh @('api', "repos/$RepoName/actions/runs?head_sha=$($pr.sha)&per_page=100",
         '--jq', '.workflow_runs')
@@ -622,7 +612,7 @@ function Get-CandidateRuns {
 
 function Get-MsixArtifact {
     <# First run in the list that has a downloadable msix-packages artifact. #>
-    param([string]$RepoName, [object[]]$Runs)
+    param([string]$RepoName, [object[]]$Runs, [switch]$Quiet)
 
     foreach ($run in $Runs) {
         $artifacts = Invoke-Gh @('api', "repos/$RepoName/actions/runs/$($run.id)/artifacts",
@@ -632,7 +622,9 @@ function Get-MsixArtifact {
         if ($msix) {
             return [pscustomobject]@{ Run = $run; Artifact = $msix }
         }
-        Write-Detail "Run $($run.id) has no usable $ArtifactName artifact, trying older run..."
+        if (-not $Quiet) {
+            Write-Detail "Run $($run.id) has no usable $ArtifactName artifact, trying older run..."
+        }
     }
     return $null
 }
@@ -821,6 +813,70 @@ function Install-WinappPackage {
     Write-Ok 'Package installed'
 }
 
+function Show-ScriptHelp {
+    # Hand-written rather than Get-Help: it stays readable, and it works identically when the
+    # script is run from the web as a scriptblock, where Get-Help has no file to read.
+    # Written to the pipeline a line at a time so it can be piped, paged, or grepped.
+    @'
+winapp-pr - install winapp CLI MSIX builds produced by CI
+
+USAGE
+  winapp-pr [<pr>|<branch>] [options]
+
+PICKING A BUILD
+  winapp-pr                 choose from a list of open pull requests
+  winapp-pr 690             a pull request
+  winapp-pr main            a branch
+  winapp-pr -Run <id>       an exact workflow run
+
+COMMANDS
+  -Update                   install the newest build of whatever you have
+  -Status                   show the installed build and where it came from
+  -List                     list recent builds for the target
+  -PruneCerts               remove trusted CI certificates from past installs
+  -AddToPath                install winapp-pr itself onto your PATH
+  -UpdateTool               update winapp-pr itself
+  -Help                     show this
+
+OPTIONS
+  -Repo <owner/name>        install from another repo, such as a private fork
+  -Arch <x64|arm64>         override the detected architecture
+  -Force                    reinstall even if that build is already installed
+  -NonInteractive           skip the picker and use the current git branch
+
+Installing a build replaces any winapp package already installed, and needs the
+GitHub CLI; winapp-pr offers to install it and sign you in if it is missing.
+Set $env:WINAPP_PR_REPO to change the default repo.
+'@ -split "`r?`n"
+}
+
+function Get-InstalledArch {
+    <# Maps the installed package's architecture onto the names used for artifacts. #>
+    param([object]$Package)
+
+    if (-not $Package) { return '' }
+    switch ("$($Package.Architecture)".ToLower()) {
+        'x64'   { 'x64' }
+        'arm64' { 'arm64' }
+        default { "$($Package.Architecture)".ToLower() }
+    }
+}
+
+function Test-StateMatchesInstall {
+    <#
+        True when the install record still describes the package that is actually installed.
+        A package installed by other means -- double-clicking an MSIX, setup-winapprun.ps1 --
+        leaves the record describing a build that is no longer there.
+    #>
+    param([object]$State, [object]$Package)
+
+    if (-not $State -or -not $Package) { return $false }
+    if ($State.Version -ne $Package.Version) { return $false }
+    # Records written before Arch was tracked can't be checked on it; version alone will do.
+    if ($State.Arch -and $State.Arch -ne (Get-InstalledArch -Package $Package)) { return $false }
+    return $true
+}
+
 function Show-Status {
     $installed = Get-InstalledWinapp
     if (-not $installed) {
@@ -832,16 +888,24 @@ function Show-Status {
     }
 
     $state = Get-InstallState
-    if ($state -and $state.Version -eq ($installed | Select-Object -First 1).Version) {
+    if (Test-StateMatchesInstall -State $state -Package ($installed | Select-Object -First 1)) {
         Write-Detail "Source: $($state.Repo)  $($state.Branch)  @ $($state.HeadSha)"
         Write-Detail "Run   : $($state.RunId)  installed $($state.InstalledAt)"
+    }
+    elseif ($state) {
+        Write-Warn 'This package was not installed by winapp-pr; its source is unknown.'
     }
 }
 
 # ── Main ─────────────────────────────────────────────────────────────────────
 
 function Invoke-Main {
-    if ($Update) {
+    if ($Help) {
+        Show-ScriptHelp
+        return
+    }
+
+    if ($UpdateTool) {
         Write-Step 'Updating winapp-pr from main'
         Update-Self
         return
@@ -863,6 +927,30 @@ function Invoke-Main {
 
 
     $repoName = Resolve-Repo
+    $installState = Get-InstallState
+    $installedPackage = Get-InstalledWinapp | Select-Object -First 1
+    $stateIsLive = Test-StateMatchesInstall -State $installState -Package $installedPackage
+
+    if ($Update) {
+        if (-not $installState -or -not ($installState.Pr -or $installState.Branch)) {
+            Fail 'No record of a previous install to update. Pass a PR number or branch instead.'
+        }
+        if ($installedPackage -and -not $stateIsLive) {
+            Fail @"
+The installed package ($($installedPackage.Name) $($installedPackage.Version)) was not installed
+by winapp-pr, so there is no way to tell which build it came from.
+
+Name what you want instead, for example:
+  winapp-pr $($installState.Branch)
+"@
+        }
+        # The record describes where this build came from, so only an explicit -Repo may
+        # override it; WINAPP_PR_REPO is a default for new installs, not a redirect for this one.
+        if (-not $Repo -and $installState.Repo) {
+            $repoName = $installState.Repo
+        }
+    }
+
     if ($repoName -notmatch '^[^/]+/[^/]+$') {
         Fail "Repo must be in owner/name form, got '$repoName'."
     }
@@ -892,6 +980,20 @@ function Invoke-Main {
     }
     else {
         $spec = $Target
+        $updateHeadRepo = ''
+        if (-not $spec -and $Update) {
+            # Prefer the PR the build came from: a branch name alone can match another fork's
+            # runs in this same base repo. Fall back to the branch, pinned to its head repo.
+            if ($installState.Pr) {
+                $spec = [string]$installState.Pr
+                Write-Detail "Updating the installed build: PR #$($installState.Pr)"
+            }
+            else {
+                $spec = $installState.Branch
+                $updateHeadRepo = $installState.HeadRepo
+                Write-Detail "Updating the installed build: $($installState.Branch)"
+            }
+        }
         if (-not $spec) {
             $spec = if ($NonInteractive -or $List) {
                 Resolve-CurrentBranch -RepoName $repoName
@@ -901,7 +1003,7 @@ function Invoke-Main {
             }
         }
         Write-Step "Resolving build from $repoName"
-        $runs = Get-CandidateRuns -RepoName $repoName -TargetSpec $spec
+        $runs = Get-CandidateRuns -RepoName $repoName -TargetSpec $spec -HeadRepo $updateHeadRepo
         if (-not $runs) {
             Fail "No '$WorkflowName' runs found for '$spec' in $repoName."
         }
@@ -932,6 +1034,17 @@ function Invoke-Main {
         Write-Warn "No package for the PR's head commit ($($script:TargetHeadSha.Substring(0,8))) yet -- using an earlier build."
     }
 
+    # Re-resolving often lands on the build already installed; don't churn the package for nothing.
+    # Requires the record to still describe the installed package, and the same architecture,
+    # so asking for a different -Arch is never mistaken for a no-op.
+    if (-not $Force -and $stateIsLive -and
+        $installState.RunId -eq $selected.Run.id -and
+        (Get-InstalledArch -Package $installedPackage) -eq $architecture) {
+        Write-Ok "Already on this build -- nothing to do."
+        Write-Detail 'Use -Force to reinstall it anyway.'
+        return
+    }
+
     Write-Step "Fetching $architecture package"
     $package = Get-CachedMsixPackage -RepoName $repoName -Run $selected.Run -Architecture $architecture
 
@@ -952,9 +1065,12 @@ function Invoke-Main {
         Set-InstallState @{
             Repo        = $repoName
             RunId       = $selected.Run.id
+            Pr          = $script:TargetPr
             Branch      = $selected.Run.head_branch
+            HeadRepo    = $selected.Run.head_repository.full_name
             HeadSha     = $selected.Run.head_sha.Substring(0, 8)
             Version     = $installed.Version
+            Arch        = $architecture
             Thumbprint  = $certificate.Thumbprint
             InstalledAt = (Get-Date).ToString('s')
         }


### PR DESCRIPTION
Based directly on `main`. Single commit, one file.

Picking up newer commits on the build you are already running was more work than it should be. You had to remember which PR or branch it came from — `-Status` would tell you, but that is an extra step — and name it again. Worse, re-resolving the same target silently uninstalled and reinstalled an identical package with no indication you were already current.

## Changes

**`-Update`** installs the newest build for whatever is installed:

```powershell
winapp-pr -Update
```

It resolves by the PR the build came from where there was one. Fork PRs run in the *base* repo, so a branch name alone can match another fork's runs — `main` being the obvious case — and picking "the newest run on that branch" could hand you an unrelated contributor's build. Where only a branch is known, resolution is pinned to that build's head repository instead.

Only an explicit `-Repo` overrides the recorded source. `WINAPP_PR_REPO` is a default for *new* installs, not a redirect for an existing one; otherwise having it point at the public repo while running a private-fork build would send `-Update` looking for that branch in the wrong place.

Updating the tool itself moves from `-Update` to **`-UpdateTool`**. Updating the *build* is by far the more common intent, so it should own the obvious name.

**Already-installed builds are no longer reinstalled.** Any resolution that lands on the run you are already on stops early:

```
   [OK] Run 30544907744  [success]  de22c73a
   [OK] Already on this build -- nothing to do.
   Use -Force to reinstall it anyway.
```

This applies to naming a target explicitly too, so `winapp-pr 681` when you are on 681's newest build is a no-op instead of a ~10 second uninstall/reinstall cycle.

**The install record is only trusted while it still describes the installed package.** A package installed by other means — double-clicking an MSIX, `setup-winapprun.ps1` — used to leave the record describing a build that was no longer there, which would have let the no-op above skip a genuinely needed install. The record is now validated against the live package first:

```
>> Installed winapp package
   winapp-dev 0.5.1.40  [CN=runneradmin]
   [WARN] This package was not installed by winapp-pr; its source is unknown.
```

`-Update` refuses rather than guessing, and points at a concrete alternative:

```
[ERROR] The installed package (winapp-dev 0.5.1.40) was not installed
by winapp-pr, so there is no way to tell which build it came from.

Name what you want instead, for example:
  winapp-pr jay/find-ui-port
```

The record now tracks architecture as well, so requesting a different `-Arch` for a run you already have is not mistaken for a no-op. Records written before this change lack the newer fields and fall back to the old behaviour, so nobody has to reinstall to get a working record.

**The picker shows build freshness**, distinguishing "you have this" from "there is something newer":

```
   * installed   ^ newer build available   . current branch

  1. . #702  Add winapp-pr -Update and show build freshness in the picker      nmetulev - 2m
  2. ^ #681  feat: add winapp find-ui — WinUI control & sample search     Jaylyn-Barbee - 4m
  3.   #701  ci: make sample-test Pester install resilient to PSGallery       nmetulev - 2h
```

Freshness is resolved the same way an install would resolve it — the newest run that actually has an artifact, pinned to the same head repository — so neither an in-progress build nor another fork's run produces a phantom `^`. It costs two extra API calls, only for the one installed branch.

**`-Help`** lists everything. PowerShell's built-in `-?` already covers the on-disk case, but it throws when the script is run from the web as a scriptblock:

```
InvalidArgument: Cannot process argument because the value of argument "helpTarget" is null.
```

That is exactly how the documented installer runs it, so `-Help` uses `Get-Help` when there is a file and falls back to the script's own comment-based help block otherwise.

## Also carries the #700 review fixes

Those review comments were written after #700 had already merged, so they never landed. They are folded in here rather than left on a dead branch:

- The gh readiness check is scoped with `--active --hostname github.com`. A bare `gh auth status` fails when *any* configured account on *any* host is stale, so anyone with a second account would have been pushed into a pointless sign-in.
- When an invalid `GH_TOKEN` or `GITHUB_TOKEN` is the cause, say so instead of offering to sign in. `gh auth login` refuses to store credentials while an env token is set, so that prompt could only ever dead-end.

## Validation

The fork-collision fix was reproduced directly: two `Build and Package` runs on a branch named `feature` from different head repositories, the unrelated one newer. Unfiltered resolution selects the stranger's run; pinned to the head repository it selects the right one.

`-Update` was checked with `WINAPP_PR_REPO` pointing at a different repo, confirming it stays on the recorded source; with a record carrying a PR number, confirming it resolves by PR; and with a legacy record lacking the new fields, confirming the branch path still works. A real install was run end to end to confirm `Pr`, `HeadRepo`, and `Arch` are persisted.

Also exercised against real branch builds: `-Update` when current reports it and exits 0; `-Update -Force` performs a full reinstall; `-Update` with no record fails cleanly; `-UpdateTool` still targets the tool. Record validation was covered as a table — matching version and architecture, mismatched architecture, legacy record, and a version mismatch standing in for a manual install — and end to end by pointing the record at a version that is not installed. Picker markers were checked in all three states, and `-Help` both from a file and through a scriptblock.
