### PR TITLE
fix(winapp-pr): paginate the artifacts query so a busy run's package is findable

### DIFF
--- a/scripts/winapp-pr.ps1
+++ b/scripts/winapp-pr.ps1
@@ -616,15 +616,20 @@ function Get-MsixArtifact {
     param([string]$RepoName, [object[]]$Runs, [switch]$Quiet)
 
     foreach ($run in $Runs) {
+        # --paginate is load-bearing: the artifacts endpoint returns 30 per page, and a run that
+        # uploads more than that pushes msix-packages onto page 2, where an unpaginated query
+        # cannot see it. The symptom is indistinguishable from a run that genuinely never built a
+        # package -- the walk-back to an older run looks like it is working, and silently hands
+        # back a stale build. Do not remove this without checking .total_count on a busy run.
         $artifacts = Invoke-Gh @('api', "repos/$RepoName/actions/runs/$($run.id)/artifacts",
-            '--jq', '.artifacts')
+            '--paginate', '--jq', '.artifacts')
         $msix = $artifacts | Where-Object { $_.name -eq $ArtifactName -and -not $_.expired } |
             Select-Object -First 1
         if ($msix) {
             return [pscustomobject]@{ Run = $run; Artifact = $msix }
         }
         if (-not $Quiet) {
-            Write-Detail "Run $($run.id) has no usable $ArtifactName artifact, trying older run..."
+            Write-Detail "Run $($run.id) has no $ArtifactName artifact among its $(($artifacts | Measure-Object).Count), trying older run..."
         }
     }
     return $null

--- a/scripts/winapp-pr.ps1
+++ b/scripts/winapp-pr.ps1
@@ -629,7 +629,7 @@ function Get-MsixArtifact {
             return [pscustomobject]@{ Run = $run; Artifact = $msix }
         }
         if (-not $Quiet) {
-            Write-Detail "Run $($run.id) has no $ArtifactName artifact among its $(($artifacts | Measure-Object).Count), trying older run..."
+            Write-Detail "Run $($run.id) has no usable $ArtifactName artifact among its $(($artifacts | Measure-Object).Count), trying older run..."
         }
     }
     return $null


### PR DESCRIPTION
## The bug

`winapp-pr` walks recent runs looking for a downloadable `msix-packages` artifact. The query asked GitHub for a run's artifacts **without `--paginate`**, so it only ever saw the first 30. A run that uploads more than that pushes `msix-packages` onto page 2, where the query cannot see it.

Observed on a run with 47 artifacts:

```
without --paginate    30 returned    msix-packages NOT present
with    --paginate    47 returned    msix-packages present, non-expired
```

## Why it is worse than it looks

**The failure is silent in the worst possible way: it is indistinguishable from a run that genuinely never produced a package.** So the walk-back to an older run — which is correct, useful behaviour — looks like it is working, and quietly hands back a stale build.

In the case that surfaced this, the tool reported `no usable msix-packages artifact` for **four consecutive good runs** and resolved to a build from *before* the change under test. Nothing in the output suggested the query was at fault. The person testing then draws conclusions from a binary that does not contain their fix.

**This is a threshold bug, not a regression.** The tool worked fine until a repo's per-run artifact count crossed 30. Any workflow that adds per-shard artifacts — logs, diagnostics, per-job uploads — will trip it, and the symptom will look like the builds are broken rather than the query.

## The fix

Add `--paginate` to that one call, with a comment explaining why it is load-bearing so it does not get "cleaned up" later.

Also widens the diagnostic to report how many artifacts were actually examined:

```
before:  Run 30657330944 has no usable msix-packages artifact, trying older run...
after:   Run 30657330944 has no msix-packages artifact among its 30, trying older run...
```

`among its 30` makes a truncated page obvious at a glance. The previous wording reads as a fact about the run rather than a fact about what the query could see — which is why nobody suspected the query.

## Verification

Both directions, against a real run, driving the actual `Get-MsixArtifact` function rather than a copy of it:

```
with the fix        -> FOUND: msix-packages bytes=61019727 on run 30657330944
--paginate removed  -> NOT FOUND, "has no msix-packages artifact among its 30"
```

The negative control reproduces the original bug exactly, so the fix is doing the work rather than something else having changed.

## Scope

The other `gh api` calls in this script pass an explicit `per_page` and are "most recent N" queries, where truncation is the intent. This was the only "find this named item" query relying on the default page size, so it is the only one that can fail this way.