### PR TITLE
Invoke the CLI directly instead of building command strings in package-msix.ps1

### DIFF
--- a/scripts/package-msix.ps1
+++ b/scripts/package-msix.ps1
@@ -167,9 +167,8 @@ try
     
     # [Temporary], Ensure build tools are available in CI
     Write-Host "[CLI] Ensure build tools are available" -ForegroundColor Cyan
-    $UpdateCmd = "& `"$CliExe`" update"
-    Write-Host "  Command: $UpdateCmd" -ForegroundColor DarkGray
-    Invoke-Expression $UpdateCmd
+    Write-Host "  Command: & `"$CliExe`" update" -ForegroundColor DarkGray
+    & $CliExe update
     
     if ($LASTEXITCODE -ne 0) {
         Write-Error "Failed to download build tools"
@@ -324,16 +323,15 @@ try
     New-Item -ItemType Directory -Path $DistributionPath -Force | Out-Null
     
     # Check for dev certificate and generate if needed
-    $CertParam = ""
+    $CertArgs = @()
     
     if (-not (Test-Path $DevCertPath) -and $Stable -eq $false) {
         Write-Host "[CERT] Dev certificate not found, generating new certificate..." -ForegroundColor Yellow
         Write-Host "  Certificate will be generated from manifest: $TargetManifestPath" -ForegroundColor Gray
         
         # Generate certificate using the CLI
-        $CertGenerateCmd = "& `"$CliExe`" cert generate --manifest `"$TargetManifestPath`""
-        Write-Host "  Command: $CertGenerateCmd" -ForegroundColor DarkGray
-        Invoke-Expression $CertGenerateCmd
+        Write-Host "  Command: & `"$CliExe`" cert generate --manifest `"$TargetManifestPath`"" -ForegroundColor DarkGray
+        & $CliExe cert generate --manifest $TargetManifestPath
         
         if ($LASTEXITCODE -ne 0) {
             Write-Error "Failed to generate certificate"
@@ -351,7 +349,7 @@ try
     
     if ($Stable -eq $false) {
         if (Test-Path $DevCertPath) {
-            $CertParam = "--cert `"$DevCertPath`""
+            $CertArgs = @('--cert', $DevCertPath)
             Write-Host "[INFO] Using dev certificate: $DevCertPath" -ForegroundColor Gray
         } else {
             Write-Warning "Dev certificate not found at $DevCertPath. Packages will not be signed."
@@ -374,9 +372,10 @@ try
     
     # Package x64 directly to final location
     Write-Host "[PACKAGE] Creating x64 MSIX package..." -ForegroundColor Blue
-    $X64PackageCmd = "& `"$CliExe`" package `"$X64LayoutPath`" --name `"$($X64PackageName -replace '\.msix$', '')`" --output `"$(Join-Path $DistributionPath $X64PackageName)`" $CertParam"
-    Write-Host "  Command: $X64PackageCmd" -ForegroundColor Gray
-    Invoke-Expression $X64PackageCmd
+    $X64OutputPath = Join-Path $DistributionPath $X64PackageName
+    $X64PackageArgs = @('package', $X64LayoutPath, '--name', ($X64PackageName -replace '\.msix$', ''), '--output', $X64OutputPath) + $CertArgs
+    Write-Host "  Command: & `"$CliExe`" $($X64PackageArgs -join ' ')" -ForegroundColor Gray
+    & $CliExe @X64PackageArgs
     if ($LASTEXITCODE -ne 0) {
         Write-Error "Failed to create x64 MSIX package"
         exit 1
@@ -386,9 +385,10 @@ try
     
     # Package arm64 directly to final location
     Write-Host "[PACKAGE] Creating arm64 MSIX package..." -ForegroundColor Blue
-    $Arm64PackageCmd = "& `"$CliExe`" package `"$Arm64LayoutPath`" --name `"$($Arm64PackageName -replace '\.msix$', '')`" --output `"$(Join-Path $DistributionPath $Arm64PackageName)`" $CertParam"
-    Write-Host "  Command: $Arm64PackageCmd" -ForegroundColor Gray
-    Invoke-Expression $Arm64PackageCmd
+    $Arm64OutputPath = Join-Path $DistributionPath $Arm64PackageName
+    $Arm64PackageArgs = @('package', $Arm64LayoutPath, '--name', ($Arm64PackageName -replace '\.msix$', ''), '--output', $Arm64OutputPath) + $CertArgs
+    Write-Host "  Command: & `"$CliExe`" $($Arm64PackageArgs -join ' ')" -ForegroundColor Gray
+    & $CliExe @Arm64PackageArgs
     if ($LASTEXITCODE -ne 0) {
         Write-Error "Failed to create arm64 MSIX package"
         exit 1


### PR DESCRIPTION
## What

The four CLI invocations in `scripts/package-msix.ps1` built a command string by interpolation and then executed it through `Invoke-Expression`:

```powershell
$X64PackageCmd = "& `"$CliExe`" package `"$X64LayoutPath`" --name `"...`" ... $CertParam"
Invoke-Expression $X64PackageCmd
```

Layout paths, package names, and the certificate path all flowed into that string. Any character with meaning to the PowerShell parser — a quote, semicolon, or ampersand in a path — would be re-interpreted as syntax instead of being passed through as data.

## How

Use the call operator with an argument array and splat it:

```powershell
$X64PackageArgs = @('package', $X64LayoutPath, '--name', $name, '--output', $X64OutputPath) + $CertArgs
& $CliExe @X64PackageArgs
```

`$CertParam` (previously the pre-quoted string `--cert "path"`) becomes `$CertArgs`, a proper array, so the certificate path arrives as a discrete argument rather than a fragment of a larger string that gets re-parsed.

The `Write-Host` command echoes are kept so build logs still show what ran, but they are now display-only and never executed.

## Validation

`.\scripts\build-cli.ps1 -SkipTests -SkipNpm` runs clean end to end through the full MSIX path — build-tools update, both architecture layouts, and both packages created and signed:

```
winappcli_0.5.1.30_x64.msix (16.87 MB)   Package has been signed
winappcli_0.5.1.30_arm64.msix (15.88 MB) Package has been signed
```

No behavior change is intended; this is purely how the arguments reach the CLI.
