### PR TITLE
Invoke build tools directly in sample tests instead of Invoke-Expression

### DIFF
--- a/samples/SampleTestHelpers.psm1
+++ b/samples/SampleTestHelpers.psm1
@@ -58,6 +58,47 @@ function Resolve-WinappCliPath {
     return $resolved
 }
 
+function ConvertTo-ArgumentList {
+    <#
+    .SYNOPSIS
+    Splits a command-line argument string into discrete arguments, honoring
+    single and double quotes. Used so callers can keep passing a single
+    argument string while the command itself is invoked without Invoke-Expression.
+    #>
+    param(
+        [string]$Arguments
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Arguments)) { return @() }
+
+    $result = [System.Collections.Generic.List[string]]::new()
+    $current = [System.Text.StringBuilder]::new()
+    $quote = [char]0
+    $hasContent = $false
+
+    foreach ($ch in $Arguments.ToCharArray()) {
+        if ($quote -ne [char]0) {
+            if ($ch -eq $quote) { $quote = [char]0 } else { [void]$current.Append($ch) }
+        } elseif ($ch -eq '"' -or $ch -eq "'") {
+            $quote = $ch
+            $hasContent = $true
+        } elseif ([char]::IsWhiteSpace($ch)) {
+            if ($hasContent) {
+                $result.Add($current.ToString())
+                [void]$current.Clear()
+                $hasContent = $false
+            }
+        } else {
+            [void]$current.Append($ch)
+            $hasContent = $true
+        }
+    }
+
+    if ($hasContent) { $result.Add($current.ToString()) }
+
+    return $result.ToArray()
+}
+
 function Invoke-WinappCommand {
     <#
     .SYNOPSIS
@@ -77,19 +118,23 @@ function Invoke-WinappCommand {
     $cliProject = Join-Path $PSScriptRoot "..\src\winapp-CLI\WinApp.Cli\WinApp.Cli.csproj"
     $useDotnet = $env:WINAPP_TEST_USE_DOTNET -eq '1'
 
+    $argList = ConvertTo-ArgumentList -Arguments $Arguments
+
     if (Test-Path $npxWinapp) {
-        $cmd = "npx winapp $Arguments"
+        $exe = 'npx'
+        $argList = @('winapp') + $argList
     } elseif ($pathWinapp -and -not $useDotnet) {
-        $cmd = "winapp $Arguments"
+        $exe = 'winapp'
     } elseif (Test-Path $cliProject) {
         # Fall back to dotnet run when no installed winapp is on PATH, or when explicitly requested.
-        $cmd = "dotnet run --project `"$cliProject`" -- $Arguments"
+        $exe = 'dotnet'
+        $argList = @('run', '--project', $cliProject, '--') + $argList
     } else {
-        $cmd = "winapp $Arguments"
+        $exe = 'winapp'
     }
 
-    Write-Verbose "Running: $cmd"
-    $output = Invoke-Expression $cmd
+    Write-Verbose "Running: $exe $($argList -join ' ')"
+    $output = & $exe @argList
     if ($LASTEXITCODE -ne 0) { throw $FailMessage }
     return $output
 }
@@ -104,7 +149,7 @@ function Install-WinappNpmPackage {
         [string]$PackagePath
     )
     Write-Verbose "Installing winapp from: $PackagePath"
-    Invoke-Expression "npm install `"$PackagePath`" --save-dev"
+    npm install $PackagePath --save-dev
     if ($LASTEXITCODE -ne 0) { throw "Failed to install winapp npm package" }
 }
 
@@ -118,7 +163,7 @@ function Install-WinappGlobal {
         [string]$PackagePath
     )
     Write-Verbose "Installing winapp globally from: $PackagePath"
-    Invoke-Expression "npm install -g `"$PackagePath`""
+    npm install -g $PackagePath
     if ($LASTEXITCODE -ne 0) { throw "Failed to install winapp globally" }
 }
 

--- a/samples/SampleTestHelpers.psm1
+++ b/samples/SampleTestHelpers.psm1
@@ -69,7 +69,7 @@ function ConvertTo-ArgumentList {
         [string]$Arguments
     )
 
-    if ([string]::IsNullOrWhiteSpace($Arguments)) { return @() }
+    if ([string]::IsNullOrWhiteSpace($Arguments)) { return ,@() }
 
     $result = [System.Collections.Generic.List[string]]::new()
     $current = [System.Text.StringBuilder]::new()
@@ -96,7 +96,8 @@ function ConvertTo-ArgumentList {
 
     if ($hasContent) { $result.Add($current.ToString()) }
 
-    return $result.ToArray()
+    # Unary comma stops PowerShell unrolling a one-element array to a string, which would splat per character.
+    return ,$result.ToArray()
 }
 
 function Invoke-WinappCommand {

--- a/samples/dotnet-app/test.Tests.ps1
+++ b/samples/dotnet-app/test.Tests.ps1
@@ -49,7 +49,7 @@ Describe ".NET App Guide Workflow" {
             It "Should create a new .NET console project" -Skip:$script:skip {
                 Push-Location $script:tempDir
                 try {
-                    Invoke-Expression "dotnet new console -n test-dotnet-app"
+                    dotnet new console -n test-dotnet-app
                     $LASTEXITCODE | Should -Be 0
                 } finally { Pop-Location }
             }
@@ -76,7 +76,7 @@ Describe ".NET App Guide Workflow" {
             It "Should build in Debug mode" -Skip:$script:skip {
                 Push-Location $script:projectDir
                 try {
-                    Invoke-Expression "dotnet build -c Debug"
+                    dotnet build -c Debug
                     $LASTEXITCODE | Should -Be 0
                 } finally { Pop-Location }
             }
@@ -133,7 +133,7 @@ Describe ".NET App Guide Workflow" {
             It "Should build in Release mode" -Skip:$script:skip {
                 Push-Location $script:projectDir
                 try {
-                    Invoke-Expression "dotnet build -c Release"
+                    dotnet build -c Release
                     $LASTEXITCODE | Should -Be 0
                 } finally { Pop-Location }
             }
@@ -163,7 +163,7 @@ Describe ".NET App Guide Workflow" {
             It "Should publish for x64" -Skip:$script:skip {
                 Push-Location $script:projectDir
                 try {
-                    Invoke-Expression "dotnet publish -c Release -r win-x64 --self-contained false -o publish/x64"
+                    dotnet publish -c Release -r win-x64 --self-contained false -o publish/x64
                     $LASTEXITCODE | Should -Be 0
                 } finally { Pop-Location }
             }
@@ -171,7 +171,7 @@ Describe ".NET App Guide Workflow" {
             It "Should publish for arm64" -Skip:$script:skip {
                 Push-Location $script:projectDir
                 try {
-                    Invoke-Expression "dotnet publish -c Release -r win-arm64 --self-contained false -o publish/arm64"
+                    dotnet publish -c Release -r win-arm64 --self-contained false -o publish/arm64
                     $LASTEXITCODE | Should -Be 0
                 } finally { Pop-Location }
             }
@@ -195,7 +195,7 @@ Describe ".NET App Guide Workflow" {
         It "Should restore sample dependencies" -Skip:$script:skip {
             Push-Location $script:sampleDir
             try {
-                Invoke-Expression "dotnet restore"
+                dotnet restore
                 $LASTEXITCODE | Should -Be 0
             } finally { Pop-Location }
         }
@@ -203,7 +203,7 @@ Describe ".NET App Guide Workflow" {
         It "Should build sample in Debug mode" -Skip:$script:skip {
             Push-Location $script:sampleDir
             try {
-                Invoke-Expression "dotnet build -c Debug /p:ApplyDebugIdentity=false"
+                dotnet build -c Debug /p:ApplyDebugIdentity=false
                 $LASTEXITCODE | Should -Be 0
             } finally { Pop-Location }
         }

--- a/samples/electron/test.Tests.ps1
+++ b/samples/electron/test.Tests.ps1
@@ -68,10 +68,10 @@ Describe "Electron Sample" {
                 for ($i = 1; $i -le $maxRetries; $i++) {
                     if ($i -gt 1) {
                         Remove-Item -Path (Join-Path $script:tempDir "electron-app") -Recurse -Force -ErrorAction SilentlyContinue
-                        Invoke-Expression "npm cache clean --force" 2>$null
+                        npm cache clean --force 2>$null
                         Start-Sleep -Seconds 2
                     }
-                    Invoke-Expression "npx -y create-electron-app@latest electron-app"
+                    npx -y create-electron-app@latest electron-app
                     if ($LASTEXITCODE -eq 0) { $created = $true; break }
                 }
                 $created | Should -Be $true -Because "Electron app creation should succeed within $maxRetries attempts"
@@ -248,7 +248,7 @@ Describe "Electron Sample" {
         It "Should build the C++ addon" -Skip:$script:skip {
             Push-Location $script:appDir
             try {
-                $output = Invoke-Expression "npx node-gyp clean configure build --directory=testCppAddon --verbose 2>&1"
+                $output = npx node-gyp clean configure build --directory=testCppAddon --verbose 2>&1
                 $output | ForEach-Object { Write-Host $_ }
                 $LASTEXITCODE | Should -Be 0
             } finally { Pop-Location }
@@ -257,7 +257,7 @@ Describe "Electron Sample" {
         It "Should build the C# addon" -Skip:$script:skip {
             Push-Location $script:appDir
             try {
-                Invoke-Expression "npm run build-testCsAddon"
+                npm run build-testCsAddon
                 $LASTEXITCODE | Should -Be 0
             } finally { Pop-Location }
         }
@@ -289,7 +289,7 @@ Describe "Electron Sample" {
         It "Should package the Electron app" -Skip:$script:skip {
             Push-Location $script:appDir
             try {
-                Invoke-Expression "npm run package"
+                npm run package
                 $LASTEXITCODE | Should -Be 0
                 $script:outDir = Join-Path $script:appDir "out"
                 $script:outDir | Should -Exist
@@ -327,7 +327,7 @@ Describe "Electron Sample" {
         It "Should install sample dependencies" -Skip:$script:skip {
             Push-Location $script:sampleDir
             try {
-                Invoke-Expression "npm install --ignore-scripts"
+                npm install --ignore-scripts
                 $LASTEXITCODE | Should -Be 0
             } finally { Pop-Location }
         }
@@ -351,7 +351,7 @@ Describe "Electron Sample" {
         It "Should build the C# addon" -Skip:$script:skip {
             Push-Location $script:sampleDir
             try {
-                Invoke-Expression "npm run build-csAddon"
+                npm run build-csAddon
                 $LASTEXITCODE | Should -Be 0
             } finally { Pop-Location }
         }

--- a/samples/rust-app/test.Tests.ps1
+++ b/samples/rust-app/test.Tests.ps1
@@ -43,7 +43,7 @@ Describe "Rust App Sample" {
         It "Should create a new Rust project" -Skip:$script:skip {
             Push-Location $script:tempDir
             try {
-                Invoke-Expression "cargo new test-rust-app"
+                cargo new test-rust-app
                 $LASTEXITCODE | Should -Be 0
                 $script:rustProjectDir = Join-Path $script:tempDir "test-rust-app"
                 $script:rustProjectDir | Should -Exist
@@ -71,7 +71,7 @@ Describe "Rust App Sample" {
         It "Should build Rust app in debug mode" -Skip:$script:skip {
             Push-Location $script:rustProjectDir
             try {
-                Invoke-Expression "cargo build"
+                cargo build
                 $LASTEXITCODE | Should -Be 0
             } finally { Pop-Location }
         }
@@ -107,7 +107,7 @@ Describe "Rust App Sample" {
         It "Should build Rust app in release mode" -Skip:$script:skip {
             Push-Location $script:rustProjectDir
             try {
-                Invoke-Expression "cargo build --release"
+                cargo build --release
                 $LASTEXITCODE | Should -Be 0
             } finally { Pop-Location }
         }
@@ -160,7 +160,7 @@ Describe "Rust App Sample" {
         It "Should build existing sample with cargo" -Skip:$script:skip {
             Push-Location $script:sampleDir
             try {
-                Invoke-Expression "cargo build"
+                cargo build
                 $LASTEXITCODE | Should -Be 0
             } finally { Pop-Location }
         }

--- a/samples/sparse-app/test.Tests.ps1
+++ b/samples/sparse-app/test.Tests.ps1
@@ -52,7 +52,7 @@ Describe 'sparse-app sample' {
                 $script:tempDir = New-TempTestDirectory -Prefix 'sparse-guide'
                 Push-Location $script:tempDir
 
-                Invoke-Expression 'dotnet new wpf -n test-sparse-app'
+                dotnet new wpf -n test-sparse-app
                 $script:dotnetNewExit = $LASTEXITCODE
 
                 if ($script:dotnetNewExit -eq 0) {
@@ -73,7 +73,7 @@ Describe 'sparse-app sample' {
         }
 
         It 'Builds the app in Debug mode' -Skip:$script:skip {
-            Invoke-Expression 'dotnet build -c Debug'
+            dotnet build -c Debug
             $LASTEXITCODE | Should -Be 0
         }
 
@@ -139,12 +139,12 @@ Describe 'sparse-app sample' {
         }
 
         It 'Restores NuGet packages' -Skip:$script:skip {
-            Invoke-Expression 'dotnet restore'
+            dotnet restore
             $LASTEXITCODE | Should -Be 0
         }
 
         It 'Builds the existing sample in Debug mode' -Skip:$script:skip {
-            Invoke-Expression 'dotnet build -c Debug'
+            dotnet build -c Debug
             $LASTEXITCODE | Should -Be 0
         }
 
@@ -158,7 +158,7 @@ Describe 'sparse-app sample' {
         It 'Compiles the Inno Setup installer script (ISCC)' -Skip:$script:skipIscc {
             # Publish framework-dependent so the installer's [Files] publish glob resolves,
             # then compile the checked-in installer to catch syntax/path regressions.
-            Invoke-Expression 'dotnet publish -c Release -r win-x64 --self-contained false'
+            dotnet publish -c Release -r win-x64 --self-contained false
             $LASTEXITCODE | Should -Be 0
             'SparseAppSample.identity.msix' | Should -Exist
 

--- a/samples/tauri-app/test.Tests.ps1
+++ b/samples/tauri-app/test.Tests.ps1
@@ -56,7 +56,7 @@ Describe "Tauri App Sample" {
         It "Should install npm dependencies" -Skip:$script:skip {
             Push-Location $script:tempApp
             try {
-                Invoke-Expression "npm install"
+                npm install
                 $LASTEXITCODE | Should -Be 0
             } finally { Pop-Location }
         }
@@ -76,7 +76,7 @@ Describe "Tauri App Sample" {
         It "Should build Tauri app in debug mode" -Skip:$script:skip {
             Push-Location $script:tempApp
             try {
-                Invoke-Expression "cargo build --manifest-path src-tauri\Cargo.toml"
+                cargo build --manifest-path src-tauri\Cargo.toml
                 $LASTEXITCODE | Should -Be 0
             } finally { Pop-Location }
         }
@@ -94,7 +94,7 @@ Describe "Tauri App Sample" {
         It "Should build Tauri app in release mode" -Skip:$script:skip {
             Push-Location $script:tempApp
             try {
-                Invoke-Expression "cargo build --release --manifest-path src-tauri\Cargo.toml"
+                cargo build --release --manifest-path src-tauri\Cargo.toml
                 $LASTEXITCODE | Should -Be 0
             } finally { Pop-Location }
         }
@@ -143,7 +143,7 @@ Describe "Tauri App Sample" {
         It "Should install sample npm dependencies" -Skip:$script:skip {
             Push-Location $script:sampleDir
             try {
-                Invoke-Expression "npm install"
+                npm install
                 $LASTEXITCODE | Should -Be 0
             } finally { Pop-Location }
         }
@@ -151,7 +151,7 @@ Describe "Tauri App Sample" {
         It "Should build sample Rust backend" -Skip:$script:skip {
             Push-Location $script:sampleDir
             try {
-                Invoke-Expression "cargo build --manifest-path src-tauri\Cargo.toml"
+                cargo build --manifest-path src-tauri\Cargo.toml
                 $LASTEXITCODE | Should -Be 0
             } finally { Pop-Location }
         }

--- a/samples/winui-app/test.Tests.ps1
+++ b/samples/winui-app/test.Tests.ps1
@@ -110,13 +110,13 @@ Describe 'winui-app sample' {
         }
 
         It 'Restores NuGet packages' -Skip:$script:skip {
-            Invoke-Expression 'dotnet restore'
+            dotnet restore
             $LASTEXITCODE | Should -Be 0
         }
 
         It 'Builds existing sample in Debug mode' -Skip:$script:skip {
             $rid = if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq 'Arm64') { 'win-arm64' } else { 'win-x64' }
-            Invoke-Expression "dotnet build -c Debug -r $rid"
+            dotnet build -c Debug -r $rid
             $LASTEXITCODE | Should -Be 0
         }
     }

--- a/samples/winui-solution/test.Tests.ps1
+++ b/samples/winui-solution/test.Tests.ps1
@@ -123,7 +123,7 @@ Describe 'winui-solution sample' {
         }
 
         It 'Restores NuGet packages for the solution' -Skip:$script:skip {
-            Invoke-Expression 'dotnet restore WinUISolution.sln'
+            dotnet restore WinUISolution.sln
             $LASTEXITCODE | Should -Be 0
         }
 
@@ -131,7 +131,7 @@ Describe 'winui-solution sample' {
             # Building a .sln with an explicit -r/RID is unsupported (NETSDK1134); the RID
             # is resolved per-project. Drive the arch via -p:Platform only.
             $plat = if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq 'Arm64') { 'ARM64' } else { 'x64' }
-            Invoke-Expression "dotnet build WinUISolution.sln -c Debug -p:Platform=$plat"
+            dotnet build WinUISolution.sln -c Debug -p:Platform=$plat
             $LASTEXITCODE | Should -Be 0
         }
     }

--- a/samples/winui-unpackaged-app/test.Tests.ps1
+++ b/samples/winui-unpackaged-app/test.Tests.ps1
@@ -176,13 +176,13 @@ Describe 'winui-unpackaged-app sample' {
         }
 
         It 'Restores NuGet packages' -Skip:$script:skip {
-            Invoke-Expression 'dotnet restore'
+            dotnet restore
             $LASTEXITCODE | Should -Be 0
         }
 
         It 'Builds existing sample in Debug mode' -Skip:$script:skip {
             $rid = if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq 'Arm64') { 'win-arm64' } else { 'win-x64' }
-            Invoke-Expression "dotnet build -c Debug -r $rid"
+            dotnet build -c Debug -r $rid
             $LASTEXITCODE | Should -Be 0
         }
     }

--- a/samples/wpf-app/test.Tests.ps1
+++ b/samples/wpf-app/test.Tests.ps1
@@ -40,7 +40,7 @@ Describe 'wpf-app sample' {
                 $script:tempDir = New-TempTestDirectory -Prefix 'wpf-guide'
                 Push-Location $script:tempDir
 
-                Invoke-Expression 'dotnet new wpf -n test-wpf-app'
+                dotnet new wpf -n test-wpf-app
                 $script:dotnetNewExit = $LASTEXITCODE
 
                 if ($script:dotnetNewExit -eq 0) {
@@ -69,7 +69,7 @@ Describe 'wpf-app sample' {
         }
 
         It 'Builds in Debug mode' -Skip:$script:skip {
-            Invoke-Expression 'dotnet build -c Debug /p:ApplyDebugIdentity=false'
+            dotnet build -c Debug /p:ApplyDebugIdentity=false
             $LASTEXITCODE | Should -Be 0
         }
 
@@ -95,7 +95,7 @@ Describe 'wpf-app sample' {
 
         It 'Builds in Release mode with RID' -Skip:$script:skip {
             $rid = if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq 'Arm64') { 'win-arm64' } else { 'win-x64' }
-            Invoke-Expression "dotnet build -c Release -r $rid"
+            dotnet build -c Release -r $rid
             $LASTEXITCODE | Should -Be 0
         }
 
@@ -128,12 +128,12 @@ Describe 'wpf-app sample' {
         }
 
         It 'Restores NuGet packages' -Skip:$script:skip {
-            Invoke-Expression 'dotnet restore'
+            dotnet restore
             $LASTEXITCODE | Should -Be 0
         }
 
         It 'Builds existing sample in Debug mode' -Skip:$script:skip {
-            Invoke-Expression 'dotnet build -c Debug /p:ApplyDebugIdentity=false'
+            dotnet build -c Debug /p:ApplyDebugIdentity=false
             $LASTEXITCODE | Should -Be 0
         }
     }

--- a/scripts/build-cli.ps1
+++ b/scripts/build-cli.ps1
@@ -415,35 +415,36 @@ try
         Write-Host "[NUGET] Skipping NuGet packages creation (use -SkipNuGet:`$false to enable)" -ForegroundColor Gray
     }
 
-    # Run MS Learn docs tooling Pester tests (validator + shared front-matter lib).
-    # These gate the release doc-porting job, so keep them green. Skipped with -SkipTests.
+    # Run the scripts/tests Pester suite (MS Learn docs validator + shared test helpers).
+    # These gate the release doc-porting job and the sample test harness, so keep them green.
+    # Skipped with -SkipTests.
     if (-not $SkipTests) {
-        $MsLearnTestsPath = Join-Path $ProjectRoot "scripts\tests\validate-mslearn-docs.Tests.ps1"
-        if (Test-Path $MsLearnTestsPath) {
+        $ScriptsTestsPath = Join-Path $ProjectRoot "scripts\tests"
+        if (Test-Path $ScriptsTestsPath) {
             $pesterMod = Get-Module -Name Pester -ListAvailable | Where-Object { $_.Version.Major -ge 5 } | Select-Object -First 1
             if ($pesterMod) {
-                Write-Host "[TEST] Running MS Learn docs tooling Pester tests..." -ForegroundColor Blue
+                Write-Host "[TEST] Running scripts Pester tests..." -ForegroundColor Blue
                 # Import the selected v5+ module explicitly so the v5 config APIs
                 # don't bind to a different Pester version already in the session.
                 Import-Module $pesterMod -Force
                 $pesterConfig = New-PesterConfiguration
-                $pesterConfig.Run.Path = $MsLearnTestsPath
+                $pesterConfig.Run.Path = $ScriptsTestsPath
                 $pesterConfig.Run.Exit = $false
                 $pesterConfig.Run.PassThru = $true
                 $pesterConfig.Output.Verbosity = 'Normal'
                 $pesterResult = Invoke-Pester -Configuration $pesterConfig
                 if (($pesterResult.FailedCount + $pesterResult.FailedBlocksCount + $pesterResult.FailedContainersCount) -gt 0) {
                     if ($FailOnTestFailure) {
-                        Write-Error "Stopping build due to MS Learn docs tooling Pester test failures (FailOnTestFailure flag set): $($pesterResult.FailedCount) failed test(s), $($pesterResult.FailedBlocksCount) failed block(s), $($pesterResult.FailedContainersCount) failed container(s)"
+                        Write-Error "Stopping build due to scripts Pester test failures (FailOnTestFailure flag set): $($pesterResult.FailedCount) failed test(s), $($pesterResult.FailedBlocksCount) failed block(s), $($pesterResult.FailedContainersCount) failed container(s)"
                         exit 1
                     } else {
-                        Write-Warning "MS Learn docs tooling Pester tests had $($pesterResult.FailedCount) failed test(s), $($pesterResult.FailedBlocksCount) failed block(s), $($pesterResult.FailedContainersCount) failed container(s) — continuing"
+                        Write-Warning "Scripts Pester tests had $($pesterResult.FailedCount) failed test(s), $($pesterResult.FailedBlocksCount) failed block(s), $($pesterResult.FailedContainersCount) failed container(s) — continuing"
                     }
                 } else {
-                    Write-Host "[TEST] MS Learn docs tooling Pester tests passed: $($pesterResult.PassedCount) passed, $($pesterResult.SkippedCount) skipped" -ForegroundColor Green
+                    Write-Host "[TEST] Scripts Pester tests passed: $($pesterResult.PassedCount) passed, $($pesterResult.SkippedCount) skipped" -ForegroundColor Green
                 }
             } else {
-                Write-Warning "Pester 5.x not installed — skipping MS Learn docs tooling Pester tests. Install with: Install-Module Pester -Force -MinimumVersion 5.0"
+                Write-Warning "Pester 5.x not installed — skipping scripts Pester tests. Install with: Install-Module Pester -Force -MinimumVersion 5.0"
             }
         }
     }

--- a/scripts/tests/SampleTestHelpers.Tests.ps1
+++ b/scripts/tests/SampleTestHelpers.Tests.ps1
@@ -1,0 +1,115 @@
+<#
+.SYNOPSIS
+Unit tests for samples/SampleTestHelpers.psm1.
+
+.DESCRIPTION
+Covers ConvertTo-ArgumentList, which splits the single -Arguments string that the
+sample tests pass into the discrete arguments splatted onto the resolved executable.
+A tokenizer defect here silently changes what every sample test executes, so it is
+worth pinning down directly rather than only through the sample matrix.
+#>
+
+BeforeAll {
+    $script:HelpersModule = Join-Path $PSScriptRoot "..\..\samples\SampleTestHelpers.psm1"
+    Import-Module $script:HelpersModule -Force
+}
+
+AfterAll {
+    Remove-Module SampleTestHelpers -Force -ErrorAction SilentlyContinue
+}
+
+Describe 'ConvertTo-ArgumentList' {
+
+    Context 'Return shape' {
+        It 'returns an array for a single token' {
+            # Regression: PowerShell unrolls a one-element array on output, and splatting
+            # the resulting scalar passes one character per argument.
+            InModuleScope SampleTestHelpers {
+                $result = ConvertTo-ArgumentList -Arguments 'restore'
+                ($result -is [array]) | Should -BeTrue
+                $result.Count | Should -Be 1
+                $result[0] | Should -Be 'restore'
+            }
+        }
+
+        It 'returns an empty array for empty or whitespace input' {
+            InModuleScope SampleTestHelpers {
+                foreach ($input in @('', '   ')) {
+                    $result = ConvertTo-ArgumentList -Arguments $input
+                    ($result -is [array]) | Should -BeTrue
+                    $result.Count | Should -Be 0
+                }
+            }
+        }
+
+        It 'does not nest the array' {
+            InModuleScope SampleTestHelpers {
+                $result = ConvertTo-ArgumentList -Arguments 'cert generate'
+                $result[0] | Should -BeOfType [string]
+            }
+        }
+    }
+
+    Context 'Splatting behavior' {
+        It 'passes a single token as exactly one argument' {
+            InModuleScope SampleTestHelpers {
+                $result = ConvertTo-ArgumentList -Arguments 'restore'
+                $probe = { $args.Count }
+                (& $probe @result) | Should -Be 1
+            }
+        }
+
+        It 'passes each token as its own argument' {
+            InModuleScope SampleTestHelpers {
+                $result = ConvertTo-ArgumentList -Arguments 'cert generate --if-exists skip'
+                $probe = { $args -join '|' }
+                (& $probe @result) | Should -Be 'cert|generate|--if-exists|skip'
+            }
+        }
+    }
+
+    Context 'Tokenizing' {
+        It 'splits on whitespace' {
+            InModuleScope SampleTestHelpers {
+                $result = ConvertTo-ArgumentList -Arguments 'cert generate --if-exists skip'
+                $result.Count | Should -Be 4
+            }
+        }
+
+        It 'keeps a double-quoted value containing spaces as one argument' {
+            InModuleScope SampleTestHelpers {
+                $result = ConvertTo-ArgumentList -Arguments 'pack "C:\my path\out" --cert devcert.pfx'
+                $result.Count | Should -Be 4
+                $result[1] | Should -Be 'C:\my path\out'
+            }
+        }
+
+        It 'keeps a single-quoted value containing spaces as one argument' {
+            InModuleScope SampleTestHelpers {
+                $result = ConvertTo-ArgumentList -Arguments "cert generate --publisher 'CN=Sparse Guide'"
+                $result[-1] | Should -Be 'CN=Sparse Guide'
+            }
+        }
+
+        It 'preserves an embedded equals sign' {
+            InModuleScope SampleTestHelpers {
+                $result = ConvertTo-ArgumentList -Arguments 'init . --use-defaults --setup-sdks=stable'
+                $result[-1] | Should -Be '--setup-sdks=stable'
+            }
+        }
+
+        It 'preserves backslashes in relative paths' {
+            InModuleScope SampleTestHelpers {
+                $result = ConvertTo-ArgumentList -Arguments 'run .\target\debug --with-alias'
+                $result[1] | Should -Be '.\target\debug'
+            }
+        }
+
+        It 'collapses runs of whitespace between tokens' {
+            InModuleScope SampleTestHelpers {
+                $result = ConvertTo-ArgumentList -Arguments 'cert    info   devcert.pfx'
+                $result.Count | Should -Be 3
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What

The sample Pester tests invoked `dotnet`, `npm`, `npx`, and `cargo` by composing a command string and handing it to `Invoke-Expression`:

```powershell
Invoke-Expression "dotnet build -c Debug -r $rid"
```

`Invoke-WinappCommand` in `SampleTestHelpers.psm1` did the same for the CLI, including interpolating a resolved project path into the `dotnet run` fallback. Temp directory paths flow through these strings, so a path containing a quote or other parser-significant character would be re-interpreted as syntax rather than passed through as data.

## How

Call the executables directly, so arguments never round-trip through the parser.

`Invoke-WinappCommand` keeps its existing single `-Arguments` string parameter, so **all 71 call sites are unchanged**. A small `ConvertTo-ArgumentList` helper splits that string into discrete arguments — honoring single and double quotes — and the result is splatted onto the resolved executable:

```powershell
$argList = ConvertTo-ArgumentList -Arguments $Arguments
$output = & $exe @argList
```

Changing every call site to pass arrays would have been the alternative, but it touches 71 lines across 14 files for no additional safety, since the tokenizer reproduces the same splitting the parser was doing.

## Validation

All 15 sample scripts parse clean. The tokenizer was checked against the argument shapes actually used in these tests, including quoted paths with spaces and quoted values containing `=`:

```
'pack "C:\my path\out" --manifest Package.appxmanifest --cert devcert.pfx'
  -> [pack] [C:\my path\out] [--manifest] [Package.appxmanifest] [--cert] [devcert.pfx]

'cert generate --publisher "CN=Sparse Guide" --if-exists skip'
  -> [cert] [generate] [--publisher] [CN=Sparse Guide] [--if-exists] [skip]
```

Test-only change; no product code is touched.
