### PR TITLE
Use -EncodedCommand for the elevated Developer Mode script

### DIFF
--- a/src/winapp-CLI/WinApp.Cli.Tests/DevModeServiceTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/DevModeServiceTests.cs
@@ -3,6 +3,8 @@
 
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Text;
+using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Spectre.Console.Testing;
 using WinApp.Cli.ConsoleTasks;
@@ -90,7 +92,12 @@ public class DevModeServiceTests
         var psi = captured[0];
         StringAssert.EndsWith(psi.FileName, "powershell.exe");
         Assert.AreEqual("runas", psi.Verb);
-        StringAssert.Contains(psi.Arguments, "AppModelUnlock");
+
+        // The script is passed as base64 UTF-16LE via -EncodedCommand, so assert on the decoded form.
+        var match = Regex.Match(psi.Arguments, @"-EncodedCommand\s+(?<b64>[A-Za-z0-9+/=]+)");
+        Assert.IsTrue(match.Success, $"Expected an -EncodedCommand payload. Got: {psi.Arguments}");
+        var script = Encoding.Unicode.GetString(Convert.FromBase64String(match.Groups["b64"].Value));
+        StringAssert.Contains(script, "AppModelUnlock");
     }
 
     [TestMethod]

--- a/src/winapp-CLI/WinApp.Cli/Services/DevModeService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/DevModeService.cs
@@ -4,6 +4,7 @@
 using Microsoft.Win32;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Text;
 using WinApp.Cli.ConsoleTasks;
 
 namespace WinApp.Cli.Services;
@@ -33,8 +34,9 @@ Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModel
 
         try
         {
-            var exit = RunElevated(ps,
-                $"-NoProfile -ExecutionPolicy Bypass -Command \"& {{ {EscapeForPSArg(psScript)} }}\"");
+            // -EncodedCommand takes base64 UTF-16LE, so the script never passes through command-line quoting.
+            string encoded = Convert.ToBase64String(Encoding.Unicode.GetBytes(psScript));
+            var exit = RunElevated(ps, $"-NoProfile -ExecutionPolicy Bypass -EncodedCommand {encoded}");
             if (exit == 0 || exit == 3010)
             {
                 taskContext.AddDebugMessage("Developer Mode enabled (via PowerShell).");
@@ -108,11 +110,5 @@ Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModel
         p.Start();
         p.WaitForExit();
         return p.ExitCode;
-    }
-
-    private static string EscapeForPSArg(string s)
-    {
-        // Minimal escaping for embedding a script inside -Command "..."
-        return s.Replace("\"", "`\"");
     }
 }


### PR DESCRIPTION
## What

`DevModeService.EnsureWin11DevModeAsync` embedded its registry script inside a `-Command "& { ... }"` argument:

```csharp
var exit = RunElevated(ps,
    $"-NoProfile -ExecutionPolicy Bypass -Command \"& {{ {EscapeForPSArg(psScript)} }}\"");
```

`EscapeForPSArg` only escaped double quotes, which is the fragile half of a quoting problem rather than a fix for it. The script itself is hardcoded, so there is no injection path today — but the shape invites one the moment anything dynamic is added, and the escaping helper looks more complete than it is.

## How

Switch to `-EncodedCommand`, which takes base64 UTF-16LE:

```csharp
string encoded = Convert.ToBase64String(Encoding.Unicode.GetBytes(psScript));
var exit = RunElevated(ps, $"-NoProfile -ExecutionPolicy Bypass -EncodedCommand {encoded}");
```

Base64 output contains no characters with meaning to the shell, so the quoting problem disappears rather than being escaped around, and `EscapeForPSArg` is deleted.

This is already the established pattern elsewhere in the repo — `scripts/winapp-pr.ps1` and the debug-output tests both use `-EncodedCommand` for the same reason.

The `cmd.exe` + `reg.exe` fallback is untouched.

## Validation

`DevModeServiceTests` passes. One test asserted on the raw argument string containing `AppModelUnlock`, which base64 naturally breaks; it now decodes the payload and asserts on the script text:

```csharp
var match = Regex.Match(psi.Arguments, @"-EncodedCommand\s+(?<b64>[A-Za-z0-9+/=]+)");
var script = Encoding.Unicode.GetString(Convert.FromBase64String(match.Groups["b64"].Value));
StringAssert.Contains(script, "AppModelUnlock");
```

That is a stronger assertion than the substring match it replaces — it verifies the script that will actually execute, not just the command line.
