### PR TITLE
Cover NuGet and npm in Dependabot, and use the CodeQL security-extended suite

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -2,5 +2,6 @@ queries:
   - uses: security-extended
 paths:
   - src
+  - .github
 paths-ignore:
   - '**/*Tests/*.cs'

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,3 +1,5 @@
+queries:
+  - uses: security-extended
 paths:
   - src
 paths-ignore:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,23 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+
+  - package-ecosystem: "nuget"
+    directory: "/src/winapp-CLI"
+    groups:
+      nuget:
+        patterns: ["*"]
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "npm"
+    directory: "/src/winapp-npm"
+    groups:
+      npm:
+        patterns: ["*"]
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,9 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/*"
     groups:
       github-actions:
         patterns: ["*"]


### PR DESCRIPTION
## Dependabot

`dependabot.yml` configured version updates for `github-actions` only. The shipped NuGet and npm dependencies were never getting update PRs.

Worth noting why that was easy to miss: npm bumps *have* been landing (#708, #722). Those came from Dependabot **security** updates, which run without a config entry — but only once an advisory exists for a package you already depend on. **Version** updates, which keep dependencies current before an advisory lands, need the config entry that was missing.

This adds two entries, matching the grouping and cooldown of the existing one:

- `nuget` at `/src/winapp-CLI` — picks up `Directory.Packages.props`
- `npm` at `/src/winapp-npm` — the shipped npm package

## CodeQL

`codeql.yml` analyzes `csharp`, `javascript-typescript`, `c-cpp`, and `actions`, but the config requested no query suite, so all four ran the default set. This adds `security-extended`.

Expect more findings on the first run after this merges — that is the point, but it does mean the initial triage pass will be larger than usual.

## Open question for the reviewer

There are currently 12 open Dependabot alerts on `main`, and every one is in an ecosystem this config does not cover:

```
high     npm    tar
high     npm    tmp
medium   npm    tar
medium   rust   tauri
low      rust   rand
```

Those live in `samples/` (`samples/electron`, `samples/tauri-app`, `samples/rust-app`), not in shipped code. I deliberately left samples out of this PR: adding npm and cargo version updates across every sample directory would generate a steady stream of PRs against demo code, and security updates already cover the vulnerable cases.

If you would rather have the samples tracked too, say the word and I will add `cargo` plus sample directories in a follow-up — it is a config-only change either way.
