### PR TITLE
Map the remaining winapp run options to MSBuild properties

### DIFF
--- a/docs/dotnet-run-support.md
+++ b/docs/dotnet-run-support.md
@@ -87,6 +87,29 @@ samples/
 | `WinAppRunExecutable` | (empty) | Executable path relative to the build-output folder. Use to disambiguate when the manifest contains a `$targetnametoken$` placeholder and the output folder contains more than one `.exe`. |
 | `WinAppRunArgs` | (empty) | Raw arguments appended to the `winapp run` command line, for options that have no dedicated property. See [Escape hatch](#escape-hatch-winapprunargs). |
 
+#### Mutually exclusive settings
+
+`WinAppRunNoLaunch` and `WinAppRunDetach` each describe a different launch behavior — one never
+starts the app, the other starts it and stops tracking it — so neither can be combined with the
+properties that need a tracked, running process, nor with each other:
+
+| Property | Cannot be combined with |
+|----------|-------------------------|
+| `WinAppRunNoLaunch` | `WinAppRunDetach`, `WinAppRunUseExecutionAlias`, `WinAppRunDebugOutput`, `WinAppRunUnregisterOnExit` |
+| `WinAppRunDetach` | `WinAppRunNoLaunch`, `WinAppRunUseExecutionAlias`, `WinAppRunDebugOutput`, `WinAppRunUnregisterOnExit` |
+
+The CLI rejects a conflicting pair before doing any work, so the run fails immediately:
+
+```
+> dotnet run -p:WinAppRunDetach=true -p:WinAppRunUnregisterOnExit=true
+❌ --detach and --unregister-on-exit cannot be used together.
+```
+
+`WinAppRunUseExecutionAlias`, `WinAppRunDebugOutput`, and `WinAppRunUnregisterOnExit` can be combined
+with each other. `WinAppRunClean`, `WinAppRunSymbols`, `WinAppRunExecutable`, and `WinAppLaunchArgs`
+have no restrictions. `WinAppRunSymbols` is not rejected on its own, but only has an effect together
+with `WinAppRunDebugOutput`.
+
 #### Escape hatch: WinAppRunArgs
 
 Every option `winapp run` accepts in folder mode has a dedicated property above. `WinAppRunArgs`

--- a/docs/dotnet-run-support.md
+++ b/docs/dotnet-run-support.md
@@ -108,7 +108,9 @@ The CLI rejects a conflicting pair before doing any work, so the run fails immed
 `WinAppRunUseExecutionAlias`, `WinAppRunDebugOutput`, and `WinAppRunUnregisterOnExit` can be combined
 with each other. `WinAppRunClean`, `WinAppRunSymbols`, `WinAppRunExecutable`, and `WinAppLaunchArgs`
 have no restrictions. `WinAppRunSymbols` is not rejected on its own, but only has an effect together
-with `WinAppRunDebugOutput`.
+with `WinAppRunDebugOutput`. `WinAppRunArgs` adds no restriction of its own, but a switch passed
+through it is checked like any other, so `WinAppRunArgs="--detach"` still conflicts with
+`WinAppRunNoLaunch`.
 
 #### Escape hatch: WinAppRunArgs
 
@@ -125,7 +127,7 @@ occupies in other toolsets:
 
 ```
 run "<output>" --manifest "<manifest>" --detach --caller nuget-package --verbose
-                                       ^ from WinAppRunDetach            ^ from WinAppRunArgs
+                                       ^ from WinAppRunDetach          ^ from WinAppRunArgs
 ```
 
 Use it for options that have no property rather than to override one. Repeating a boolean switch is

--- a/docs/dotnet-run-support.md
+++ b/docs/dotnet-run-support.md
@@ -80,6 +80,38 @@ samples/
 | `WinAppRunUseExecutionAlias` | `false` | Launch via execution alias instead of AUMID. Keeps console I/O in the current terminal. Requires `uap5:ExecutionAlias` in the manifest. Cannot be combined with `WinAppRunNoLaunch`. |
 | `WinAppRunNoLaunch` | `false` | Only register package identity without launching the app. Cannot be combined with `WinAppRunUseExecutionAlias`. |
 | `WinAppRunDebugOutput` | `false` | Attach as a debugger to capture `OutputDebugString` messages and first-chance exceptions. Only one debugger can attach at a time, so Visual Studio or VS Code cannot debug simultaneously. Use `WinAppRunNoLaunch` instead to attach a different debugger. Cannot be combined with `WinAppRunNoLaunch`. |
+| `WinAppRunDetach` | `false` | Return immediately after launching instead of waiting for the app to exit. Prints the PID. |
+| `WinAppRunUnregisterOnExit` | `false` | Unregister the development package after the app exits. Only removes packages registered in development mode. |
+| `WinAppRunClean` | `false` | Remove the existing package's application data (LocalState, settings) before re-deploying. Application data is preserved by default. |
+| `WinAppRunSymbols` | `false` | Download symbols from the Microsoft Symbol Server for richer native crash analysis. Only has an effect together with `WinAppRunDebugOutput`. |
+| `WinAppRunExecutable` | (empty) | Executable path relative to the build-output folder. Use to disambiguate when the manifest contains a `$targetnametoken$` placeholder and the output folder contains more than one `.exe`. |
+| `WinAppRunArgs` | (empty) | Raw arguments appended to the `winapp run` command line, for options that have no dedicated property. See [Escape hatch](#escape-hatch-winapprunargs). |
+
+#### Escape hatch: WinAppRunArgs
+
+Every option `winapp run` accepts in folder mode has a dedicated property above. `WinAppRunArgs`
+exists for the rest — the global options such as `--verbose`, and any option added to the CLI before
+a property is wired up for it:
+
+```powershell
+dotnet run -p:WinAppRunArgs="--verbose"
+```
+
+It is appended **after** every property-derived switch, the same position `AdditionalOptions`
+occupies in other toolsets:
+
+```
+run "<output>" --manifest "<manifest>" --detach --caller nuget-package --verbose
+                                       ^ from WinAppRunDetach            ^ from WinAppRunArgs
+```
+
+Use it for options that have no property rather than to override one. Repeating a boolean switch is
+harmless, but `winapp` rejects a scalar option supplied twice instead of letting the later value win:
+
+```
+> dotnet run -p:WinAppRunExecutable=a.exe -p:WinAppRunArgs="--executable b.exe"
+Option '--executable' expects a single argument but 2 were provided.
+```
 
 ### Targets (Microsoft.Windows.SDK.BuildTools.WinApp.targets)
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -824,7 +824,8 @@ conflicting pair fails the run with `--X and --Y cannot be used together`:
 
 `WinAppRunUseExecutionAlias`, `WinAppRunDebugOutput`, and `WinAppRunUnregisterOnExit` can be combined
 with each other. `WinAppRunClean`, `WinAppRunSymbols`, `WinAppRunExecutable`, and `WinAppLaunchArgs`
-have no restrictions.
+have no restrictions. `WinAppRunArgs` adds no restriction of its own, but a switch passed through it
+is checked like any other, so `WinAppRunArgs="--detach"` still conflicts with `WinAppRunNoLaunch`.
 
 ```xml
 <PropertyGroup>

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -813,6 +813,19 @@ When using the `Microsoft.Windows.SDK.BuildTools.WinApp` NuGet package, `dotnet 
 | `WinAppRunExecutable` | (empty) | Executable path relative to the build-output folder. Use when the manifest contains `$targetnametoken$` and the output folder has more than one `.exe`. |
 | `WinAppRunArgs` | (empty) | Raw arguments appended to the `winapp run` command line, for options with no dedicated property (for example `--verbose`). Appended after every property above. |
 
+**Mutually exclusive settings.** `WinAppRunNoLaunch` and `WinAppRunDetach` each describe a different
+launch behavior, so they conflict with the other launch properties and with each other. Setting a
+conflicting pair fails the run with `--X and --Y cannot be used together`:
+
+| Property | Cannot be combined with |
+|----------|-------------------------|
+| `WinAppRunNoLaunch` | `WinAppRunDetach`, `WinAppRunUseExecutionAlias`, `WinAppRunDebugOutput`, `WinAppRunUnregisterOnExit` |
+| `WinAppRunDetach` | `WinAppRunNoLaunch`, `WinAppRunUseExecutionAlias`, `WinAppRunDebugOutput`, `WinAppRunUnregisterOnExit` |
+
+`WinAppRunUseExecutionAlias`, `WinAppRunDebugOutput`, and `WinAppRunUnregisterOnExit` can be combined
+with each other. `WinAppRunClean`, `WinAppRunSymbols`, `WinAppRunExecutable`, and `WinAppLaunchArgs`
+have no restrictions.
+
 ```xml
 <PropertyGroup>
   <WinAppRunUseExecutionAlias>true</WinAppRunUseExecutionAlias>

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -799,6 +799,12 @@ When using the `Microsoft.Windows.SDK.BuildTools.WinApp` NuGet package, `dotnet 
 | `WinAppRunUseExecutionAlias` | `false` | Launch via execution alias instead of AUMID activation |
 | `WinAppRunNoLaunch` | `false` | Only register identity without launching |
 | `WinAppRunDebugOutput` | `false` | Capture `OutputDebugString` messages and first-chance exceptions. Only one debugger can attach at a time (prevents VS/VS Code). Use `WinAppRunNoLaunch` instead to attach a different debugger. |
+| `WinAppRunDetach` | `false` | Return immediately after launching instead of waiting for the app to exit. Prints the PID. |
+| `WinAppRunUnregisterOnExit` | `false` | Unregister the development package after the app exits |
+| `WinAppRunClean` | `false` | Remove the existing package's application data (LocalState, settings) before re-deploying |
+| `WinAppRunSymbols` | `false` | Download symbols from the Microsoft Symbol Server for richer native crash analysis. Only has an effect with `WinAppRunDebugOutput`. |
+| `WinAppRunExecutable` | (empty) | Executable path relative to the build-output folder. Use when the manifest contains `$targetnametoken$` and the output folder has more than one `.exe`. |
+| `WinAppRunArgs` | (empty) | Raw arguments appended to the `winapp run` command line, for options with no dedicated property (for example `--verbose`). Appended after every property above. |
 
 ```xml
 <PropertyGroup>

--- a/src/winapp-NuGet/README.md
+++ b/src/winapp-NuGet/README.md
@@ -78,6 +78,15 @@ Set these MSBuild properties in your `.csproj` to customize behavior:
 | `WinAppRunExecutable` | (empty) | Executable path relative to the build-output folder. Use when the manifest contains `$targetnametoken$` and the output folder has more than one `.exe`. |
 | `WinAppRunArgs` | (empty) | Raw arguments appended to the `winapp run` command line, for options with no dedicated property. Appended after every property above. |
 
+**Mutually exclusive settings.** `WinAppRunNoLaunch` and `WinAppRunDetach` each describe a different launch behavior, so they conflict with the other launch properties and with each other:
+
+| Property | Cannot be combined with |
+|----------|-------------------------|
+| `WinAppRunNoLaunch` | `WinAppRunDetach`, `WinAppRunUseExecutionAlias`, `WinAppRunDebugOutput`, `WinAppRunUnregisterOnExit` |
+| `WinAppRunDetach` | `WinAppRunNoLaunch`, `WinAppRunUseExecutionAlias`, `WinAppRunDebugOutput`, `WinAppRunUnregisterOnExit` |
+
+A conflicting pair fails the run with `--X and --Y cannot be used together`. The other three launch properties can be combined with each other, and `WinAppRunClean`, `WinAppRunSymbols`, `WinAppRunExecutable`, and `WinAppLaunchArgs` have no restrictions.
+
 Example:
 
 ```xml

--- a/src/winapp-NuGet/README.md
+++ b/src/winapp-NuGet/README.md
@@ -85,7 +85,7 @@ Set these MSBuild properties in your `.csproj` to customize behavior:
 | `WinAppRunNoLaunch` | `WinAppRunDetach`, `WinAppRunUseExecutionAlias`, `WinAppRunDebugOutput`, `WinAppRunUnregisterOnExit` |
 | `WinAppRunDetach` | `WinAppRunNoLaunch`, `WinAppRunUseExecutionAlias`, `WinAppRunDebugOutput`, `WinAppRunUnregisterOnExit` |
 
-A conflicting pair fails the run with `--X and --Y cannot be used together`. The other three launch properties can be combined with each other, and `WinAppRunClean`, `WinAppRunSymbols`, `WinAppRunExecutable`, and `WinAppLaunchArgs` have no restrictions.
+A conflicting pair fails the run with `--X and --Y cannot be used together`. The other three launch properties can be combined with each other, and `WinAppRunClean`, `WinAppRunSymbols`, `WinAppRunExecutable`, and `WinAppLaunchArgs` have no restrictions. `WinAppRunArgs` adds no restriction of its own, but a switch passed through it is checked like any other, so `WinAppRunArgs="--detach"` still conflicts with `WinAppRunNoLaunch`.
 
 Example:
 

--- a/src/winapp-NuGet/README.md
+++ b/src/winapp-NuGet/README.md
@@ -71,6 +71,12 @@ Set these MSBuild properties in your `.csproj` to customize behavior:
 | `WinAppRunUseExecutionAlias` | `false` | Launch via execution alias instead of AUMID activation. Useful for console apps that need terminal I/O. |
 | `WinAppRunNoLaunch` | `false` | Only register identity without launching the app |
 | `WinAppRunDebugOutput` | `false` | Capture `OutputDebugString` messages and first-chance exceptions. Only one debugger can attach at a time (prevents VS/VS Code). Use `WinAppRunNoLaunch` instead to attach a different debugger. Cannot be combined with `WinAppRunNoLaunch`. |
+| `WinAppRunDetach` | `false` | Return immediately after launching instead of waiting for the app to exit. Prints the PID. |
+| `WinAppRunUnregisterOnExit` | `false` | Unregister the development package after the app exits |
+| `WinAppRunClean` | `false` | Remove the existing package's application data (LocalState, settings) before re-deploying |
+| `WinAppRunSymbols` | `false` | Download symbols from the Microsoft Symbol Server for richer native crash analysis. Only has an effect with `WinAppRunDebugOutput`. |
+| `WinAppRunExecutable` | (empty) | Executable path relative to the build-output folder. Use when the manifest contains `$targetnametoken$` and the output folder has more than one `.exe`. |
+| `WinAppRunArgs` | (empty) | Raw arguments appended to the `winapp run` command line, for options with no dedicated property. Appended after every property above. |
 
 Example:
 

--- a/src/winapp-NuGet/build/Microsoft.Windows.SDK.BuildTools.WinApp.props
+++ b/src/winapp-NuGet/build/Microsoft.Windows.SDK.BuildTools.WinApp.props
@@ -56,6 +56,48 @@
       Use WinAppRunNoLaunch instead if you need to attach a different debugger.
     -->
     <WinAppRunDebugOutput Condition="'$(WinAppRunDebugOutput)' == ''">false</WinAppRunDebugOutput>
+
+    <!--
+      When true, return immediately after launching the application instead of
+      waiting for it to exit. The PID is printed to stdout.
+    -->
+    <WinAppRunDetach Condition="'$(WinAppRunDetach)' == ''">false</WinAppRunDetach>
+
+    <!--
+      When true, unregister the development package after the application exits.
+      Only removes packages that were registered in development mode.
+    -->
+    <WinAppRunUnregisterOnExit Condition="'$(WinAppRunUnregisterOnExit)' == ''">false</WinAppRunUnregisterOnExit>
+
+    <!--
+      When true, remove the existing package's application data (LocalState, settings,
+      and so on) before re-deploying. Application data is preserved by default.
+    -->
+    <WinAppRunClean Condition="'$(WinAppRunClean)' == ''">false</WinAppRunClean>
+
+    <!--
+      When true, download symbols from the Microsoft Symbol Server for richer native
+      crash analysis. Only has an effect together with WinAppRunDebugOutput.
+    -->
+    <WinAppRunSymbols Condition="'$(WinAppRunSymbols)' == ''">false</WinAppRunSymbols>
+
+    <!--
+      Path to the executable, relative to the build-output folder. Use to disambiguate
+      when the manifest contains a $targetnametoken$ placeholder and the output folder
+      contains more than one .exe.
+    -->
+    <WinAppRunExecutable Condition="'$(WinAppRunExecutable)' == ''"></WinAppRunExecutable>
+
+    <!--
+      Raw arguments appended to the winapp run command line, for options that have no
+      dedicated property above (the verbose switch, for example). Appended AFTER every
+      property above, following the same convention as AdditionalOptions in other toolsets.
+
+      Use this for options that have no property rather than to override one: winapp
+      rejects a scalar option supplied twice ("Option 'executable' expects a single
+      argument but 2 were provided") instead of letting the later value win.
+    -->
+    <WinAppRunArgs Condition="'$(WinAppRunArgs)' == ''"></WinAppRunArgs>
   </PropertyGroup>
 
 </Project>

--- a/src/winapp-NuGet/build/Microsoft.Windows.SDK.BuildTools.WinApp.targets
+++ b/src/winapp-NuGet/build/Microsoft.Windows.SDK.BuildTools.WinApp.targets
@@ -223,7 +223,18 @@
       <_WinAppRunArgs Condition="'$(WinAppRunUseExecutionAlias)' == 'true'">$(_WinAppRunArgs) --with-alias</_WinAppRunArgs>
       <_WinAppRunArgs Condition="'$(WinAppRunNoLaunch)' == 'true'">$(_WinAppRunArgs) --no-launch</_WinAppRunArgs>
       <_WinAppRunArgs Condition="'$(WinAppRunDebugOutput)' == 'true'">$(_WinAppRunArgs) --debug-output</_WinAppRunArgs>
+      <_WinAppRunArgs Condition="'$(WinAppRunDetach)' == 'true'">$(_WinAppRunArgs) --detach</_WinAppRunArgs>
+      <_WinAppRunArgs Condition="'$(WinAppRunUnregisterOnExit)' == 'true'">$(_WinAppRunArgs) --unregister-on-exit</_WinAppRunArgs>
+      <_WinAppRunArgs Condition="'$(WinAppRunClean)' == 'true'">$(_WinAppRunArgs) --clean</_WinAppRunArgs>
+      <_WinAppRunArgs Condition="'$(WinAppRunSymbols)' == 'true'">$(_WinAppRunArgs) --symbols</_WinAppRunArgs>
+      <_WinAppRunArgs Condition="'$(WinAppRunExecutable)' != ''">$(_WinAppRunArgs) --executable "$(WinAppRunExecutable)"</_WinAppRunArgs>
       <_WinAppRunArgs>$(_WinAppRunArgs) --caller nuget-package</_WinAppRunArgs>
+      <!--
+        WinAppRunArgs is appended last so it lands after every property-derived switch,
+        matching the position AdditionalOptions occupies in other toolsets. It is the
+        escape hatch for options with no dedicated property, such as the verbose switch.
+      -->
+      <_WinAppRunArgs Condition="'$(WinAppRunArgs)' != ''">$(_WinAppRunArgs) $(WinAppRunArgs)</_WinAppRunArgs>
     </PropertyGroup>
   </Target>
 

--- a/src/winapp-NuGet/tests/NuGet.Tests.ps1
+++ b/src/winapp-NuGet/tests/NuGet.Tests.ps1
@@ -93,6 +93,58 @@ $extraProps  </PropertyGroup>
             $out = & dotnet msbuild (Join-Path $dir "test.csproj") -getProperty:_WinAppRunSupportActive -nologo 2>&1
             ($out | Select-Object -Last 1).ToString().Trim()
         }
+
+        # Builds a project that activates run support, runs _WinAppBuildRunArgs, and returns the
+        # constructed winapp command line. Targets _WinAppRunArgs rather than the final
+        # RunArguments so the assertion does not depend on a restore/build of the fake project.
+        function script:Get-ComputedRunArgs {
+            param(
+                [string]$CaseName,
+                [string]$WinAppLaunchArgs = "",
+                [string]$WinAppRunArgs = "",
+                [switch]$WinAppRunDetach,
+                [switch]$WinAppRunUnregisterOnExit,
+                [switch]$WinAppRunClean,
+                [switch]$WinAppRunSymbols,
+                [string]$WinAppRunExecutable = ""
+            )
+            $dir = Join-Path $script:tempRoot $CaseName
+            New-Item -ItemType Directory -Path $dir -Force | Out-Null
+            Set-Content -Path (Join-Path $dir "appxmanifest.xml") -Value '<x/>'
+
+            # _WinAppValidateRunSupport hard-errors when WinAppCliPath does not exist. These tests
+            # run against the source build\ folder rather than an installed package, so there is no
+            # ..\tools\win-x64\winapp.exe; point the property at a stub instead. Nothing is executed
+            # here -- only the argument string is evaluated.
+            $fakeCli = Join-Path $dir "winapp.exe"
+            Set-Content -Path $fakeCli -Value 'stub'
+
+            $extraProps = "    <WinAppCliPath>$fakeCli</WinAppCliPath>`n"
+            if ($WinAppLaunchArgs) { $extraProps += "    <WinAppLaunchArgs>$WinAppLaunchArgs</WinAppLaunchArgs>`n" }
+            if ($WinAppRunArgs) { $extraProps += "    <WinAppRunArgs>$WinAppRunArgs</WinAppRunArgs>`n" }
+            if ($WinAppRunDetach) { $extraProps += "    <WinAppRunDetach>true</WinAppRunDetach>`n" }
+            if ($WinAppRunUnregisterOnExit) { $extraProps += "    <WinAppRunUnregisterOnExit>true</WinAppRunUnregisterOnExit>`n" }
+            if ($WinAppRunClean) { $extraProps += "    <WinAppRunClean>true</WinAppRunClean>`n" }
+            if ($WinAppRunSymbols) { $extraProps += "    <WinAppRunSymbols>true</WinAppRunSymbols>`n" }
+            if ($WinAppRunExecutable) { $extraProps += "    <WinAppRunExecutable>$WinAppRunExecutable</WinAppRunExecutable>`n" }
+
+            $csproj = @"
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
+    <OutputType>WinExe</OutputType>
+$extraProps  </PropertyGroup>
+  <Import Project="$($script:propsPath)" />
+  <Import Project="$($script:targetsPath)" />
+</Project>
+"@
+            Set-Content -Path (Join-Path $dir "test.csproj") -Value $csproj
+            $out = & dotnet msbuild (Join-Path $dir "test.csproj") -t:_WinAppBuildRunArgs -getProperty:_WinAppRunArgs -nologo 2>&1
+            if ($LASTEXITCODE -ne 0) {
+                throw "Failed to compute _WinAppRunArgs:`n$($out -join [Environment]::NewLine)"
+            }
+            ($out | Select-Object -Last 1).ToString().Trim()
+        }
     }
 
     AfterAll {
@@ -188,6 +240,55 @@ $extraProps  </PropertyGroup>
 
         It "Inactive for plain net8.0 (no Windows platform)" {
             Get-GateValue -CaseName 'plain-net8' -TargetFramework 'net8.0' -OutputType 'Exe' -ProjectDirManifest $true | Should -Be 'false'
+        }
+    }
+
+    Context "Run option properties" {
+        It "Emits no optional switches when every property is left at its default" {
+            $args = Get-ComputedRunArgs -CaseName 'run-defaults'
+
+            $args | Should -Match ' --caller nuget-package$'
+            $args | Should -Not -Match ' --detach'
+            $args | Should -Not -Match ' --unregister-on-exit'
+            $args | Should -Not -Match ' --clean'
+            $args | Should -Not -Match ' --symbols'
+            $args | Should -Not -Match ' --executable'
+        }
+
+        It "Maps WinAppLaunchArgs to --args" {
+            $args = Get-ComputedRunArgs -CaseName 'run-launch-args' -WinAppLaunchArgs '--from-property value'
+
+            $args | Should -Match ' --args "--from-property value"'
+        }
+
+        It "Maps each boolean run property to its CLI switch" {
+            $args = Get-ComputedRunArgs -CaseName 'run-bools' `
+                -WinAppRunDetach -WinAppRunUnregisterOnExit -WinAppRunClean -WinAppRunSymbols
+
+            $args | Should -Match ' --detach '
+            $args | Should -Match ' --unregister-on-exit '
+            $args | Should -Match ' --clean '
+            $args | Should -Match ' --symbols '
+        }
+
+        It "Quotes WinAppRunExecutable so a path with spaces survives" {
+            $args = Get-ComputedRunArgs -CaseName 'run-exe' -WinAppRunExecutable 'tools\My App.exe'
+
+            $args | Should -Match ' --executable "tools\\My App\.exe"'
+        }
+
+        It "Appends WinAppRunArgs after the property-derived switches" {
+            # WinAppRunArgs is the escape hatch for options with no dedicated property, so it must
+            # land last -- the same position AdditionalOptions occupies in other toolsets.
+            $args = Get-ComputedRunArgs -CaseName 'run-raw-args' -WinAppRunDetach -WinAppRunArgs '--verbose'
+
+            $args | Should -Match ' --detach .*--caller nuget-package --verbose$'
+        }
+
+        It "Omits WinAppRunArgs entirely when it is empty" {
+            $args = Get-ComputedRunArgs -CaseName 'run-raw-empty'
+
+            $args | Should -Match ' --caller nuget-package$'
         }
     }
 }


### PR DESCRIPTION
## Problem

The NuGet integration exposed only three of `winapp run`'s options as MSBuild properties — `WinAppRunUseExecutionAlias`, `WinAppRunNoLaunch`, `WinAppRunDebugOutput`. Everything else the command accepts in folder mode was unreachable from a project file or a `dotnet run -p:` switch.

## Change

A property for each remaining folder-mode option:

| Property | CLI option |
|---|---|
| `WinAppRunDetach` | `--detach` |
| `WinAppRunUnregisterOnExit` | `--unregister-on-exit` |
| `WinAppRunClean` | `--clean` |
| `WinAppRunSymbols` | `--symbols` |
| `WinAppRunExecutable` | `--executable <path>` |

That closes the gap — **every** folder-mode option now has a property. The remainder of `winapp run` is project-mode only (`-c`, `--arch`, `-r`, `-f`, `--no-build`, `--no-restore`, `-p`, `--project`) and is explicitly ignored in folder mode, which is the only mode the targets use since they always point winapp at `$(OutputPath)`.

Plus `WinAppRunArgs` for the global options with no property of their own:

```powershell
dotnet run -p:WinAppRunArgs="--verbose"
```

## Precedence

`WinAppRunArgs` is appended **after** every property-derived switch — the position `AdditionalOptions` occupies in other toolsets:

```
run "<output>" --manifest "<manifest>" --detach --caller nuget-package --verbose
                                       ^ WinAppRunDetach               ^ WinAppRunArgs
```

It's documented as the escape hatch for options *without* a property, not as an override. The usual "append last so raw wins" convention relies on the tool being last-wins, and winapp isn't:

```
> winapp run . --executable a.exe --executable b.exe
Option '--executable' expects a single argument but 2 were provided.
```

Repeating a *boolean* switch is harmless (verified), so only the scalars can collide — and in that case the user gets that clear error rather than a silent surprise. Making winapp's scalars last-wins would be the more faithful option but changes behavior for direct CLI users too, so I left it out of this PR.

## Tests

Six cases in `NuGet.Tests.ps1` build a project per scenario and assert the computed argument string: defaults emit nothing optional, each boolean maps to its switch, `WinAppRunExecutable` stays quoted so a path with spaces survives, and `WinAppRunArgs` lands last.

They point `WinAppCliPath` at a stub file — `_WinAppValidateRunSupport` hard-errors when the CLI is missing, and these run against the source `build\` folder rather than an installed package. Nothing is executed; only the argument string is evaluated.

25/27 pass locally. The 2 failures are the pre-existing package-layout tests, which need `artifacts\nuget\*.nupkg` from a full `build-cli.ps1` run.

## Notes

- Purely additive — every property defaults to its current behavior, so no existing project changes.
- No `buildTransitive` duplication needed: the csproj packs `build\**\*` to both `build` and `buildTransitive` at pack time.
- Docs updated in `docs/dotnet-run-support.md` (incl. a new escape-hatch section), `docs/usage.md`, and the package README.
