### PR TITLE
Add a consolidated security guidance page for developers

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,3 +12,7 @@ please review the latest guidance for Microsoft repositories at
 [https://aka.ms/SECURITY.md](https://aka.ms/SECURITY.md).
 
 <!-- END MICROSOFT SECURITY.MD BLOCK -->
+
+## Using winapp CLI securely
+
+For guidance on what winapp CLI development certificates and Developer Mode change on your machine, how to handle `devcert.pfx` safely, and how to sign packages for production, see the [Security guidance](docs/security.md) page.

--- a/docs/README.md
+++ b/docs/README.md
@@ -76,6 +76,7 @@ Additional guides:
 - [Packaging an EXE/CLI](guides/packaging-cli.md): step-by-step guide for packaging an existing EXE/CLI as MSIX
 - [Sparse packaging](guides/sparse.md): give an unpackaged app package identity with an identity-only (sparse) MSIX and external content
 - [Shell Completion](guides/shell-completion.md): enable tab completion for commands, options, and values in PowerShell, bash, zsh, and fish
+- [Security guidance](security.md): what development certificates and Developer Mode change on your machine, how to handle `devcert.pfx`, and how to sign for production
 
 ## Commands overview
 
@@ -100,6 +101,7 @@ winapp CLI is open source. You can find the source code, file issues, and contri
 
 - [CLI reference](usage.md)
 - [Debugging with package identity](debugging.md)
+- [Security guidance](security.md)
 - [UI automation](ui-automation.md)
 - [NPM programmatic API](npm-usage.md)
 - [Framework guides](guides/dotnet.md)

--- a/docs/guides/electron/packaging.md
+++ b/docs/guides/electron/packaging.md
@@ -144,7 +144,7 @@ module.exports = {
 ```
 
 > [!IMPORTANT]
-> `forge.config.js` is normally committed to source control, so never put a real signing certificate's password in it. The `password` default above only makes sense because `devcert.pfx` is a throwaway development certificate. For production signing, keep the certificate and its password in your CI secret store — or use Azure Trusted Signing, which has no password at all. See [Security guidance](../security.md).
+> `forge.config.js` is normally committed to source control, so never put a real signing certificate's password in it. The `password` default above only makes sense because `devcert.pfx` is a throwaway development certificate. For production signing, keep the certificate and its password in your CI secret store — or use Azure Trusted Signing, which has no password at all. See [Security guidance](../../security.md).
 
 #### Update Package.appxmanifest
 

--- a/docs/guides/electron/packaging.md
+++ b/docs/guides/electron/packaging.md
@@ -132,7 +132,9 @@ module.exports = {
         appManifest: '.\\Package.appxmanifest',
         windowsSignOptions: {
           certificateFile: '.\\devcert.pfx',
-          certificatePassword: 'password'
+          // Development certificate default password — read this from an
+          // environment variable once you sign with a real certificate.
+          certificatePassword: process.env.WINDOWS_CERT_PASSWORD || 'password'
         }
       }
     }
@@ -140,6 +142,9 @@ module.exports = {
   // ... rest of your config
 };
 ```
+
+> [!IMPORTANT]
+> `forge.config.js` is normally committed to source control, so never put a real signing certificate's password in it. The `password` default above only makes sense because `devcert.pfx` is a throwaway development certificate. For production signing, keep the certificate and its password in your CI secret store — or use Azure Trusted Signing, which has no password at all. See [Security guidance](../security.md).
 
 #### Update Package.appxmanifest
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,211 @@
+<!-- mslearn: true -->
+<!-- description: What winapp CLI development certificates and Developer Mode change on your machine, safe handling of devcert.pfx, and production signing. -->
+# Security guidance
+
+The winapp CLI makes local Windows development straightforward: it can generate a signing certificate, trust it on your machine, and turn on Developer Mode for you. Each of those steps changes machine state or creates a file that carries a private key, so it helps to know exactly what they do.
+
+This page explains the consequence of each command, how to undo it, and what to do differently when you ship. Development certificates and Developer Mode are the normal, supported path for local testing — the goal here is that you understand what you are opting into, not that you avoid them.
+
+## Development certificates
+
+MSIX packages must be signed before Windows will install them. For local testing, [`winapp cert generate`](usage.md#cert-generate) creates a self-signed certificate so you can sign and install your own package without buying anything.
+
+### What `winapp cert generate` creates
+
+The generated certificate is a self-signed, end-entity code-signing certificate:
+
+| Property | Value |
+|----------|-------|
+| Key | RSA 2048-bit, marked exportable |
+| Signature algorithm | SHA-256 with RSA (PKCS#1 v1.5) |
+| Key usage | Digital signature |
+| Enhanced key usage | Code signing (`1.3.6.1.5.5.7.3.3`) |
+| Basic constraints | Not a certificate authority |
+| Validity | 365 days by default (`--valid-days`) |
+| Subject | Must match the `Publisher` in your manifest |
+
+The command writes two things:
+
+- `devcert.pfx` in the current directory (or the path you pass to `--output`). This file contains **both** the certificate and its private key.
+- A copy of the certificate in your personal certificate store (`Cert:\CurrentUser\My`).
+
+With `--export-cer`, it also writes a `.cer` file next to the `.pfx`. That file contains the public certificate only — no private key — which makes it the right thing to hand to a teammate or a test machine that needs to trust your builds.
+
+> [!NOTE]
+> A self-signed certificate is trusted by nobody until someone explicitly trusts it. It is fine for your own machine and your own test machines; it is not a substitute for a real code-signing identity when you distribute your app.
+
+### The default password
+
+`winapp cert generate` uses `password` as the PFX password unless you pass `--password`. The same default applies to [`winapp sign --cert-password`](usage.md#sign) and [`winapp pack`](usage.md#pack).
+
+A well-known password means the private key in `devcert.pfx` is effectively unprotected — anyone who obtains the file can sign code with it. That is an acceptable trade-off for a throwaway certificate that only ever signs local test builds on your own machine, and it is why the default exists.
+
+> [!IMPORTANT]
+> Treat the default password as a signal that the certificate is disposable. If a certificate is ever used to sign something another person will install, it should not be a `winapp cert generate` certificate with the default password — see [Signing for production](#signing-for-production).
+
+### Where the certificate file lives
+
+`devcert.pfx` is a private key on disk. Two rules keep it out of trouble:
+
+**Do not commit it.** `winapp cert generate` automatically appends the certificate's filename to the `.gitignore` next to it, so the default flow is already covered. If you move the file, rename it, or generate it into a directory managed by a different `.gitignore`, check that the entry followed it:
+
+```powershell
+git check-ignore -v devcert.pfx
+```
+
+If that prints nothing, the file is *not* ignored — add it before you commit.
+
+**Do not package it.** [`winapp pack`](usage.md#pack) packages everything in the input directory, so a `devcert.pfx` sitting in your app's output folder ends up inside the shipped MSIX. Generate the certificate outside the folder you package, as the [Packaging an EXE/CLI guide](guides/packaging-cli.md) shows, and confirm it is absent before you distribute:
+
+```powershell
+# Unpack the package and check that no certificate is inside
+winapp tool makeappx unpack /p .\MyApp.msix /d .\inspect /o
+Get-ChildItem .\inspect -Recurse -Include *.pfx, *.cer
+```
+
+> [!TIP]
+> If a `.pfx` with a real private key ever does get committed or published, rotate it: generate a new certificate, re-sign, and stop trusting the old one using the steps in [Removing a trusted certificate](#removing-a-trusted-certificate). Deleting the file from a later commit does not remove it from history.
+
+### What `winapp cert install` grants
+
+[`winapp cert install`](usage.md#cert-install) adds the certificate to the **`LocalMachine\TrustedPeople`** store. This requires administrator privileges, because it changes trust for every user on the machine.
+
+Once a certificate is in `TrustedPeople`, Windows will accept **any** MSIX package signed by that certificate as trusted enough to install — not just the package you were testing. For a certificate whose private key you hold and keep locally, that is exactly the intended effect. It is also the reason to be deliberate about it:
+
+- Trust certificates you generated yourself, or that come from someone you would let install software on the machine.
+- Do not install a development certificate on shared, production, or build machines that other people rely on.
+- Prefer distributing the `.cer` (public key only) rather than the `.pfx` when a colleague needs to install your test package. They gain the ability to trust your builds without gaining the ability to sign as you.
+
+To trust a `.cer` on another test machine, import it directly — `winapp cert install` expects a PFX:
+
+```powershell
+# Run as Administrator
+Import-Certificate -FilePath .\devcert.cer -CertStoreLocation Cert:\LocalMachine\TrustedPeople
+```
+
+### Removing a trusted certificate
+
+Development certificates expire after a year by default, but expiry is not removal. When you are finished with a certificate — the project ended, the machine is being repurposed, or the key may have leaked — remove it explicitly.
+
+First, find its thumbprint:
+
+```powershell
+Get-ChildItem Cert:\LocalMachine\TrustedPeople |
+    Where-Object { $_.Subject -like '*CN=Contoso*' } |
+    Format-List Subject, Thumbprint, NotAfter
+```
+
+Then remove it from the machine trust store, and from your personal store where `cert generate` also placed it:
+
+```powershell
+# Run as Administrator. Replace with the thumbprint from the previous command.
+$thumbprint = 'ABCD...'
+Remove-Item -Path "Cert:\LocalMachine\TrustedPeople\$thumbprint"
+Remove-Item -Path "Cert:\CurrentUser\My\$thumbprint"
+```
+
+Finally, delete the `.pfx` and any `.cer` copies you handed out, and unregister packages you sideloaded with it:
+
+```powershell
+winapp unregister
+```
+
+> [!NOTE]
+> Removing the certificate does not uninstall packages that were already installed with it. Uninstall those separately through **Settings > Apps > Installed apps**, or with [`winapp unregister`](usage.md#unregister) for packages registered in development mode.
+
+## Developer Mode
+
+Windows requires Developer Mode to register an app package directly from a folder on disk — a *loose layout* — instead of installing a built, signed MSIX. Commands such as [`winapp run`](usage.md#run) and [`create-debug-identity`](usage.md#create-debug-identity) rely on that and fail without it, and [`winapp init`](usage.md#init) offers to turn it on for you.
+
+### What enabling it changes
+
+The CLI enables Developer Mode by writing two `DWORD` values under `HKEY_LOCAL_MACHINE`:
+
+```text
+HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock
+    AllowDevelopmentWithoutDevLicense = 1
+    AllowAllTrustedApps               = 1
+```
+
+Because these are machine-wide settings, the CLI launches an elevated helper process and Windows shows a **User Account Control** prompt. Nothing is changed if you decline the prompt.
+
+Practically, this means the machine will:
+
+- Register app packages directly from a folder on disk, without them being built into an MSIX or signed at all (`AllowDevelopmentWithoutDevLicense`).
+- Install app packages from outside the Microsoft Store as long as they are signed by a certificate the machine trusts — including any development certificate in `TrustedPeople` (`AllowAllTrustedApps`).
+
+> [!IMPORTANT]
+> Developer Mode plus a trusted development certificate is a deliberate loosening of the default install restrictions. That combination belongs on development and test machines. Leave it off on production machines, kiosks, and shared infrastructure.
+
+### Controlling when it is enabled
+
+`winapp init` prompts before touching anything, and skips the prompt entirely — leaving Developer Mode unchanged — when run non-interactively or with `--use-defaults` / `--no-prompt`. That makes CI runs safe by default:
+
+```powershell
+winapp init --use-defaults
+```
+
+If you would rather manage the setting yourself, enable it once through **Settings > System > For developers > Developer Mode** and the CLI will detect it and move on.
+
+### Turning it off
+
+Use **Settings > System > For developers** and switch **Developer Mode** off. This is the recommended path, because Settings also cleans up the associated OS state. To confirm the registry value afterwards:
+
+```powershell
+Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock' `
+    -Name AllowDevelopmentWithoutDevLicense, AllowAllTrustedApps
+```
+
+Turning Developer Mode off does not remove trusted certificates or already-installed packages — see [Removing a trusted certificate](#removing-a-trusted-certificate).
+
+## Signing for production
+
+A development certificate only works for people who have explicitly trusted it. To distribute your app, sign it with an identity that Windows already trusts.
+
+### Choose a signing identity
+
+- **[Azure Trusted Signing](https://azure.microsoft.com/products/trusted-signing)** — a cloud-managed signing service. The private key never exists on your build machine, so there is no `.pfx` to protect, leak, or rotate by hand. Use [`winapp az-sign`](usage.md#az-sign), which authenticates with the standard Azure credential chain and works with GitHub Actions OIDC or a managed identity.
+
+  ```powershell
+  winapp az-sign .\MyApp.msix
+  ```
+
+- **A code-signing certificate from a trusted certificate authority** — use [`winapp sign`](usage.md#sign) with `--cert` and `--cert-password`. You are then responsible for storing the key material safely; keep it in a hardware token, a key vault, or your CI provider's secret store, and never in the repository.
+
+- **The Microsoft Store** — if you distribute exclusively through the Store, it signs the package for you and you do not need to sign before submission.
+
+In every case the certificate subject must match the `Publisher` value in your manifest, including for [sparse packages](guides/sparse.md).
+
+### Keep signing secrets out of the repository
+
+Certificate passwords belong in your CI secret store, not in a config file. Read them from the environment instead of hard-coding them:
+
+```powershell
+winapp sign .\MyApp.msix --cert $env:SIGNING_CERT_PATH --cert-password $env:SIGNING_CERT_PASSWORD
+```
+
+The same applies to build configuration checked into source control, such as an Electron Forge config — see [Electron packaging](guides/electron/packaging.md). `winapp az-sign` avoids the problem entirely, because there is no password to pass.
+
+## Before you publish
+
+A short checklist for the transition from local testing to distribution:
+
+- The package is signed with a CA-issued certificate, Azure Trusted Signing, or submitted to the Store — not with `devcert.pfx`.
+- No `.pfx` or `.cer` file is inside the packaged output.
+- No certificate password appears in committed files, build scripts, or CI logs.
+- The certificate subject matches the manifest `Publisher`.
+- Development certificates and Developer Mode are not enabled on machines that only need to *run* the app.
+
+## Reporting a security issue
+
+To report a security vulnerability in the winapp CLI itself, follow the process in [SECURITY.md](../SECURITY.md). Please do not open a public GitHub issue for security reports.
+
+## Related topics
+
+- [CLI reference](usage.md)
+- [Debugging with package identity](debugging.md)
+- [Packaging an EXE/CLI](guides/packaging-cli.md)
+- [Sparse packaging](guides/sparse.md)
+- [Electron packaging](guides/electron/packaging.md)
+- [Sign an app package using SignTool](https://learn.microsoft.com/windows/msix/package/sign-app-package-using-signtool)
+- [Azure Trusted Signing](https://learn.microsoft.com/azure/trusted-signing/)

--- a/docs/security.md
+++ b/docs/security.md
@@ -36,7 +36,7 @@ With `--export-cer`, it also writes a `.cer` file next to the `.pfx`. That file 
 
 ### The default password
 
-`winapp cert generate` uses `password` as the PFX password unless you pass `--password`. The same default applies to [`winapp sign --cert-password`](usage.md#sign) and [`winapp pack`](usage.md#pack).
+`winapp cert generate` uses `password` as the PFX password unless you pass `--password`. The same default applies when you later supply that certificate to [`winapp sign`](usage.md#sign), whose password option is also `--password`, and to [`winapp pack`](usage.md#pack), which takes `--cert-password`.
 
 A well-known password means the private key in `devcert.pfx` is effectively unprotected — anyone who obtains the file can sign code with it. That is an acceptable trade-off for a throwaway certificate that only ever signs local test builds on your own machine, and it is why the default exists.
 
@@ -95,14 +95,23 @@ Get-ChildItem Cert:\LocalMachine\TrustedPeople |
     Format-List Subject, Thumbprint, NotAfter
 ```
 
-Then remove it from the machine trust store, and from your personal store where `cert generate` also placed it:
+Then remove it from the machine trust store. This step needs elevation:
 
 ```powershell
 # Run as Administrator. Replace with the thumbprint from the previous command.
 $thumbprint = 'ABCD...'
 Remove-Item -Path "Cert:\LocalMachine\TrustedPeople\$thumbprint"
+```
+
+`cert generate` also placed the certificate, along with its private key, in your personal store. Remove that from a **normal, non-elevated prompt, signed in as the account that ran `cert generate`**:
+
+```powershell
+$thumbprint = 'ABCD...'
 Remove-Item -Path "Cert:\CurrentUser\My\$thumbprint"
 ```
+
+> [!IMPORTANT]
+> Run the two commands above in the contexts shown. If you elevated using a different administrator account, `Cert:\CurrentUser` in that elevated session is that administrator's store — not yours — so the private key would be left behind in the generating user's store.
 
 Finally, delete the `.pfx` and any `.cer` copies you handed out, and unregister packages you sideloaded with it:
 
@@ -139,7 +148,7 @@ Practically, this means the machine will:
 
 ### Controlling when it is enabled
 
-`winapp init` prompts before touching anything, and skips the prompt entirely — leaving Developer Mode unchanged — when run non-interactively or with `--use-defaults` / `--no-prompt`. That makes CI runs safe by default:
+`winapp init` asks before changing anything, and `--use-defaults` skips the question entirely, leaving Developer Mode untouched. That makes scripted and CI runs safe by default:
 
 ```powershell
 winapp init --use-defaults
@@ -170,7 +179,7 @@ A development certificate only works for people who have explicitly trusted it. 
   winapp az-sign .\MyApp.msix
   ```
 
-- **A code-signing certificate from a trusted certificate authority** — use [`winapp sign`](usage.md#sign) with `--cert` and `--cert-password`. You are then responsible for storing the key material safely; keep it in a hardware token, a key vault, or your CI provider's secret store, and never in the repository.
+- **A code-signing certificate from a trusted certificate authority** — pass it to [`winapp sign`](usage.md#sign) as the second positional argument, with its password in `--password`. You are then responsible for storing the key material safely; keep it in a hardware token, a key vault, or your CI provider's secret store, and never in the repository.
 
 - **The Microsoft Store** — if you distribute exclusively through the Store, it signs the package for you and you do not need to sign before submission.
 
@@ -181,7 +190,7 @@ In every case the certificate subject must match the `Publisher` value in your m
 Certificate passwords belong in your CI secret store, not in a config file. Read them from the environment instead of hard-coding them:
 
 ```powershell
-winapp sign .\MyApp.msix --cert $env:SIGNING_CERT_PATH --cert-password $env:SIGNING_CERT_PASSWORD
+winapp sign .\MyApp.msix $env:SIGNING_CERT_PATH --password $env:SIGNING_CERT_PASSWORD
 ```
 
 The same applies to build configuration checked into source control, such as an Electron Forge config — see [Electron packaging](guides/electron/packaging.md). `winapp az-sign` avoids the problem entirely, because there is no password to pass.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -938,26 +938,27 @@ winapp cert install ./mycert.pfx
 Sign MSIX packages and executables with certificates.
 
 ```bash
-winapp sign <file-path> [options]
+winapp sign <file-path> <cert-path> [options]
 ```
 
 **Arguments:**
 
 - `file-path` - Path to MSIX package or executable to sign
+- `cert-path` - Path to the signing certificate (.pfx)
 
 **Options:**
 
-- `--cert <path>` - Path to signing certificate
-- `--cert-password <password>` - Certificate password (default: "password")
+- `--password <password>` - Certificate password (default: "password")
+- `--timestamp <url>` - RFC 3161 timestamp server URL
 
 **Examples:**
 
 ```bash
 # Sign MSIX package
-winapp sign MyApp.msix --cert ./mycert.pfx
+winapp sign MyApp.msix ./mycert.pfx
 
-# Sign executable
-winapp sign ./bin/MyApp.exe --cert ./mycert.pfx --cert-password mypassword
+# Sign executable with a non-default certificate password
+winapp sign ./bin/MyApp.exe ./mycert.pfx --password mypassword
 ```
 
 ---

--- a/llms.txt
+++ b/llms.txt
@@ -29,6 +29,7 @@ A single shared plugin at `plugins/winapp/` serves both GitHub Copilot and Claud
 - [CLI Schema](https://raw.githubusercontent.com/microsoft/WinAppCli/main/docs/cli-schema.json): Machine-readable JSON schema of all commands, options, and types
 - [Usage Guide](https://github.com/microsoft/WinAppCli/blob/main/docs/usage.md): Full documentation for humans
 - [Debugging Guide](https://github.com/microsoft/WinAppCli/blob/main/docs/debugging.md): `winapp run` vs `create-debug-identity`, IDE setup, and debugging workflows
+- [Security Guidance](https://github.com/microsoft/WinAppCli/blob/main/docs/security.md): What development certificates and Developer Mode change on a machine, safe handling of `devcert.pfx`, and production signing options
 
 ## Guides
 

--- a/scripts/port-mslearn-docs.ps1
+++ b/scripts/port-mslearn-docs.ps1
@@ -549,6 +549,7 @@ $TocLabels = [ordered]@{
     "usage.md"                                   = "Commands and usage"
     "debugging.md"                               = "Debugging with package identity"
     "ui-automation.md"                           = "UI Automation"
+    "security.md"                                = "Security guidance"
     "guides/index.md"                            = "Framework guides"
     "guides/dotnet.md"                           = ".NET / WPF / WinForms"
     "guides/maui.md"                             = ".NET MAUI"
@@ -636,6 +637,7 @@ $tocTree = @(
     (New-TocNode "usage.md")
     (New-TocNode "debugging.md")
     (New-TocNode "ui-automation.md")
+    (New-TocNode "security.md")
     (New-TocNode "guides/index.md" @(
         (New-TocNode "guides/dotnet.md")
         (New-TocNode "guides/maui.md")


### PR DESCRIPTION
## What was missing

The repo had no consolidated security guidance. `SECURITY.md` was only the standard vulnerability-reporting boilerplate, and certificate / Developer Mode guidance was spread across individual framework guides — they show the commands, but rarely the consequence of running them.

Several things had no coverage anywhere:

- What trusting a certificate into `LocalMachine\TrustedPeople` actually grants, and how to remove it later.
- What Developer Mode enables, and why it should not be left on for machines that only need to run the app.
- Safe handling of `devcert.pfx` — keeping it out of source control and out of the packaged output.
- That the documented default PFX password (`password`) leaves the private key effectively unprotected, and that this is fine *only* for a throwaway local test certificate.
- Production signing options collected in one place.

## What this adds

A single new page, `docs/security.md`, rather than warnings scattered through every guide:

- **Development certificates** — exactly what `winapp cert generate` produces (RSA-2048 / SHA-256, code-signing EKU, non-CA, 365-day default, exportable key, plus a copy in `Cert:\CurrentUser\My`), what the default password means, why `devcert.pfx` must stay out of both git and the packaged folder, what `winapp cert install` grants via `LocalMachine\TrustedPeople`, and how to remove a certificate when you are done with it.
- **Developer Mode** — the two `HKLM\...\AppModelUnlock` values the CLI writes, why there is a UAC prompt, what the machine will then accept, how `winapp init` prompts (and skips the prompt under `--use-defaults` / non-interactive, so CI is unaffected), and how to turn it back off.
- **Signing for production** — Azure Trusted Signing via `winapp az-sign`, a CA-issued certificate via `winapp sign`, or Store submission, plus keeping certificate passwords in a CI secret store.
- A short pre-publish checklist.

## Supporting changes

- `docs/README.md` — links the new page from the additional-guides list and Related topics (hand-maintained index, no auto-discovery).
- `llms.txt` — adds the page to the Docs list.
- `SECURITY.md` — adds a short section linking the new page. The existing Microsoft reporting block is untouched.
- `docs/guides/electron/packaging.md` — the Electron Forge example previously showed `certificatePassword: 'password'` with no comment. The example still works, but now reads the password from an environment variable with the dev-certificate default as a fallback, and an admonition explains why a real signing password must never live in a committed `forge.config.js`.

## Tone

Factual and proportionate. Development certificates and Developer Mode are the normal path for local testing and the page says so; the goal is that a reader understands the consequence of each command before running it.

## Validation

No CLI or build surface changed, so nothing needed rebuilding. Every relative link and `usage.md` anchor referenced by the new page was verified to resolve against a real file/heading in the tree. The page satisfies the MS Learn front-matter rules used by `scripts/validate-mslearn-docs.ps1`: `<!-- mslearn: true -->` marker present, H1 title, a distinct `<!-- description: ... -->` of 137 characters (within the 115–145 range), YAML-safe as a plain scalar, no banned marketing words, and all callouts use MS Learn alert syntax.
