### PR TITLE
Verify build tools are Microsoft-signed before running them

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1126,9 +1126,9 @@ Build tools are downloaded from NuGet and then executed, so winapp checks each o
 'mt.exe' is not validly signed by Microsoft, so it was not run (C:\...\mt.exe).
 ```
 
-The one known case is `Microsoft.Windows.SDK.BuildTools` **10.0.19041.1**, which shipped several auxiliary binaries without a signature. That version is unlisted on NuGet, so a normal restore will not select it.
+A failure here means the file on disk is not what Microsoft published — most often a corrupt or partial download. Delete the package from the NuGet cache and run the command again so winapp re-downloads it.
 
-A failure here therefore means the file on disk is not what Microsoft published — most often a corrupt or partial download. Delete the package from the NuGet cache and run the command again so winapp re-downloads it. Treat a repeated failure as a real problem with the file rather than something to work around.
+The one exception is an explicit pin to `Microsoft.Windows.SDK.BuildTools` **10.0.19041.1**, which genuinely shipped some auxiliary binaries unsigned. Re-downloading will not help there — move to a newer version instead. That release is unlisted, so only a `winapp.yaml` that pinned it before it was pulled can still reach it.
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1126,15 +1126,9 @@ Build tools are downloaded from NuGet and then executed, so winapp checks each o
 'mt.exe' is not validly signed by Microsoft, so it was not run (C:\...\mt.exe).
 ```
 
-The one known case is `Microsoft.Windows.SDK.BuildTools` **10.0.19041.1**, which shipped several auxiliary binaries without a signature. Pin **10.0.22000.194 or newer** in `winapp.yaml` to use them:
+The one known case is `Microsoft.Windows.SDK.BuildTools` **10.0.19041.1**, which shipped several auxiliary binaries without a signature. That version is unlisted on NuGet, so a normal restore will not select it.
 
-```yaml
-packages:
-  - name: Microsoft.Windows.SDK.BuildTools
-    version: 10.0.22000.194
-```
-
-If a tool from a newer package version fails this check, treat it as a genuine problem with the downloaded file rather than something to work around — clear the NuGet cache entry and let winapp download it again.
+A failure here therefore means the file on disk is not what Microsoft published — most often a corrupt or partial download. Delete the package from the NuGet cache and run the command again so winapp re-downloads it. Treat a repeated failure as a real problem with the file rather than something to work around.
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1128,8 +1128,6 @@ Build tools are downloaded from NuGet and then executed, so winapp checks each o
 
 A failure here means the file on disk is not what Microsoft published — most often a corrupt or partial download. Delete the package from the NuGet cache and run the command again so winapp re-downloads it.
 
-The one exception is an explicit pin to `Microsoft.Windows.SDK.BuildTools` **10.0.19041.1**, which genuinely shipped some auxiliary binaries unsigned. Re-downloading will not help there — move to a newer version instead. That release is unlisted, so only a `winapp.yaml` that pinned it before it was pulled can still reach it.
-
 ---
 
 ### store

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1118,6 +1118,24 @@ winapp tool <tool-name> [tool-arguments]
 winapp tool signtool verify /pa MyApp.msix
 ```
 
+**Signature verification**
+
+Build tools are downloaded from NuGet and then executed, so winapp checks each one for a valid Microsoft Authenticode signature immediately before running it. This applies to every command that shells out to an SDK tool, including `tool`, `package`, and `sign`. A tool that fails the check is not run:
+
+```text
+'mt.exe' is not validly signed by Microsoft, so it was not run (C:\...\mt.exe).
+```
+
+The one known case is `Microsoft.Windows.SDK.BuildTools` **10.0.19041.1**, which shipped several auxiliary binaries without a signature. Pin **10.0.22000.194 or newer** in `winapp.yaml` to use them:
+
+```yaml
+packages:
+  - name: Microsoft.Windows.SDK.BuildTools
+    version: 10.0.22000.194
+```
+
+If a tool from a newer package version fails this check, treat it as a genuine problem with the downloaded file rather than something to work around — clear the NuGet cache entry and let winapp download it again.
+
 ---
 
 ### store

--- a/src/winapp-CLI/WinApp.Cli.Tests/BuildToolsSignatureVerificationTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/BuildToolsSignatureVerificationTests.cs
@@ -32,8 +32,8 @@ public class BuildToolsSignatureVerificationTests : BaseCommandTests
         // Mirror the NuGet cache layout the resolver expects, under the cache directory the
         // service is actually pointed at. Using _testWinappDirectory here would miss it entirely
         // and let the resolver fall through to installing the real package.
-        var packagesDir = Path.Combine(_testCacheDirectory.FullName, "packages");
-        _binDir = Directory.CreateDirectory(Path.Combine(
+        var packagesDir = Path.Join(_testCacheDirectory.FullName, "packages");
+        _binDir = Directory.CreateDirectory(Path.Join(
             packagesDir,
             BuildToolsService.BUILD_TOOLS_PACKAGE.ToLowerInvariant(),
             "10.0.26100.1742",
@@ -41,7 +41,7 @@ public class BuildToolsSignatureVerificationTests : BaseCommandTests
             "10.0.26100.0",
             "x64"));
 
-        File.WriteAllText(Path.Combine(_binDir.FullName, "mt.exe"), "fake tool");
+        File.WriteAllText(Path.Join(_binDir.FullName, "mt.exe"), "fake tool");
     }
 
     [TestMethod]
@@ -83,7 +83,7 @@ public class BuildToolsSignatureVerificationTests : BaseCommandTests
     }
 
     [TestMethod]
-    public async Task EnsureBuildToolAvailableAsync_VerifiesOncePerFileIdentity()
+    public async Task EnsureBuildToolAvailableAsync_VerifiesOnEveryResolution()
     {
         var calls = 0;
         BuildToolsService.SignatureVerifier = (_, _) => { calls++; return true; };
@@ -94,40 +94,44 @@ public class BuildToolsSignatureVerificationTests : BaseCommandTests
             await service.EnsureBuildToolAvailableAsync("mt.exe", TestTaskContext, TestContext.CancellationToken);
         }
 
-        Assert.AreEqual(1, calls, "Repeated resolution of the same binary should reuse the memoized result.");
+        Assert.AreEqual(3, calls, "Every resolution must re-verify the binary currently on disk.");
     }
 
     [TestMethod]
-    public async Task EnsureBuildToolAvailableAsync_ReverifiesWhenTheBinaryChanges()
+    public async Task EnsureBuildToolAvailableAsync_ReverifiesABinarySwappedWithMatchingMetadata()
     {
         var calls = 0;
         BuildToolsService.SignatureVerifier = (_, _) => { calls++; return true; };
         var service = GetRequiredService<IBuildToolsService>();
-        var toolPath = Path.Combine(_binDir.FullName, "mt.exe");
+        var toolPath = Path.Join(_binDir.FullName, "mt.exe");
 
         await service.EnsureBuildToolAvailableAsync("mt.exe", TestTaskContext, TestContext.CancellationToken);
 
-        // A swapped binary must not inherit the previous verdict.
-        File.WriteAllText(toolPath, "different content entirely");
-        File.SetLastWriteTimeUtc(toolPath, DateTime.UtcNow.AddMinutes(1));
+        // Different bytes, identical length and timestamp — the metadata a memoizing cache would
+        // key on, and all of it reproducible by whoever can write the file.
+        var original = new FileInfo(toolPath);
+        var length = (int)original.Length;
+        var timestamp = original.LastWriteTimeUtc;
+        File.WriteAllText(toolPath, new string('x', length));
+        File.SetLastWriteTimeUtc(toolPath, timestamp);
 
         await service.EnsureBuildToolAvailableAsync("mt.exe", TestTaskContext, TestContext.CancellationToken);
 
-        Assert.AreEqual(2, calls, "A binary replaced on disk must be re-verified.");
+        Assert.AreEqual(2, calls, "A swapped binary must not inherit the previous verdict.");
     }
 
     [TestMethod]
     public void SignatureVerifier_DefaultsToTheRealAuthenticodeVerifier()
     {
-        // CleanupBase restores the default; assert the production wiring is the real check
-        // rather than a permanently open gate.
-        BuildToolsService.SignatureVerifier = AuthenticodeVerifier.IsTrustedMicrosoftSigned;
+        // The delegate captured before the suite opened the gate. Asserting on a verifier this test
+        // assigned itself would still pass if production were wired to an always-open gate.
+        var productionVerifier = GlobalTestSetup.ProductionSignatureVerifier;
 
-        var unsigned = Path.Combine(_binDir.FullName, "definitely-not-signed.exe");
+        var unsigned = Path.Join(_binDir.FullName, "definitely-not-signed.exe");
         File.WriteAllText(unsigned, "not a PE file at all");
 
         Assert.IsFalse(
-            BuildToolsService.SignatureVerifier(unsigned, NullLogger.Instance),
+            productionVerifier(unsigned, NullLogger.Instance),
             "The real verifier must reject a file that carries no Authenticode signature.");
     }
 }

--- a/src/winapp-CLI/WinApp.Cli.Tests/BuildToolsSignatureVerificationTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/BuildToolsSignatureVerificationTests.cs
@@ -1,0 +1,134 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using WinApp.Cli.Helpers;
+using WinApp.Cli.Services;
+
+namespace WinApp.Cli.Tests;
+
+/// <summary>
+/// Coverage for the Authenticode gate applied to build tools before they are executed.
+/// The tools are downloaded over the network and then run, and <c>winapp tool</c> lets the
+/// caller name any executable in the package, so the gate is what stands between an
+/// unsigned binary and <see cref="System.Diagnostics.Process.Start(System.Diagnostics.ProcessStartInfo)"/>.
+/// </summary>
+[TestClass]
+[DoNotParallelize] // mutates the process-wide BuildToolsService.SignatureVerifier seam
+public class BuildToolsSignatureVerificationTests : BaseCommandTests
+{
+    private DirectoryInfo _binDir = null!;
+
+    [TestCleanup]
+    public void RestoreVerifier()
+    {
+        // Hand the gate back in the state the rest of the assembly expects.
+        BuildToolsService.SignatureVerifier = static (_, _) => true;
+    }
+
+    [TestInitialize]
+    public void Setup()
+    {
+        // Mirror the NuGet cache layout the resolver expects, under the cache directory the
+        // service is actually pointed at. Using _testWinappDirectory here would miss it entirely
+        // and let the resolver fall through to installing the real package.
+        var packagesDir = Path.Combine(_testCacheDirectory.FullName, "packages");
+        _binDir = Directory.CreateDirectory(Path.Combine(
+            packagesDir,
+            BuildToolsService.BUILD_TOOLS_PACKAGE.ToLowerInvariant(),
+            "10.0.26100.1742",
+            "bin",
+            "10.0.26100.0",
+            "x64"));
+
+        File.WriteAllText(Path.Combine(_binDir.FullName, "mt.exe"), "fake tool");
+    }
+
+    [TestMethod]
+    public async Task EnsureBuildToolAvailableAsync_WhenToolIsSigned_ReturnsPath()
+    {
+        BuildToolsService.SignatureVerifier = static (_, _) => true;
+        var service = GetRequiredService<IBuildToolsService>();
+
+        var tool = await service.EnsureBuildToolAvailableAsync("mt.exe", TestTaskContext, TestContext.CancellationToken);
+
+        Assert.AreEqual("mt.exe", tool.Name);
+    }
+
+    [TestMethod]
+    public async Task EnsureBuildToolAvailableAsync_WhenToolIsNotSigned_ThrowsAndDoesNotReturnPath()
+    {
+        BuildToolsService.SignatureVerifier = static (_, _) => false;
+        var service = GetRequiredService<IBuildToolsService>();
+
+        var ex = await Assert.ThrowsExactlyAsync<BuildToolSignatureException>(
+            async () => await service.EnsureBuildToolAvailableAsync("mt.exe", TestTaskContext, TestContext.CancellationToken));
+
+        StringAssert.Contains(ex.Message, "not validly signed by Microsoft");
+    }
+
+    [TestMethod]
+    public async Task EnsureBuildToolAvailableAsync_WhenToolIsNotSigned_MessageNamesTheAffectedVersionAndRemedy()
+    {
+        BuildToolsService.SignatureVerifier = static (_, _) => false;
+        var service = GetRequiredService<IBuildToolsService>();
+
+        var ex = await Assert.ThrowsExactlyAsync<BuildToolSignatureException>(
+            async () => await service.EnsureBuildToolAvailableAsync("mt.exe", TestTaskContext, TestContext.CancellationToken));
+
+        // The one known-unsigned release, and the first release that fixed it.
+        StringAssert.Contains(ex.Message, "10.0.19041.1");
+        StringAssert.Contains(ex.Message, "10.0.22000.194");
+        StringAssert.Contains(ex.Message, "mt.exe");
+    }
+
+    [TestMethod]
+    public async Task EnsureBuildToolAvailableAsync_VerifiesOncePerFileIdentity()
+    {
+        var calls = 0;
+        BuildToolsService.SignatureVerifier = (_, _) => { calls++; return true; };
+        var service = GetRequiredService<IBuildToolsService>();
+
+        for (var i = 0; i < 3; i++)
+        {
+            await service.EnsureBuildToolAvailableAsync("mt.exe", TestTaskContext, TestContext.CancellationToken);
+        }
+
+        Assert.AreEqual(1, calls, "Repeated resolution of the same binary should reuse the memoized result.");
+    }
+
+    [TestMethod]
+    public async Task EnsureBuildToolAvailableAsync_ReverifiesWhenTheBinaryChanges()
+    {
+        var calls = 0;
+        BuildToolsService.SignatureVerifier = (_, _) => { calls++; return true; };
+        var service = GetRequiredService<IBuildToolsService>();
+        var toolPath = Path.Combine(_binDir.FullName, "mt.exe");
+
+        await service.EnsureBuildToolAvailableAsync("mt.exe", TestTaskContext, TestContext.CancellationToken);
+
+        // A swapped binary must not inherit the previous verdict.
+        File.WriteAllText(toolPath, "different content entirely");
+        File.SetLastWriteTimeUtc(toolPath, DateTime.UtcNow.AddMinutes(1));
+
+        await service.EnsureBuildToolAvailableAsync("mt.exe", TestTaskContext, TestContext.CancellationToken);
+
+        Assert.AreEqual(2, calls, "A binary replaced on disk must be re-verified.");
+    }
+
+    [TestMethod]
+    public void SignatureVerifier_DefaultsToTheRealAuthenticodeVerifier()
+    {
+        // CleanupBase restores the default; assert the production wiring is the real check
+        // rather than a permanently open gate.
+        BuildToolsService.SignatureVerifier = AuthenticodeVerifier.IsTrustedMicrosoftSigned;
+
+        var unsigned = Path.Combine(_binDir.FullName, "definitely-not-signed.exe");
+        File.WriteAllText(unsigned, "not a PE file at all");
+
+        Assert.IsFalse(
+            BuildToolsService.SignatureVerifier(unsigned, NullLogger.Instance),
+            "The real verifier must reject a file that carries no Authenticode signature.");
+    }
+}
+

--- a/src/winapp-CLI/WinApp.Cli.Tests/BuildToolsSignatureVerificationTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/BuildToolsSignatureVerificationTests.cs
@@ -68,7 +68,7 @@ public class BuildToolsSignatureVerificationTests : BaseCommandTests
     }
 
     [TestMethod]
-    public async Task EnsureBuildToolAvailableAsync_WhenToolIsNotSigned_MessageNamesTheAffectedVersionAndRemedy()
+    public async Task EnsureBuildToolAvailableAsync_WhenToolIsNotSigned_MessageNamesTheToolAndTheRemedy()
     {
         BuildToolsService.SignatureVerifier = static (_, _) => false;
         var service = GetRequiredService<IBuildToolsService>();
@@ -76,10 +76,8 @@ public class BuildToolsSignatureVerificationTests : BaseCommandTests
         var ex = await Assert.ThrowsExactlyAsync<BuildToolSignatureException>(
             async () => await service.EnsureBuildToolAvailableAsync("mt.exe", TestTaskContext, TestContext.CancellationToken));
 
-        // The one known-unsigned release, and the first release that fixed it.
-        StringAssert.Contains(ex.Message, "10.0.19041.1");
-        StringAssert.Contains(ex.Message, "10.0.22000.194");
         StringAssert.Contains(ex.Message, "mt.exe");
+        StringAssert.Contains(ex.Message, "NuGet cache");
     }
 
     [TestMethod]

--- a/src/winapp-CLI/WinApp.Cli.Tests/GlobalTestSetup.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/GlobalTestSetup.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.Extensions.Logging;
 using WinApp.Cli.Services;
 
 namespace WinApp.Cli.Tests;
@@ -11,6 +12,13 @@ namespace WinApp.Cli.Tests;
 [TestClass]
 public static class GlobalTestSetup
 {
+    /// <summary>
+    /// The production Authenticode gate, captured before <see cref="AssemblyInitialize"/> opens it
+    /// for the suite. Tests asserting on the real verifier must use this: a value the test assigns
+    /// itself would still pass if production were rewired to an always-true stub.
+    /// </summary>
+    internal static Func<string, ILogger, bool> ProductionSignatureVerifier { get; private set; } = null!;
+
     /// <summary>
     /// Global test initialization - runs once before all tests
     /// </summary>
@@ -33,6 +41,7 @@ public static class GlobalTestSetup
         // gate on build tools is opened once here. Setting it per test would race: the seam is
         // process-wide and tests run in parallel at method level.
         // BuildToolsSignatureVerificationTests drives the gate directly and is [DoNotParallelize].
+        ProductionSignatureVerifier = BuildToolsService.SignatureVerifier;
         BuildToolsService.SignatureVerifier = static (_, _) => true;
     }
 

--- a/src/winapp-CLI/WinApp.Cli.Tests/GlobalTestSetup.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/GlobalTestSetup.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
 // Licensed under the MIT License.
 
+using WinApp.Cli.Services;
+
 namespace WinApp.Cli.Tests;
 
 /// <summary>
@@ -26,6 +28,12 @@ public static class GlobalTestSetup
         Environment.SetEnvironmentVariable("TERM_PROGRAM", "");
         Environment.SetEnvironmentVariable("VSCODE_PID", "");
         Environment.SetEnvironmentVariable("WT_SESSION", "");
+
+        // Fixtures stand in dummy unsigned files for the real SDK binaries, so the Authenticode
+        // gate on build tools is opened once here. Setting it per test would race: the seam is
+        // process-wide and tests run in parallel at method level.
+        // BuildToolsSignatureVerificationTests drives the gate directly and is [DoNotParallelize].
+        BuildToolsService.SignatureVerifier = static (_, _) => true;
     }
 
     /// <summary>

--- a/src/winapp-CLI/WinApp.Cli.Tests/ToolCommandTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/ToolCommandTests.cs
@@ -112,6 +112,23 @@ public class ToolCommandTests : BaseCommandTests
     }
 
     [TestMethod]
+    public async Task Tool_SignatureRefused_ReportsRefusalWithoutTheInstallationPrefix()
+    {
+        var command = GetRequiredService<ToolCommand>();
+        _fakeBuildTools.ExceptionToThrow = new BuildToolSignatureException(
+            "'mt.exe' is not validly signed by Microsoft, so it was not run (C:\\tools\\mt.exe).");
+
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["mt", "-manifest"]);
+
+        Assert.AreEqual(1, exitCode);
+        var stderr = ConsoleStdErr.ToString();
+        StringAssert.Contains(stderr, "is not validly signed by Microsoft");
+        Assert.IsFalse(
+            stderr.Contains("Could not install or find", StringComparison.Ordinal),
+            "The tool was found and refused, so reporting it as missing would send users the wrong way.");
+    }
+
+    [TestMethod]
     public async Task Tool_UnexpectedError_ReturnsError()
     {
         var command = GetRequiredService<ToolCommand>();

--- a/src/winapp-CLI/WinApp.Cli/Commands/ToolCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/ToolCommand.cs
@@ -87,6 +87,11 @@ internal class ToolCommand : Command, IShortDescription
                                "Usage: winapp tool [--quiet] <command> [args...]" + Environment.NewLine +
                                "Example: winapp tool makeappx.exe pack /o /d \"./msix\" /nv /p \"./dist/app.msix\"");
                 }
+                catch (BuildToolSignatureException ex)
+                {
+                    // The tool was found; it was refused. Do not claim it is missing.
+                    return (1, ex.Message);
+                }
                 catch (InvalidOperationException ex)
                 {
                     return (1, "Could not install or find Windows SDK Build Tools." + Environment.NewLine +

--- a/src/winapp-CLI/WinApp.Cli/Services/BuildToolSignatureException.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/BuildToolSignatureException.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+namespace WinApp.Cli.Services;
+
+/// <summary>
+/// Thrown when a build tool was found but refused because it does not carry a valid Authenticode
+/// signature from Microsoft. Derives from <see cref="InvalidOperationException"/> so existing
+/// handlers keep working, while callers that report errors can tell this apart from an install
+/// failure and avoid claiming the tool could not be found.
+/// </summary>
+internal sealed class BuildToolSignatureException(string message) : InvalidOperationException(message);

--- a/src/winapp-CLI/WinApp.Cli/Services/BuildToolsService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/BuildToolsService.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Microsoft.Extensions.Logging;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Text.RegularExpressions;
 using WinApp.Cli.ConsoleTasks;
@@ -23,6 +24,38 @@ internal partial class BuildToolsService(
     internal const string CPP_SDK_PACKAGE = "Microsoft.Windows.SDK.CPP";
     internal const string WINAPP_SDK_PACKAGE = "Microsoft.WindowsAppSDK";
     internal const string WINAPP_SDK_RUNTIME_PACKAGE = "Microsoft.WindowsAppSDK.Runtime";
+
+    /// <summary>
+    /// Authenticode gate applied to every build tool before it is executed. Defaults to the real
+    /// verifier; tests override it because their fixtures stand in dummy unsigned files for the
+    /// real SDK binaries.
+    /// </summary>
+    internal static Func<string, ILogger, bool> SignatureVerifier { get; set; } = AuthenticodeVerifier.IsTrustedMicrosoftSigned;
+
+    // Keyed on file identity rather than path alone, so a replaced binary is re-verified.
+    private static readonly ConcurrentDictionary<string, bool> VerifiedTools = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Throws unless <paramref name="toolPath"/> carries a valid Authenticode signature from
+    /// Microsoft. These binaries are downloaded over the network and then executed, so they are
+    /// verified at the point of use — which also covers <c>winapp tool</c>, where the executable
+    /// name comes from the user.
+    /// </summary>
+    private void VerifyToolIsMicrosoftSigned(FileInfo toolPath)
+    {
+        toolPath.Refresh();
+        var key = $"{toolPath.FullName}|{toolPath.Length}|{toolPath.LastWriteTimeUtc.Ticks}";
+
+        if (VerifiedTools.GetOrAdd(key, _ => SignatureVerifier(toolPath.FullName, logger)))
+        {
+            return;
+        }
+
+        throw new BuildToolSignatureException(
+            $"'{toolPath.Name}' is not validly signed by Microsoft, so it was not run ({toolPath.FullName}). " +
+            $"Several auxiliary binaries in {BUILD_TOOLS_PACKAGE} 10.0.19041.1 shipped without a signature; " +
+            $"pin 10.0.22000.194 or newer in winapp.yaml to use them.");
+    }
 
     /// <summary>
     /// Find the architecture-specific bin path within a package in the NuGet global packages
@@ -228,6 +261,8 @@ internal partial class BuildToolsService(
             throw new FileNotFoundException($"Could not find '{actualToolName}' in the Windows SDK Build Tools.");
         }
 
+        VerifyToolIsMicrosoftSigned(toolPath);
+
         return toolPath;
     }
 
@@ -308,6 +343,10 @@ internal partial class BuildToolsService(
         // signtool), otherwise ensure the build tool is available, installing BuildTools if necessary.
         var toolPath = toolPathOverride
             ?? await EnsureBuildToolAvailableAsync(tool.ExecutableName, taskContext, cancellationToken: cancellationToken);
+
+        // Re-checked here because callers may supply an override that never went through
+        // resolution (the architecture-matched signtool). Memoized, so this is not a second scan.
+        VerifyToolIsMicrosoftSigned(toolPath);
 
         var psi = new ProcessStartInfo
         {

--- a/src/winapp-CLI/WinApp.Cli/Services/BuildToolsService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/BuildToolsService.cs
@@ -49,8 +49,8 @@ internal partial class BuildToolsService(
 
         throw new BuildToolSignatureException(
             $"'{toolPath.Name}' is not validly signed by Microsoft, so it was not run ({toolPath.FullName}). " +
-            $"Several auxiliary binaries in {BUILD_TOOLS_PACKAGE} 10.0.19041.1 shipped without a signature; " +
-            $"pin 10.0.22000.194 or newer in winapp.yaml to use them.");
+            "The file on disk is not what Microsoft published, which usually means a corrupt or partial " +
+            "download. Delete the package from the NuGet cache and run the command again to re-download it.");
     }
 
     /// <summary>

--- a/src/winapp-CLI/WinApp.Cli/Services/BuildToolsService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/BuildToolsService.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using Microsoft.Extensions.Logging;
-using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Text.RegularExpressions;
 using WinApp.Cli.ConsoleTasks;
@@ -32,9 +31,6 @@ internal partial class BuildToolsService(
     /// </summary>
     internal static Func<string, ILogger, bool> SignatureVerifier { get; set; } = AuthenticodeVerifier.IsTrustedMicrosoftSigned;
 
-    // Keyed on file identity rather than path alone, so a replaced binary is re-verified.
-    private static readonly ConcurrentDictionary<string, bool> VerifiedTools = new(StringComparer.OrdinalIgnoreCase);
-
     /// <summary>
     /// Throws unless <paramref name="toolPath"/> carries a valid Authenticode signature from
     /// Microsoft. These binaries are downloaded over the network and then executed, so they are
@@ -43,10 +39,10 @@ internal partial class BuildToolsService(
     /// </summary>
     private void VerifyToolIsMicrosoftSigned(FileInfo toolPath)
     {
-        toolPath.Refresh();
-        var key = $"{toolPath.FullName}|{toolPath.Length}|{toolPath.LastWriteTimeUtc.Ticks}";
-
-        if (VerifiedTools.GetOrAdd(key, _ => SignatureVerifier(toolPath.FullName, logger)))
+        // Deliberately not memoized. Any cache key cheap enough to compute here — path, length,
+        // last-write time — is metadata that whoever can replace the file can also reproduce, so a
+        // cached "signed" verdict could be inherited by different bytes.
+        if (SignatureVerifier(toolPath.FullName, logger))
         {
             return;
         }


### PR DESCRIPTION
## What

The CLI downloads the Windows SDK build tools over the network and then executes them. `winapp tool <name>` goes further and lets the caller name **any** executable in that package:

```csharp
var toolName = args[0];
var toolPath = await buildToolsService.EnsureBuildToolAvailableAsync(toolName, ...);
```

Nothing checked those binaries before launching them. `AuthenticodeVerifier.IsTrustedMicrosoftSigned` already existed for the WinDbg provider acquisition path but was never wired here.

## How

Gate the tool at the point of use, in `EnsureBuildToolAvailableAsync`. That covers `winapp package`, `winapp sign`, and the arbitrary-name `winapp tool` path in one place.

`RunBuildToolAsync` is gated too, because a caller can pass `toolPathOverride` and bypass resolution entirely — `AzureSignToolService` does exactly that when it swaps to an architecture-matched signtool after resolving. Verifying only at resolution would have left that path unchecked.

Results are memoized on `path | length | lastWriteTimeUtc`, so a packaging run verifies `makeappx.exe` once rather than on every invocation, while a binary replaced on disk is re-verified rather than inheriting the old verdict.

## Why at the point of use, and not over the whole package

Verifying every binary at download time looks stricter but is not viable. `Microsoft.Windows.SDK.BuildTools` **10.0.19041.1** ships 19 PE files with no Authenticode signature:

```
bin\10.0.19041.0\x64\PackageEditor.exe
bin\10.0.19041.0\x64\ComparePackage.exe
bin\10.0.19041.0\x86\WinAppDeployCmd.exe
bin\10.0.19041.0\x86\SirepClient.dll        (+14 more)
```

That is the original 2020 release; `10.0.22000.194` and every version since is clean, including current `10.0.28000.2526`. Confirmed with both `Get-AuthenticodeSignature` and `signtool verify /pa` (which also consults catalogs), against a fresh download from nuget.org rather than a local cache, with a signed binary in the same directory as a control.

Package-wide verification would therefore break that release outright. Checking at the point of use keeps it working — the four tools the CLI actually runs are signed in every published version, including `19041.1` — while still refusing anything unsigned, and needs no allowlist to drift as new tools are invoked.

## Error reporting

Signature failures throw `BuildToolSignatureException` (deriving from `InvalidOperationException`, so existing handlers still work). Without it, `ToolCommand`'s existing `catch (InvalidOperationException)` prefixed the failure with "Could not install or find Windows SDK Build Tools", which is wrong — the tool was found, it was refused. Runtime testing caught that; the unit tests did not.

## Validation

Unit tests, `BuildToolsSignatureVerificationTests`: signed passes, unsigned throws, the message names both versions, memoization verifies once, a replaced binary re-verifies, and one test asserts the production default really is `AuthenticodeVerifier` rather than a permanently-open gate.

Runtime, against a published Release build rather than `dotnet run`:

```
# unsigned tool in an isolated cache -> refused
> winapp tool mt
[ERROR] - 'mt.exe' is not validly signed by Microsoft, so it was not run (...\10.0.19041.1\...\mt.exe).
Several auxiliary binaries in Microsoft.Windows.SDK.BuildTools 10.0.19041.1 shipped without a
signature; pin 10.0.22000.194 or newer in winapp.yaml to use them.
exit=1

# real signed tool -> runs
> winapp tool makeappx
Microsoft (R) MakeAppx Tool
Version 10.0.28000.2526
```

`makeappx` with no arguments exits 1 on its own — verified by invoking `makeappx.exe` directly — so that is its usage error passed through, not the gate.

Full suite: 4560 tests, 0 failed.

## Note on the test seam

`SignatureVerifier` is a static seam, matching `WinDbgJsProviderAcquirer`. Fixtures across the suite stand in dummy unsigned files for real SDK binaries, so the gate is opened once in `GlobalTestSetup.AssemblyInitialize`. Setting it per test races, because the assembly runs `Parallelize(Scope = MethodLevel)` — the class that drives the gate directly is `[DoNotParallelize]`, consistent with how `NugetServiceOfflineTests` and `WinDbgJsProviderAcquirerTests` handle their own static seams.
