### PR TITLE
Update nuget network policy for release failure

### DIFF
--- a/.pipelines/release.yml
+++ b/.pipelines/release.yml
@@ -38,7 +38,8 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
     settings:
-      networkIsolationPolicy: Permissive,CFSClean
+      # CFSClean blocks NuGet endpoints, including publishing to api.nuget.org.
+      networkIsolationPolicy: Permissive,CFSClean2
     sdl:
       policheck:
         enabled: true


### PR DESCRIPTION
Nuget failing due to a policy mismatch.