### PR TITLE
Say what the default certificate password actually means

### DIFF
--- a/src/winapp-CLI/WinApp.Cli/Services/CertificateService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/CertificateService.cs
@@ -336,10 +336,12 @@ internal partial class CertificateService(
                 };
             }
 
-            // Display password information
             if (password == "password")
             {
-                taskContext.AddStatusMessage($"{UiSymbols.Note} Using default password");
+                taskContext.AddStatusMessage(
+                    $"{UiSymbols.Warning} Protected with the default password ('password'), which is public. " +
+                    "Treat this certificate as development-only: anyone who obtains the .pfx can sign as you. " +
+                    "Pass --password to choose your own, and use a CA-issued certificate or Azure Trusted Signing to ship.");
             }
 
             // Install certificate if requested


### PR DESCRIPTION
## Problem

`winapp cert generate` defaults the PFX password to the literal `password`, and said so like this:

```
Using default password
```

That is a fact with no consequence attached, which is the least useful half of the message. The consequence is what matters: the value is published in our own documentation, so the `.pfx` is only as protected as the file permissions on it. Anyone who obtains the file can sign as that developer — and if the certificate was installed into `LocalMachine\TrustedPeople`, the machine will trust the result.

## Change

One message. Same default, same commands, same output stream, no behaviour change:

```
Protected with the default password ('password'), which is public. Treat this
certificate as development-only: anyone who obtains the .pfx can sign as you.
Pass --password to choose your own, and use a CA-issued certificate or Azure
Trusted Signing to ship.
```

## Why not change the default

Raised while auditing secrets handling, so it is worth writing down why the default stays:

- The certificate is self-signed, generated locally, and protects the developer's own key on their own disk. It is not a Microsoft credential and is never deployed to a Microsoft system.
- `cert generate` already adds the `.pfx` to `.gitignore`, which closes the leak vector that actually matters.
- Randomising it would break every sample, guide and sample test in the repo for a development-only artifact, and would mean handing the user a generated secret to store somewhere — trading a known, disclosed default for a worse problem.

The honest fix is disclosure, which the docs already do and the CLI now does too.

## Audit findings from the same pass

Checked the rest of the secrets surface while here; no changes needed:

- **No key material committed** — no tracked `.pfx`, `.p12`, `.pem`, `.key`, `.snk`, `.cer`, `.crt`, `.jks` or `.keystore` anywhere in the repo.
- **No literal secrets in pipelines or workflows** — every credential-shaped value resolves through `$(...)`, `${{ secrets.* }}` or a variable group.
- **Telemetry cannot leak option values by construction** — `CommandInvokedEvent.GetValue` returns the literal `"[string]"` for every `string`, `FileInfo` and `DirectoryInfo` option, so `--password` is recorded as `[string]` and never as its value. It is an allow-list of harmless types rather than a deny-list of sensitive names, so a new secret-bearing option cannot regress it.
- **Display redaction for MSBuild properties** — `RedactSecretsForDisplay` masks `-p:Name=Value` where the name matches `password`, `pwd`, `secret`, `token`, `apikey`, `accesskey`, `credential` or `connectionstring`, at token level so a quote inside a value cannot leave part of it unmasked. The command actually passed to `dotnet` is unaltered.

## Validation

Build clean. Two `~Cert` integration tests fail locally, both with `The SSL connection could not be established` while downloading `Microsoft.Windows.SDK.BuildTools` — nuget.org is unreachable from this machine at the moment (verified independently against `api.nuget.org`), and neither test touches the changed line. Leaving CI to confirm.
