### PR TITLE
Use the preinstalled Rust toolchain instead of an unpinned third-party action

### DIFF
--- a/.github/workflows/test-samples.yml
+++ b/.github/workflows/test-samples.yml
@@ -154,7 +154,13 @@ jobs:
       if: >-
         steps.check.outputs.skip != 'true' &&
         contains(fromJson('["rust-app", "tauri-app"]'), matrix.sample)
-      uses: dtolnay/rust-toolchain@stable
+      shell: pwsh
+      # windows-latest already ships rustup with a stable toolchain, so this selects
+      # what is on the image rather than pulling a third-party action or fetching a toolchain.
+      run: |
+        rustup default stable
+        rustc --version
+        cargo --version
 
     # Install the Inno Setup compiler (ISCC.exe) so the sparse-app installer test
     # actually compiles installer/setup.iss instead of being skipped for a missing ISCC.


### PR DESCRIPTION
## Problem

`dtolnay/rust-toolchain@stable` was the **only** action in the repo referenced by a mutable tag instead of a commit SHA:

```yaml
- name: Setup Rust
  uses: dtolnay/rust-toolchain@stable
```

Every other action — `actions/*`, `github/codeql-action/*`, `dorny/test-reporter`, `subosito/flutter-action` — is pinned to a 40-character SHA with a version comment. So this reads as an oversight rather than a decision, and it means whoever controls that tag can run arbitrary code in our CI the next time it moves, with no review and no diff.

## Change

`windows-latest` already ships rustup with a stable toolchain, so the step can select what is on the image:

```yaml
- name: Setup Rust
  shell: pwsh
  run: |
    rustup default stable
    rustc --version
    cargo --version
```

That removes the third-party action *and* the toolchain download in one go — the second matters for the network-isolation work coming under the approved-sources requirement, since it drops a build-time fetch from `static.rust-lang.org`.

Version output is echoed so the toolchain actually used is visible in the log, which the action used to provide.

## Validation

- Workflow YAML parses (`ConvertFrom-Yaml`), jobs intact: `build`, `test-sample`, `test-samples-result`.
- No unpinned external actions remain anywhere in `.github/workflows` — verified by scanning for `uses:` refs that are not 40-char SHAs.
- The `rust-app` and `tauri-app` matrix legs exercise this; leaving CI to confirm the preinstalled toolchain resolves, since that depends on the runner image rather than anything reproducible locally.

## Context

Found while auditing for SDL requirement *"Production builds must only consume dependencies from approved sources"* (in effect 10/1/2026). This is the subset of that audit that is both a live risk today and unambiguous to fix. The remaining findings need decisions and are being tracked separately — notably `choco install innosetup` in this same workflow (Chocolatey is explicitly prohibited by that requirement), the two other third-party actions, and `networkIsolationPolicy: Permissive` in the ADO pipelines.
