### PR TITLE
Verify the gh download in both release stages, and bump it to 2.97.0

### DIFF
--- a/.pipelines/release.yml
+++ b/.pipelines/release.yml
@@ -34,6 +34,15 @@ parameters:
     type: boolean
     default: false
 
+variables:
+  # Declared once so the URL and its hash cannot drift apart across the stages that install gh.
+  # To bump: take the version and its SHA-256 from the gh_<version>_checksums.txt asset published
+  # with the release at https://github.com/cli/cli/releases.
+  - name: GhCliUrl
+    value: https://github.com/cli/cli/releases/download/v2.97.0/gh_2.97.0_windows_amd64.zip
+  - name: GhCliSha256
+    value: 35D7FE05C4DD1411FFDA1E73DFC7C6F44B75C936CA51FA6595C657FDC0350CEC
+
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
@@ -397,13 +406,18 @@ extends:
                 Invoke-WebRequest https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx -OutFile $vcLibsFile
                 Add-AppxPackage $vcLibsFile
                 
-                # Install gh
-                # TODO: Change this to get the latest version of gh
+                # Install gh with integrity verification
                 Write-Host "Installing gh..."
                 $tempDir = "$(Agent.TempDirectory)"
                 Write-Host "TempDir: $tempDir"
-                Invoke-WebRequest -Uri "https://github.com/cli/cli/releases/download/v2.83.1/gh_2.83.1_windows_amd64.zip" -OutFile "$tempdir\gh.zip"
-                Expand-Archive "$tempdir\gh.zip" -DestinationPath "$tempDir\gh"
+                $ghZipPath = "$tempDir\gh.zip"
+                Invoke-WebRequest -Uri "$(GhCliUrl)" -OutFile $ghZipPath
+                $actualHash = (Get-FileHash $ghZipPath -Algorithm SHA256).Hash
+                if ($actualHash -ne "$(GhCliSha256)") {
+                  Write-Error "SHA-256 mismatch for gh.zip! Expected: $(GhCliSha256), Got: $actualHash"
+                  exit 1
+                }
+                Expand-Archive $ghZipPath -DestinationPath "$tempDir\gh"
 
                 # Download and install wingetcreate
                 Write-Host "Installing wingetcreate..."
@@ -490,13 +504,11 @@ extends:
                 # Install gh with integrity verification
                 Write-Host "Installing gh..."
                 $tempDir = "$(Agent.TempDirectory)"
-                $ghZipUrl = "https://github.com/cli/cli/releases/download/v2.83.1/gh_2.83.1_windows_amd64.zip"
                 $ghZipPath = "$tempDir\gh.zip"
-                $ghExpectedHash = "1324871424CB8CB3793914565026A8DA53B1A633FA05760597ABEF54B57FF12E"
-                Invoke-WebRequest -Uri $ghZipUrl -OutFile $ghZipPath
+                Invoke-WebRequest -Uri "$(GhCliUrl)" -OutFile $ghZipPath
                 $actualHash = (Get-FileHash $ghZipPath -Algorithm SHA256).Hash
-                if ($actualHash -ne $ghExpectedHash) {
-                  Write-Error "SHA-256 mismatch for gh.zip! Expected: $ghExpectedHash, Got: $actualHash"
+                if ($actualHash -ne "$(GhCliSha256)") {
+                  Write-Error "SHA-256 mismatch for gh.zip! Expected: $(GhCliSha256), Got: $actualHash"
                   exit 1
                 }
                 Expand-Archive $ghZipPath -DestinationPath "$tempDir\gh"


### PR DESCRIPTION
## Problem

`.pipelines/release.yml` installs the GitHub CLI in two stages from the same URL, and only one of them checked what it downloaded:

| Stage | Integrity check |
|---|---|
| `Release_MSLearn` (line ~493) | SHA-256 verified, build fails on mismatch |
| `Release_WinGet` (line ~405) | **none** — downloaded and extracted as-is |

The unverified copy then runs `gh.exe repo sync` against the winget-pkgs fork using a GitHub token, inside a production release. Same URL, same version, two different standards.

Both stages also hardcoded the URL and (where present) the hash independently, which is what let them diverge in the first place. The `# TODO: Change this to get the latest version of gh` sitting directly above the unverified copy would have walked into the same trap again — bump one site, miss the other, and the two stages silently run different `gh` versions.

## Change

The URL and its hash are declared once as pipeline variables and referenced from both stages:

```yaml
variables:
  # Declared once so the URL and its hash cannot drift apart across the stages that install gh.
  # To bump: take the version and its SHA-256 from the gh_<version>_checksums.txt asset published
  # with the release at https://github.com/cli/cli/releases.
  - name: GhCliUrl
    value: https://github.com/cli/cli/releases/download/v2.97.0/gh_2.97.0_windows_amd64.zip
  - name: GhCliSha256
    value: 35D7FE05C4DD1411FFDA1E73DFC7C6F44B75C936CA51FA6595C657FDC0350CEC
```

Both stages now perform the same `Get-FileHash` check and fail the build on mismatch. The comment records where the hash comes from, so the next bump is a two-line edit with an obvious source of truth — which is the actual resolution of that TODO.

## Version bump

2.83.1 → 2.97.0 (latest, published 2026-07-31). The pinned hash was established two ways before being written down:

```
published SHA-256: 35D7FE05C4DD1411FFDA1E73DFC7C6F44B75C936CA51FA6595C657FDC0350CEC   (gh_2.97.0_checksums.txt)
computed  SHA-256: 35D7FE05C4DD1411FFDA1E73DFC7C6F44B75C936CA51FA6595C657FDC0350CEC   (independent download)
MATCH
```

## Validation

`.pipelines/release.yml` parses (`ConvertFrom-Yaml`); top-level keys and all stages intact — `Build`, `Release_GitHub`, `Release_Npm`/`Release_NuGet` (conditional), `Release_WinGet`, `Release_MSLearn`. The URL and hash literals each appear exactly once, in the variables block.

I cannot execute an ADO pipeline run from here, so the behavioural check is limited to that: YAML validity, and both call sites resolving the same two variables.

## Context

From the audit for *"Production builds must only consume dependencies from approved sources"*. This is a genuine production-path finding — unlike the ones I raised against the GitHub Actions workflows, which are the external-contributor build and are explicitly permitted to use public registries. Separately still open: whether a GitHub-published binary from the `cli` org counts as an approved source at all, which needs confirmation rather than a code change.
