### PR TITLE
Publish NuGet from a separate pipeline so release.yml keeps CFSClean

### DIFF
--- a/.github/skills/pr-review/dimensions/ship-surfaces.md
+++ b/.github/skills/pr-review/dimensions/ship-surfaces.md
@@ -64,7 +64,9 @@ finding — do not double-report).
 - New NuGet `.csproj` needs `<Copyright>© Microsoft Corporation. All rights
   reserved.</Copyright>`.
 - MSBuild globs are `**\*` / `**\*.*`, never bare `**`.
-- Release runs `.pipelines/release.yml` on `rel/v*` with ESRP signing — changes
-  to signing flow, output paths, or artifact names need pipeline review.
+- Release runs `.pipelines/release.yml` on `rel/v*` with ESRP signing, and
+  `.pipelines/release-nuget.yml` publishes the signed packages to nuget.org —
+  changes to signing flow, output paths, or artifact names need pipeline review.
+  The `nuget-packages` artifact name is a contract between the two pipelines.
 - Release builds treat warnings as errors with `EnforceCodeStyleInBuild=true`;
   flag new `<NoWarn>` that suppresses something real.

--- a/.pipelines/release-nuget.yml
+++ b/.pipelines/release-nuget.yml
@@ -1,0 +1,95 @@
+# Publishes the signed NuGet packages produced by "WinDevCLI - Release" to nuget.org.
+#
+# This lives in its own pipeline because 1ES network isolation policy is pipeline-wide and
+# cannot be scoped to a single stage or job. CFSClean sinkholes api.nuget.org, so a pipeline
+# that pushes to nuget.org cannot run under it. Keeping the push here lets the main release
+# pipeline stay on CFSClean, and limits the CFS exception to a pipeline that only downloads
+# an already-signed .nupkg and publishes it - it never restores packages.
+#
+# Once ESRP Release supports NuGet, this should move to EsrpRelease (as the npm publish in
+# release.yml already does) and the policy here can go back to CFSClean.
+
+trigger: none
+pr: none
+
+resources:
+  repositories:
+  - repository: 1esPipelines
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+  pipelines:
+  - pipeline: release
+    source: '\Windows Developer CLI\WinDevCLI - Release'
+    trigger:
+      branches:
+        include:
+          - rel/v*
+
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
+  parameters:
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean2
+    sdl:
+      sourceAnalysisPool:
+        name: Azure-Pipelines-1ESPT-ExDShared
+        image: windows-latest
+        os: windows
+    stages:
+    - stage: Release_NuGet
+      displayName: Publish the NuGet Release
+      jobs:
+      - job: create_nuget_release
+        pool:
+          name: Azure-Pipelines-1ESPT-ExDShared
+          image: windows-latest
+          os: windows
+          hostArchitecture: amd64
+        displayName: NuGet Release
+        templateContext:
+          type: releaseJob
+          isProduction: true
+          inputs:
+          - input: pipelineArtifact
+            pipeline: release
+            artifactName: nuget-packages
+            targetPath: $(Pipeline.Workspace)/nuget-packages
+        steps:
+          # Replaces the DoEsrp gate the stage had while it lived in release.yml: the
+          # nuget-packages artifact is published whether or not ESRP signing ran, so verify
+          # the packages really are signed rather than pushing unsigned ones to nuget.org.
+          - task: PowerShell@2
+            displayName: 'Verify NuGet packages are signed'
+            inputs:
+              targetType: inline
+              pwsh: true
+              errorActionPreference: stop
+              script: |
+                if (-not (Get-Command dotnet -ErrorAction SilentlyContinue)) {
+                  throw "dotnet was not found on the agent; cannot verify package signatures."
+                }
+
+                $packages = Get-ChildItem '$(Pipeline.Workspace)/nuget-packages' -Filter *.nupkg -File
+                if (-not $packages) {
+                  throw "No .nupkg files were found to publish."
+                }
+
+                foreach ($package in $packages) {
+                  Write-Host "Verifying $($package.Name)"
+                  & dotnet nuget verify $package.FullName --all
+                  if ($LASTEXITCODE -ne 0) {
+                    throw "Signature verification failed for $($package.Name). Refusing to publish to nuget.org."
+                  }
+                }
+          - task: 1ES.PublishNuget@1
+            displayName: 'NuGet push to nuget.org'
+            retryCountOnTaskFailure: 2
+            inputs:
+              # nuget.exe rather than DotNetCoreCLI@2, which cannot use the encrypted API
+              # key from the service connection.
+              useDotNetTask: false
+              packagesToPush: '$(Pipeline.Workspace)/nuget-packages/*.nupkg'
+              packageParentPath: '$(Pipeline.Workspace)/nuget-packages'
+              nuGetFeedType: external
+              publishFeedCredentials: 'NuGet-WinAppCLI'

--- a/.pipelines/release-nuget.yml
+++ b/.pipelines/release-nuget.yml
@@ -25,6 +25,12 @@ resources:
       branches:
         include:
           - rel/v*
+      # Only Release_GitHub, matching the dependsOn this stage had inside release.yml.
+      # Without it the trigger waits for the whole run, so a failure in a later stage
+      # (Release_WinGet expires its PAT every 90 days) would silently skip publishing.
+      # nuget-packages is produced by Build, so it is already available at this point.
+      stages:
+        - Release_GitHub
 
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines

--- a/.pipelines/release.yml
+++ b/.pipelines/release.yml
@@ -38,8 +38,10 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
     settings:
-      # CFSClean blocks NuGet endpoints, including publishing to api.nuget.org.
-      networkIsolationPolicy: Permissive,CFSClean2
+      # CFSClean sinkholes the public package feeds, so this pipeline restores only from
+      # the internal feed in release-nuget.config. Pushing to nuget.org cannot run under
+      # CFSClean, so it lives in the separate .pipelines/release-nuget.yml pipeline.
+      networkIsolationPolicy: Permissive,CFSClean
     sdl:
       policheck:
         enabled: true
@@ -335,34 +337,6 @@ extends:
                 serviceendpointurl: 'https://api.esrp.microsoft.com'
                 mainpublisher: 'ESRPRELPACMAN'
                 domaintenantid: ${{ parameters.signingIdentity.tenantId }}
-
-    - ${{ if eq(parameters.DoEsrp, 'true') }}:
-      - stage: Release_NuGet
-        displayName: Publish the NuGet Release
-        dependsOn: Release_GitHub
-        jobs:
-        - job: create_nuget_release
-          pool:
-            name: Azure-Pipelines-1ESPT-ExDShared
-            image: windows-latest
-            os: windows
-            hostArchitecture: amd64
-          displayName: NuGet Release
-          templateContext:
-            type: releaseJob
-            isProduction: true
-            inputs:
-            - input: pipelineArtifact
-              artifactName: nuget-packages
-              targetPath: $(Pipeline.Workspace)/nuget-packages
-          steps:
-            - task: 1ES.PublishNuget@1
-              displayName: 'NuGet push to nuget.org'
-              inputs:
-                packagesToPush: '$(Pipeline.Workspace)/nuget-packages/*.nupkg'
-                packageParentPath: '$(Pipeline.Workspace)/nuget-packages'
-                nuGetFeedType: external
-                publishFeedCredentials: 'NuGet-WinAppCLI'
 
     - stage: Release_WinGet
       displayName: Create WinGet Release

--- a/scripts/start-release.ps1
+++ b/scripts/start-release.ps1
@@ -401,8 +401,9 @@ try {
     Write-Host "║  • Version bump PR created for $nextVersion$((' ' * (10 - $nextVersion.Length)))║" -ForegroundColor Green
     Write-Host "║                                              ║" -ForegroundColor Green
     Write-Host "║  Next steps:                                 ║" -ForegroundColor Green
-    Write-Host "║  1. Monitor the release pipeline              ║" -ForegroundColor Green
-    Write-Host "║  2. Review & merge the version bump PR       ║" -ForegroundColor Green
+    Write-Host "║  1. Monitor the release pipeline             ║" -ForegroundColor Green
+    Write-Host "║  2. Monitor the NuGet publish pipeline       ║" -ForegroundColor Green
+    Write-Host "║  3. Review & merge the version bump PR       ║" -ForegroundColor Green
     Write-Host "╚══════════════════════════════════════════════╝" -ForegroundColor Green
     Write-Host ""
 


### PR DESCRIPTION
## Why

1ES network isolation policy is **pipeline-wide** — it can't be scoped to a stage or job — and `CFSClean` sinkholes `api.nuget.org`. #740 worked around the blocked nuget.org push by moving the whole release pipeline to `CFSClean2`, but that also dropped CFS feed enforcement from the Build stage, which is the part that actually restores packages.

We asked 1ES (netiso). Their answer:

> You cannot publish to NuGet under CFSClean (until ESRP Release task support NuGet, which they are working on this quarter). If your pipeline publishes to NuGet and does not consume from it, you are eligible for an S360 exception.

## What this does

Splits the nuget.org push into its own pipeline so the exception is scoped to a pipeline that *only* publishes:

| Pipeline | Policy | Does |
|---|---|---|
| `.pipelines/release.yml` | `Permissive,CFSClean` (restored) | build, test, ESRP sign, GitHub/npm/WinGet/MSLearn releases |
| `.pipelines/release-nuget.yml` (new) | `Permissive,CFSClean2` | downloads the signed `nuget-packages` artifact and pushes it — restores nothing |

The new pipeline triggers on completion of the **`Release_GitHub` stage** of `WinDevCLI - Release` for `rel/v*`. Scoping to that stage matters: a bare completion trigger fires only when the *entire* run succeeds, which would have made publishing depend on `Release_WinGet` (whose PAT expires every 90 days), `Release_Npm` and `Release_MSLearn`. The stage filter reproduces the `dependsOn: Release_GitHub` the stage had before the move.

## Signature gate

The `Release_NuGet` stage previously sat behind `${{ if eq(parameters.DoEsrp, 'true') }}`. The split loses that gate, and the `nuget-packages` artifact is published whether or not ESRP signing ran — so a `DoEsrp: false` run could have pushed **unsigned** packages to nuget.org.

The new pipeline verifies signatures before pushing. Checked against real packages:

| Input | Result |
|---|---|
| Unsigned `.nupkg` (fresh `dotnet pack`) | `NU3004: The package is not signed` → exit 1 → step throws |
| Microsoft-signed `.nupkg` | Author + Repository signatures listed → exit 0 |

It also fails if the artifact contains no `.nupkg` at all, so an empty or misnamed artifact fails loudly instead of silently pushing nothing.

**Known limitation:** `dotnet nuget verify --all` proves a package carries a trusted signature, not that *we* signed it — a package with only a nuget.org repository signature also passes. Pinning `--certificate-fingerprint` would close that, at the cost of a constant that breaks releases whenever ESRP rotates the cert. The case this gate exists for — `DoEsrp: false` producing unsigned output — is caught, and anything foreign reaching `artifacts/nuget/` implies the build is already compromised.

## Also

- Sets `useDotNetTask: false` on the push. `DotNetCoreCLI@2` can't use the encrypted API key from the service connection — present in every working public example of an external nuget.org push (aspire, teams.net, playwright-dotnet, Agents-M365Copilot) and missing here.
- `scripts/start-release.ps1` now tells the release owner to monitor both pipelines. Previously it said "Monitor the release pipeline", singular, so a failure in the new pipeline would be invisible to whoever cut the release.

## Follow-ups (not in this PR)

- **Register `release-nuget.yml`** as a new ADO pipeline under `\Windows Developer CLI`, then file the S360 exception against *that* pipeline.
- **Move to `EsrpRelease`** once it supports NuGet — same shape as the existing npm publish — and drop the exception.
- **SFI-ES4.2.4 Wave 10** will retire `Permissive` from the policy mix. Both pipelines will need a default-deny base (`Preferred`/`Good`/`Okay`) plus add-ons. Deliberately kept separate: `release.yml` has egress CI never exercises (`aka.ms` and `github.com` in the WinGet stage, GitHub Models for release notes, ESRP), so that migration should be driven by the netiso dashboard rather than bundled here.

## Testing

All three pipeline YAMLs parse. The release-job cross-pipeline artifact input and the `stages:` trigger filter were verified against the 1ES/ADO schemas, and the ADO pipeline path (`\Windows Developer CLI\WinDevCLI - Release`) was read from the ADO API rather than guessed. The signature gate and the release banner were both exercised locally.