### PR TITLE
Limit template update checks to once a day for winapp new

### DIFF
--- a/src/winapp-CLI/WinApp.Cli.Tests/NewCommandHandlerTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/NewCommandHandlerTests.cs
@@ -1435,6 +1435,43 @@ public class NewCommandHandlerTests : BaseCommandTests
     }
 
     [TestMethod]
+    public async Task Handler_UpdateCheckFails_DoesNotCacheResult()
+    {
+        // The feed check fails (non-zero exit). The failure must NOT be cached as "up-to-date",
+        // otherwise the next run within the day would wrongly skip the retry.
+        _dotnet.RunDotnetArgumentListHandler = args =>
+        {
+            if (args.Count >= 1 && args[0] == "--version")
+            {
+                return (0, "9.0.100\n", string.Empty);
+            }
+            if (args.Count >= 2 && args[0] == "new" && args[1] == "uninstall")
+            {
+                return (0, "Microsoft.WindowsAppSDK.WinUI.CSharp.Templates\n   Version: 0.0.5-alpha\n", string.Empty);
+            }
+            if (args.Count >= 2 && args[0] == "new" && args[1] == "update")
+            {
+                return (1, string.Empty, "Unable to reach the feed."); // transient failure
+            }
+            if (args.Count >= 2 && args[0] == "new" && args[1] == "list")
+            {
+                return (0, SampleListOutput, string.Empty);
+            }
+            return (0, "created", string.Empty);
+        };
+        var command = GetRequiredService<NewCommand>();
+
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["--use-defaults", "--json", "--name", "MyApp"]);
+
+        Assert.AreEqual(NewCommand.ExitSuccess, exitCode);
+        var globalDir = GetRequiredService<IWinappDirectoryService>().GetGlobalWinappDirectory();
+        var cacheFile = new FileInfo(Path.Combine(globalDir.FullName, ".template-update-check"));
+        cacheFile.Refresh();
+        Assert.IsFalse(cacheFile.Exists,
+            "A failed feed check must not be cached, so the next run retries instead of skipping for a day.");
+    }
+
+    [TestMethod]
     [DoNotParallelize] // Swaps the process-wide TelemetryFactory override.
     public async Task Handler_HappyPath_EmitsCorrelatedNewCommandEvent()
     {

--- a/src/winapp-CLI/WinApp.Cli.Tests/NewCommandHandlerTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/NewCommandHandlerTests.cs
@@ -1346,6 +1346,94 @@ public class NewCommandHandlerTests : BaseCommandTests
             "A non-interactive (--use-defaults) run must keep the installed pack rather than performing a machine-wide update.");
     }
 
+    /// <summary>
+    /// Writes the throttle's <c>.template-update-check</c> cache into the isolated global winapp dir so
+    /// the handler treats the staleness check as already performed (stamped now).
+    /// </summary>
+    private void SeedTemplateUpdateCache(string installedVersion, string latestVersion)
+    {
+        var globalDir = GetRequiredService<IWinappDirectoryService>().GetGlobalWinappDirectory();
+        globalDir.Create();
+        var content = $"{DateTimeOffset.UtcNow:O}\n{installedVersion}\n{latestVersion}";
+        File.WriteAllText(Path.Combine(globalDir.FullName, ".template-update-check"), content);
+    }
+
+    [TestMethod]
+    public async Task Handler_StalePackInteractive_RecentCache_SkipsFeedCheckButStillUpdates()
+    {
+        // A check ran within the day and found 0.0.6-alpha; the handler must reuse that instead of
+        // re-hitting the feed, yet still offer the update.
+        SeedTemplateUpdateCache("0.0.5-alpha", "0.0.6-alpha");
+        _dotnet.RunDotnetArgumentListHandler = args =>
+        {
+            if (args.Count >= 1 && args[0] == "--version")
+            {
+                return (0, "9.0.100\n", string.Empty);
+            }
+            if (args.Count >= 2 && args[0] == "new" && args[1] == "uninstall")
+            {
+                return (0, "Microsoft.WindowsAppSDK.WinUI.CSharp.Templates\n   Version: 0.0.5-alpha\n", string.Empty);
+            }
+            if (args.Count >= 2 && args[0] == "new" && args[1] == "install")
+            {
+                return (0, "Success", string.Empty);
+            }
+            if (args.Count >= 2 && args[0] == "new" && args[1] == "list")
+            {
+                return (0, SampleListOutput, string.Empty);
+            }
+            return (0, "created", string.Empty);
+        };
+        TestAnsiConsole.Input.PushTextWithEnter("y"); // update prompt
+        var command = GetRequiredService<NewCommand>();
+
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["--template", "winui", "--name", "MyApp"]);
+
+        Assert.AreEqual(NewCommand.ExitSuccess, exitCode);
+        Assert.IsFalse(
+            _dotnet.ArgumentListInvocations.Any(a => a.Count >= 2 && a[0] == "new" && a[1] == "update"),
+            "A check performed within the last day must not re-run the NuGet feed staleness check.");
+        var install = _dotnet.ArgumentListInvocations
+            .FirstOrDefault(a => a.Count >= 3 && a[0] == "new" && a[1] == "install");
+        Assert.IsNotNull(install, "Accepting the update prompt must install the newer pack.");
+        Assert.AreEqual($"{NewCommand.TemplatePackageId}::0.0.6-alpha", install[2],
+            "The update must use the latest version from the cached check.");
+    }
+
+    [TestMethod]
+    public async Task Handler_UpToDatePack_RecentCache_SkipsFeedCheck()
+    {
+        // The last check (within the day) found the pack up-to-date (empty latest): no feed call, no install.
+        SeedTemplateUpdateCache("0.0.6-alpha", "");
+        _dotnet.RunDotnetArgumentListHandler = args =>
+        {
+            if (args.Count >= 1 && args[0] == "--version")
+            {
+                return (0, "9.0.100\n", string.Empty);
+            }
+            if (args.Count >= 2 && args[0] == "new" && args[1] == "uninstall")
+            {
+                return (0, "Microsoft.WindowsAppSDK.WinUI.CSharp.Templates\n   Version: 0.0.6-alpha\n", string.Empty);
+            }
+            if (args.Count >= 2 && args[0] == "new" && args[1] == "list")
+            {
+                return (0, SampleListOutput, string.Empty);
+            }
+            return (0, "created", string.Empty);
+        };
+        var command = GetRequiredService<NewCommand>();
+
+        var exitCode = await ParseAndInvokeWithCaptureAsync(command, ["--template", "winui", "--name", "MyApp"]);
+
+        Assert.AreEqual(NewCommand.ExitSuccess, exitCode);
+        Assert.IsFalse(
+            _dotnet.ArgumentListInvocations.Any(a => a.Count >= 2 && a[0] == "new" && a[1] == "update"),
+            "A recent up-to-date check must be reused rather than re-querying the feed.");
+        Assert.IsFalse(
+            _dotnet.ArgumentListInvocations.Any(a => a.Count >= 2 && a[0] == "new" && a[1] == "install"),
+            "An up-to-date pack must not be reinstalled.");
+    }
+
     [TestMethod]
     [DoNotParallelize] // Swaps the process-wide TelemetryFactory override.
     public async Task Handler_HappyPath_EmitsCorrelatedNewCommandEvent()

--- a/src/winapp-CLI/WinApp.Cli.Tests/NewCommandHandlerTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/NewCommandHandlerTests.cs
@@ -1355,7 +1355,7 @@ public class NewCommandHandlerTests : BaseCommandTests
         var globalDir = GetRequiredService<IWinappDirectoryService>().GetGlobalWinappDirectory();
         globalDir.Create();
         var content = $"{DateTimeOffset.UtcNow:O}\n{installedVersion}\n{latestVersion}";
-        File.WriteAllText(Path.Combine(globalDir.FullName, ".template-update-check"), content);
+        File.WriteAllText(Path.Join(globalDir.FullName, ".template-update-check"), content);
     }
 
     [TestMethod]
@@ -1465,7 +1465,7 @@ public class NewCommandHandlerTests : BaseCommandTests
 
         Assert.AreEqual(NewCommand.ExitSuccess, exitCode);
         var globalDir = GetRequiredService<IWinappDirectoryService>().GetGlobalWinappDirectory();
-        var cacheFile = new FileInfo(Path.Combine(globalDir.FullName, ".template-update-check"));
+        var cacheFile = new FileInfo(Path.Join(globalDir.FullName, ".template-update-check"));
         cacheFile.Refresh();
         Assert.IsFalse(cacheFile.Exists,
             "A failed feed check must not be cached, so the next run retries instead of skipping for a day.");

--- a/src/winapp-CLI/WinApp.Cli.Tests/TemplateUpdateCheckThrottleTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/TemplateUpdateCheckThrottleTests.cs
@@ -18,7 +18,7 @@ public class TemplateUpdateCheckThrottleTests
     [TestInitialize]
     public void Setup()
     {
-        _globalDir = new DirectoryInfo(Path.Combine(Path.GetTempPath(), $"TplThrottle_{Guid.NewGuid():N}"));
+        _globalDir = new DirectoryInfo(Path.Join(Path.GetTempPath(), $"TplThrottle_{Guid.NewGuid():N}"));
         _globalDir.Create();
     }
 
@@ -29,7 +29,7 @@ public class TemplateUpdateCheckThrottleTests
         {
             _globalDir.Delete(true);
         }
-        catch
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or DirectoryNotFoundException)
         {
             // best-effort cleanup
         }
@@ -111,7 +111,7 @@ public class TemplateUpdateCheckThrottleTests
         var throttle = CreateThrottle();
         throttle.Record("1.0.0", "1.2.0");
 
-        var cacheFile = new FileInfo(Path.Combine(_globalDir.FullName, ".template-update-check"));
+        var cacheFile = new FileInfo(Path.Join(_globalDir.FullName, ".template-update-check"));
         cacheFile.Refresh();
 
         Assert.IsTrue(cacheFile.Exists, "Recording a check must persist the cache file.");

--- a/src/winapp-CLI/WinApp.Cli.Tests/TemplateUpdateCheckThrottleTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/TemplateUpdateCheckThrottleTests.cs
@@ -1,0 +1,120 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using WinApp.Cli.Services;
+
+namespace WinApp.Cli.Tests;
+
+/// <summary>
+/// Coverage for <see cref="TemplateUpdateCheckThrottle"/> — the once-a-day gate that stops
+/// <c>winapp new</c> from hitting the NuGet feed on every invocation to check the WinUI template pack.
+/// </summary>
+[TestClass]
+public class TemplateUpdateCheckThrottleTests
+{
+    private DirectoryInfo _globalDir = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _globalDir = new DirectoryInfo(Path.Combine(Path.GetTempPath(), $"TplThrottle_{Guid.NewGuid():N}"));
+        _globalDir.Create();
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        try
+        {
+            _globalDir.Delete(true);
+        }
+        catch
+        {
+            // best-effort cleanup
+        }
+    }
+
+    private TemplateUpdateCheckThrottle CreateThrottle(Func<DateTimeOffset>? clock = null) =>
+        new(new FakeWinappDirectoryService(_globalDir), NullLogger<TemplateUpdateCheckThrottle>.Instance)
+        {
+            UtcNowProvider = clock ?? (() => DateTimeOffset.UtcNow),
+        };
+
+    [TestMethod]
+    public void TryGetRecentLatest_NoCache_ReturnsFalse()
+    {
+        var throttle = CreateThrottle();
+
+        var recent = throttle.TryGetRecentLatest("1.0.0", out var latest);
+
+        Assert.IsFalse(recent, "With no cache file a check must be due.");
+        Assert.IsNull(latest);
+    }
+
+    [TestMethod]
+    public void Record_ThenTryGetRecentLatest_SameVersion_ReturnsCachedLatest()
+    {
+        var throttle = CreateThrottle();
+        throttle.Record("1.0.0", "1.2.0");
+
+        var recent = throttle.TryGetRecentLatest("1.0.0", out var latest);
+
+        Assert.IsTrue(recent, "A check recorded just now must be considered recent.");
+        Assert.AreEqual("1.2.0", latest);
+    }
+
+    [TestMethod]
+    public void Record_UpToDate_ReturnsRecentWithNullLatest()
+    {
+        var throttle = CreateThrottle();
+        // A null/empty latest means "no update available as of the last check".
+        throttle.Record("1.0.0", null);
+
+        var recent = throttle.TryGetRecentLatest("1.0.0", out var latest);
+
+        Assert.IsTrue(recent);
+        Assert.IsNull(latest, "Up-to-date must be reused as a null latest, not an empty string.");
+    }
+
+    [TestMethod]
+    public void TryGetRecentLatest_OlderThanADay_ReturnsFalse()
+    {
+        var recordedAt = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var writer = CreateThrottle(() => recordedAt);
+        writer.Record("1.0.0", "1.2.0");
+
+        // Read 25 hours later: the cached check has expired, so a fresh check is due.
+        var reader = CreateThrottle(() => recordedAt.AddHours(25));
+        var recent = reader.TryGetRecentLatest("1.0.0", out var latest);
+
+        Assert.IsFalse(recent, "A check older than the interval must expire.");
+        Assert.IsNull(latest);
+    }
+
+    [TestMethod]
+    public void TryGetRecentLatest_DifferentInstalledVersion_ReturnsFalse()
+    {
+        var throttle = CreateThrottle();
+        throttle.Record("1.0.0", "1.2.0");
+
+        // The pack was updated since the last check, so the cached "latest" no longer applies.
+        var recent = throttle.TryGetRecentLatest("1.2.0", out var latest);
+
+        Assert.IsFalse(recent, "A different installed version must invalidate the cached check.");
+        Assert.IsNull(latest);
+    }
+
+    [TestMethod]
+    public void Record_WritesHiddenCacheFile()
+    {
+        var throttle = CreateThrottle();
+        throttle.Record("1.0.0", "1.2.0");
+
+        var cacheFile = new FileInfo(Path.Combine(_globalDir.FullName, ".template-update-check"));
+        cacheFile.Refresh();
+
+        Assert.IsTrue(cacheFile.Exists, "Recording a check must persist the cache file.");
+        Assert.IsTrue(cacheFile.Attributes.HasFlag(FileAttributes.Hidden), "Cache file must be hidden.");
+    }
+}

--- a/src/winapp-CLI/WinApp.Cli.Tests/WinUiTemplateCatalogTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/WinUiTemplateCatalogTests.cs
@@ -71,9 +71,10 @@ public class WinUiTemplateCatalogTests
             "-----------------------------------------------  -----------  -----------\n" +
             "Microsoft.WindowsAppSDK.WinUI.CSharp.Templates   0.0.5-alpha  0.0.6-alpha\n";
 
-        var (current, latest) = WinUiTemplateCatalog.ParseUpdateCheck(
+        var (outcome, current, latest) = WinUiTemplateCatalog.ParseUpdateCheck(
             output, "Microsoft.WindowsAppSDK.WinUI.CSharp.Templates");
 
+        Assert.AreEqual(UpdateCheckOutcome.UpdateAvailable, outcome);
         Assert.AreEqual("0.0.5-alpha", current);
         Assert.AreEqual("0.0.6-alpha", latest);
     }
@@ -81,9 +82,10 @@ public class WinUiTemplateCatalogTests
     [TestMethod]
     public void ParseUpdateCheck_UpToDate_ReturnsNulls()
     {
-        var (current, latest) = WinUiTemplateCatalog.ParseUpdateCheck(
+        var (outcome, current, latest) = WinUiTemplateCatalog.ParseUpdateCheck(
             "All template packages are up-to-date.", "Microsoft.WindowsAppSDK.WinUI.CSharp.Templates");
 
+        Assert.AreEqual(UpdateCheckOutcome.UpToDate, outcome);
         Assert.IsNull(current);
         Assert.IsNull(latest);
     }
@@ -96,10 +98,25 @@ public class WinUiTemplateCatalogTests
             "-------------  -------  ------\n" +
             "Some.Other.Id  1.0.0    2.0.0\n";
 
-        var (current, latest) = WinUiTemplateCatalog.ParseUpdateCheck(
+        var (outcome, current, latest) = WinUiTemplateCatalog.ParseUpdateCheck(
             output, "Microsoft.WindowsAppSDK.WinUI.CSharp.Templates");
 
+        Assert.AreEqual(UpdateCheckOutcome.UpToDate, outcome,
+            "A recognizable table listing only other packages means our pack is authoritatively up-to-date.");
         Assert.IsNull(current, "Only the requested package's row must be considered.");
+        Assert.IsNull(latest);
+    }
+
+    [TestMethod]
+    public void ParseUpdateCheck_UnrecognizedOutput_ReturnsUnrecognized()
+    {
+        // Exit 0 but output we can't interpret (an SDK format change or truncated stdout) must not be
+        // mistaken for "up-to-date", otherwise the throttle would cache a non-result for a day.
+        var (outcome, current, latest) = WinUiTemplateCatalog.ParseUpdateCheck(
+            "Determining projects to restore...\nSome unexpected banner.", "Microsoft.WindowsAppSDK.WinUI.CSharp.Templates");
+
+        Assert.AreEqual(UpdateCheckOutcome.Unrecognized, outcome);
+        Assert.IsNull(current);
         Assert.IsNull(latest);
     }
 

--- a/src/winapp-CLI/WinApp.Cli/Commands/NewCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/NewCommand.cs
@@ -911,10 +911,11 @@ internal class NewCommand : Command, IShortDescription
         /// Checks the NuGet feed for a newer WinUI pack via <c>dotnet new update --check-only</c> (which
         /// resolves through the caller's configured feeds and surfaces prerelease updates).
         /// <para>
-        /// <c>Succeeded</c> is <see langword="false"/> when the check itself failed (feed unreachable,
-        /// non-zero exit) so the caller can avoid caching a failure as an authoritative result;
-        /// <c>Latest</c> is the newest available version, or <see langword="null"/> when the pack is
-        /// already up-to-date.
+        /// <c>Succeeded</c> is <see langword="false"/> when the check couldn't produce an authoritative
+        /// result — a non-zero exit (feed unreachable) or exit 0 with output we can't interpret (an SDK
+        /// output-format change, truncated stdout) — so the caller avoids caching a non-result as
+        /// "up-to-date" for a day; <c>Latest</c> is the newest available version, or <see langword="null"/>
+        /// when the pack is already up-to-date.
         /// </para>
         /// </summary>
         private async Task<(bool Succeeded, string? Latest)> GetLatestAvailableVersionAsync(DirectoryInfo cwd, string installed, CancellationToken cancellationToken)
@@ -926,7 +927,13 @@ internal class NewCommand : Command, IShortDescription
                 return (false, null);
             }
 
-            var (_, latest) = WinUiTemplateCatalog.ParseUpdateCheck(output, TemplatePackageId);
+            var (outcome, _, latest) = WinUiTemplateCatalog.ParseUpdateCheck(output, TemplatePackageId);
+            if (outcome == UpdateCheckOutcome.Unrecognized)
+            {
+                // Exit 0 but output we can't interpret: don't cache it as authoritative — retry next run.
+                return (false, null);
+            }
+
             return (true, latest);
         }
 

--- a/src/winapp-CLI/WinApp.Cli/Commands/NewCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/NewCommand.cs
@@ -812,10 +812,17 @@ internal class NewCommand : Command, IShortDescription
                     }
                     else
                     {
-                        latest = await WithSpinnerAsync(
+                        var (checkSucceeded, feedLatest) = await WithSpinnerAsync(
                             "Checking for WinUI template pack updates...",
                             () => GetLatestAvailableVersionAsync(cwd, installed, cancellationToken));
-                        templateUpdateThrottle.Record(installed, latest);
+                        latest = feedLatest;
+
+                        // Only throttle a check that actually reached the feed. A transient failure must
+                        // retry on the next run rather than be cached as "up-to-date" for a day.
+                        if (checkSucceeded)
+                        {
+                            templateUpdateThrottle.Record(installed, latest);
+                        }
                     }
 
                     var isStale = latest is not null
@@ -901,22 +908,26 @@ internal class NewCommand : Command, IShortDescription
         }
 
         /// <summary>
-        /// Returns the newest available WinUI pack version reported by <c>dotnet new update
-        /// --check-only</c> (which resolves through the caller's configured NuGet feeds and surfaces
-        /// prerelease updates), or <c>null</c> when the pack is already up-to-date or the check fails.
-        /// Falls back to <paramref name="installed"/>'s value semantics via a null return.
+        /// Checks the NuGet feed for a newer WinUI pack via <c>dotnet new update --check-only</c> (which
+        /// resolves through the caller's configured feeds and surfaces prerelease updates).
+        /// <para>
+        /// <c>Succeeded</c> is <see langword="false"/> when the check itself failed (feed unreachable,
+        /// non-zero exit) so the caller can avoid caching a failure as an authoritative result;
+        /// <c>Latest</c> is the newest available version, or <see langword="null"/> when the pack is
+        /// already up-to-date.
+        /// </para>
         /// </summary>
-        private async Task<string?> GetLatestAvailableVersionAsync(DirectoryInfo cwd, string installed, CancellationToken cancellationToken)
+        private async Task<(bool Succeeded, string? Latest)> GetLatestAvailableVersionAsync(DirectoryInfo cwd, string installed, CancellationToken cancellationToken)
         {
             var (exit, output, stderr) = await dotNetService.RunDotnetCommandAsync(cwd, UpdateCheckArgs, EnglishUiEnvironment, cancellationToken);
             LogDotnetOutput(UpdateCheckArgs, exit, output, stderr);
             if (exit != 0)
             {
-                return null;
+                return (false, null);
             }
 
             var (_, latest) = WinUiTemplateCatalog.ParseUpdateCheck(output, TemplatePackageId);
-            return latest;
+            return (true, latest);
         }
 
         /// <summary>

--- a/src/winapp-CLI/WinApp.Cli/Commands/NewCommand.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/NewCommand.cs
@@ -285,6 +285,7 @@ internal class NewCommand : Command, IShortDescription
         ICurrentDirectoryProvider currentDirectoryProvider,
         IAnsiConsole ansiConsole,
         ITemplateCacheReader templateCacheReader,
+        ITemplateUpdateCheckThrottle templateUpdateThrottle,
         ILogger<Handler> logger) : AsynchronousCommandLineAction
     {
         /// <summary>How the caller asked us to resolve the template-pack version.</summary>
@@ -801,10 +802,22 @@ internal class NewCommand : Command, IShortDescription
                         return (true, await QueryInstalledPackVersionAsync(cwd, cancellationToken), null);
                     }
 
-                    // Installed: only offer an update when the pack is actually behind the feed.
-                    var latest = await WithSpinnerAsync(
-                        "Checking for WinUI template pack updates...",
-                        () => GetLatestAvailableVersionAsync(cwd, installed, cancellationToken));
+                    // Installed: only offer an update when the pack is actually behind the feed. The
+                    // feed round-trip is throttled to once a day so back-to-back invocations (e.g. list
+                    // then scaffold) don't each pay the latency; between checks the cached result is reused.
+                    string? latest;
+                    if (templateUpdateThrottle.TryGetRecentLatest(installed, out var cachedLatest))
+                    {
+                        latest = cachedLatest;
+                    }
+                    else
+                    {
+                        latest = await WithSpinnerAsync(
+                            "Checking for WinUI template pack updates...",
+                            () => GetLatestAvailableVersionAsync(cwd, installed, cancellationToken));
+                        templateUpdateThrottle.Record(installed, latest);
+                    }
+
                     var isStale = latest is not null
                         && NuGetVersionHelper.Compare(installed, latest) is int cmp && cmp < 0;
 

--- a/src/winapp-CLI/WinApp.Cli/Helpers/AtomicFile.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/AtomicFile.cs
@@ -27,6 +27,21 @@ internal static class AtomicFile
         }
     }
 
+    /// <summary>Writes <paramref name="content"/> to <paramref name="destinationPath"/> atomically.</summary>
+    public static void WriteAllText(string destinationPath, string content)
+    {
+        var tempPath = MakeTempPath(destinationPath);
+        try
+        {
+            File.WriteAllText(tempPath, content);
+            File.Move(tempPath, destinationPath, overwrite: true);
+        }
+        finally
+        {
+            TryDeleteLeftoverTemp(tempPath);
+        }
+    }
+
     /// <summary>Copies <paramref name="sourcePath"/> to <paramref name="destinationPath"/> atomically.</summary>
     public static void Copy(string sourcePath, string destinationPath)
     {

--- a/src/winapp-CLI/WinApp.Cli/Helpers/HostBuilderExtensions.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/HostBuilderExtensions.cs
@@ -42,6 +42,7 @@ internal static class StoreHostBuilderExtensions
             .AddSingleton<ICsWinRTMetadataShimService, CsWinRTMetadataShimService>()
             .AddSingleton<IProjectRunService, ProjectRunService>()
             .AddSingleton<ITemplateCacheReader, TemplateCacheReader>()
+            .AddSingleton<ITemplateUpdateCheckThrottle, TemplateUpdateCheckThrottle>()
             .AddSingleton<IWorkspaceSetupService, WorkspaceSetupService>()
             .AddSingleton<IWindowsAppRuntimeService, WindowsAppRuntimeService>()
             .AddSingleton<IGitignoreService, GitignoreService>()

--- a/src/winapp-CLI/WinApp.Cli/Helpers/WinUiTemplateCatalog.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/WinUiTemplateCatalog.cs
@@ -8,6 +8,24 @@ using System.Text.Json;
 namespace WinApp.Cli.Helpers;
 
 /// <summary>
+/// Whether a <c>dotnet new update --check-only</c> parse authoritatively determined the pack's
+/// update state. <see cref="Unrecognized"/> must not be treated as up-to-date: it means the output
+/// couldn't be interpreted (empty, truncated, or an unexpected format), so the check should retry
+/// rather than be cached.
+/// </summary>
+internal enum UpdateCheckOutcome
+{
+    /// <summary>Output couldn't be interpreted; the result is unknown and the check should retry.</summary>
+    Unrecognized,
+
+    /// <summary>Output was understood and the pack is current (no newer version offered).</summary>
+    UpToDate,
+
+    /// <summary>Output was understood and a newer version is available.</summary>
+    UpdateAvailable,
+}
+
+/// <summary>
 /// A single template row parsed from <c>dotnet new list</c>. <see cref="ShortNames"/> holds every
 /// alias dotnet accepts for the template (comma-separated in the source table); <see cref="ShortName"/>
 /// is the first (canonical) one that <c>dotnet new &lt;short&gt;</c> is invoked with. <see cref="Type"/>
@@ -152,25 +170,47 @@ internal static class WinUiTemplateCatalog
     }
 
     /// <summary>
-    /// Parses <c>dotnet new update --check-only</c> output for the given package id, returning the
-    /// installed (<c>Current</c>) and available (<c>Latest</c>) versions when an update row for the
-    /// package is present. Returns <c>(null, null)</c> when the package is up-to-date (no update row)
-    /// or the output can't be parsed. The update table has three columns (Package, Current, Latest);
-    /// the Package id contains no spaces, so a simple whitespace split is sufficient and avoids
-    /// depending on exact column widths.
+    /// Parses <c>dotnet new update --check-only</c> output for the given package id. The update table
+    /// has three columns (Package, Current, Latest); the Package id contains no spaces, so a simple
+    /// whitespace split is sufficient and avoids depending on exact column widths.
+    /// <para>
+    /// <c>Outcome</c> separates an authoritatively understood result from output we couldn't interpret:
+    /// <see cref="UpdateCheckOutcome.UpdateAvailable"/> (our package appears in the table),
+    /// <see cref="UpdateCheckOutcome.UpToDate"/> (a recognizable table or the "up-to-date" notice, with
+    /// our package absent), or <see cref="UpdateCheckOutcome.Unrecognized"/> (empty, truncated, or an
+    /// unexpected format). Callers must not treat <c>Unrecognized</c> as "up-to-date", otherwise an SDK
+    /// output-format change would be cached as a successful check and suppress retries.
+    /// </para>
     /// </summary>
-    internal static (string? Current, string? Latest) ParseUpdateCheck(string output, string packageId)
+    internal static (UpdateCheckOutcome Outcome, string? Current, string? Latest) ParseUpdateCheck(string output, string packageId)
     {
         if (string.IsNullOrEmpty(output))
         {
-            return (null, null);
+            return (UpdateCheckOutcome.Unrecognized, null, null);
         }
 
+        var recognized = false;
         foreach (var raw in output.Replace("\r\n", "\n").Split('\n'))
         {
             var line = raw.Trim();
-            if (line.Length == 0 || IsSeparatorRow(raw))
+            if (line.Length == 0)
             {
+                continue;
+            }
+
+            // A dashes separator row (always present under the Package/Current/Latest header) marks a
+            // well-formed update table, even when it lists only other packages.
+            if (IsSeparatorRow(raw))
+            {
+                recognized = true;
+                continue;
+            }
+
+            // "All template packages are up-to-date." is the authoritative "nothing to do" notice when
+            // no table is printed. English UI is forced upstream, so this phrase is stable.
+            if (line.Contains("up-to-date", StringComparison.OrdinalIgnoreCase))
+            {
+                recognized = true;
                 continue;
             }
 
@@ -179,11 +219,13 @@ internal static class WinUiTemplateCatalog
             var parts = line.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
             if (parts.Length >= 3 && parts[0].Equals(packageId, StringComparison.OrdinalIgnoreCase))
             {
-                return (parts[1], parts[2]);
+                return (UpdateCheckOutcome.UpdateAvailable, parts[1], parts[2]);
             }
         }
 
-        return (null, null);
+        return recognized
+            ? (UpdateCheckOutcome.UpToDate, null, null)
+            : (UpdateCheckOutcome.Unrecognized, null, null);
     }
 
     /// <summary>

--- a/src/winapp-CLI/WinApp.Cli/Services/ITemplateUpdateCheckThrottle.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/ITemplateUpdateCheckThrottle.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+namespace WinApp.Cli.Services;
+
+/// <summary>
+/// Throttles the WinUI template-pack staleness check ('dotnet new update --check-only', a NuGet feed
+/// round-trip) so it runs at most once per day. Without this, 'winapp new' pays the feed latency on
+/// every invocation — listing templates and then immediately scaffolding would wait twice.
+/// </summary>
+internal interface ITemplateUpdateCheckThrottle
+{
+    /// <summary>
+    /// Returns <see langword="true"/> when a check for <paramref name="installedVersion"/> ran within
+    /// the last day, letting the caller skip the network check and reuse <paramref name="latestVersion"/>
+    /// (the newest version seen then, or <see langword="null"/> when the pack was up-to-date). Returns
+    /// <see langword="false"/> when no recent check exists for that installed version, so a fresh check
+    /// is due.
+    /// </summary>
+    bool TryGetRecentLatest(string installedVersion, out string? latestVersion);
+
+    /// <summary>
+    /// Records that a staleness check just ran for <paramref name="installedVersion"/>, remembering the
+    /// newest available version (<paramref name="latestVersion"/>, or <see langword="null"/>/empty when
+    /// the pack was up-to-date) so subsequent runs within the day can reuse it.
+    /// </summary>
+    void Record(string installedVersion, string? latestVersion);
+}

--- a/src/winapp-CLI/WinApp.Cli/Services/TemplateUpdateCheckThrottle.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/TemplateUpdateCheckThrottle.cs
@@ -1,0 +1,122 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Globalization;
+using Microsoft.Extensions.Logging;
+
+namespace WinApp.Cli.Services;
+
+/// <summary>
+/// File-backed implementation of <see cref="ITemplateUpdateCheckThrottle"/>. Persists the last
+/// staleness-check timestamp in the global winapp directory, mirroring the '.update-check' cache used
+/// by <see cref="UpdateNotificationService"/> for the CLI self-update notice.
+/// </summary>
+internal sealed class TemplateUpdateCheckThrottle(
+    IWinappDirectoryService winappDirectoryService,
+    ILogger<TemplateUpdateCheckThrottle> logger) : ITemplateUpdateCheckThrottle
+{
+    private const string CacheFileName = ".template-update-check";
+    private const int CheckIntervalHours = 24;
+
+    // Seam so tests can advance the clock without waiting a real day.
+    internal Func<DateTimeOffset> UtcNowProvider { get; set; } = () => DateTimeOffset.UtcNow;
+
+    // Cache file format (one value per line):
+    //   Line 0: last-check timestamp (round-trip "O" format, UTC)
+    //   Line 1: installed pack version the check was performed against
+    //   Line 2: newest available version found (empty when up-to-date)
+
+    public bool TryGetRecentLatest(string installedVersion, out string? latestVersion)
+    {
+        latestVersion = null;
+        try
+        {
+            var cache = ReadCache(GetCacheFile());
+
+            // A recent check only counts when it was performed against the same installed version:
+            // if the pack changed (e.g. the user updated it), the cached "latest" no longer applies.
+            if (!cache.LastCheck.HasValue
+                || !string.Equals(cache.InstalledVersion, installedVersion, StringComparison.OrdinalIgnoreCase)
+                || (UtcNowProvider() - cache.LastCheck.Value).TotalHours >= CheckIntervalHours)
+            {
+                return false;
+            }
+
+            latestVersion = string.IsNullOrEmpty(cache.LatestVersion) ? null : cache.LatestVersion;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Failed to read template update-check cache; treating as due.");
+            return false;
+        }
+    }
+
+    public void Record(string installedVersion, string? latestVersion)
+    {
+        try
+        {
+            WriteCache(
+                GetCacheFile(),
+                new Entry(UtcNowProvider(), installedVersion, latestVersion ?? ""));
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Failed to write template update-check cache.");
+        }
+    }
+
+    private FileInfo GetCacheFile()
+    {
+        var globalDir = winappDirectoryService.GetGlobalWinappDirectory();
+        return new FileInfo(Path.Combine(globalDir.FullName, CacheFileName));
+    }
+
+    private static Entry ReadCache(FileInfo cacheFile)
+    {
+        if (!cacheFile.Exists)
+        {
+            return Entry.Empty;
+        }
+
+        var lines = File.ReadAllLines(cacheFile.FullName);
+
+        DateTimeOffset? lastCheck = null;
+        if (lines.Length >= 1
+            && DateTimeOffset.TryParse(lines[0], CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var parsed))
+        {
+            lastCheck = parsed;
+        }
+
+        var installedVersion = lines.Length >= 2 ? lines[1] : "";
+        var latestVersion = lines.Length >= 3 ? lines[2] : "";
+
+        return new Entry(lastCheck, installedVersion, latestVersion);
+    }
+
+    private void WriteCache(FileInfo cacheFile, Entry entry)
+    {
+        cacheFile.Directory?.Create();
+
+        // Write to a temp file then move for atomic replacement.
+        var tempPath = cacheFile.FullName + ".tmp";
+        var content = $"{entry.LastCheck?.ToString("O", CultureInfo.InvariantCulture) ?? ""}\n{entry.InstalledVersion}\n{entry.LatestVersion}";
+        File.WriteAllText(tempPath, content);
+        File.Move(tempPath, cacheFile.FullName, overwrite: true);
+
+        try
+        {
+            cacheFile.Refresh();
+            cacheFile.Attributes |= FileAttributes.Hidden;
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Failed to hide template update-check cache file.");
+        }
+    }
+
+    private sealed record Entry(DateTimeOffset? LastCheck, string InstalledVersion, string LatestVersion)
+    {
+        public static readonly Entry Empty = new(null, "", "");
+    }
+}

--- a/src/winapp-CLI/WinApp.Cli/Services/TemplateUpdateCheckThrottle.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/TemplateUpdateCheckThrottle.cs
@@ -46,7 +46,7 @@ internal sealed class TemplateUpdateCheckThrottle(
             latestVersion = string.IsNullOrEmpty(cache.LatestVersion) ? null : cache.LatestVersion;
             return true;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or FormatException)
         {
             logger.LogDebug(ex, "Failed to read template update-check cache; treating as due.");
             return false;
@@ -61,7 +61,7 @@ internal sealed class TemplateUpdateCheckThrottle(
                 GetCacheFile(),
                 new Entry(UtcNowProvider(), installedVersion, latestVersion ?? ""));
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
             logger.LogDebug(ex, "Failed to write template update-check cache.");
         }
@@ -70,7 +70,7 @@ internal sealed class TemplateUpdateCheckThrottle(
     private FileInfo GetCacheFile()
     {
         var globalDir = winappDirectoryService.GetGlobalWinappDirectory();
-        return new FileInfo(Path.Combine(globalDir.FullName, CacheFileName));
+        return new FileInfo(Path.Join(globalDir.FullName, CacheFileName));
     }
 
     private static Entry ReadCache(FileInfo cacheFile)
@@ -107,7 +107,7 @@ internal sealed class TemplateUpdateCheckThrottle(
             cacheFile.Refresh();
             cacheFile.Attributes |= FileAttributes.Hidden;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or NotSupportedException)
         {
             logger.LogDebug(ex, "Failed to hide template update-check cache file.");
         }

--- a/src/winapp-CLI/WinApp.Cli/Services/TemplateUpdateCheckThrottle.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/TemplateUpdateCheckThrottle.cs
@@ -3,6 +3,7 @@
 
 using System.Globalization;
 using Microsoft.Extensions.Logging;
+using WinApp.Cli.Helpers;
 
 namespace WinApp.Cli.Services;
 
@@ -98,11 +99,8 @@ internal sealed class TemplateUpdateCheckThrottle(
     {
         cacheFile.Directory?.Create();
 
-        // Write to a temp file then move for atomic replacement.
-        var tempPath = cacheFile.FullName + ".tmp";
         var content = $"{entry.LastCheck?.ToString("O", CultureInfo.InvariantCulture) ?? ""}\n{entry.InstalledVersion}\n{entry.LatestVersion}";
-        File.WriteAllText(tempPath, content);
-        File.Move(tempPath, cacheFile.FullName, overwrite: true);
+        AtomicFile.WriteAllText(cacheFile.FullName, content);
 
         try
         {


### PR DESCRIPTION
## Summary

`winapp new` ran the WinUI template-pack staleness check (`dotnet new update --check-only`, a NuGet feed round-trip) on **every** invocation, adding a few seconds of latency each time. Listing templates and then immediately scaffolding paid that cost twice.

This throttles the feed check to **at most once a day**, following the same pattern `UpdateNotificationService` already uses for the CLI self-update notice. Between checks, the last result is reused, so back-to-back `new` runs are fast.

## What changed

- **New `TemplateUpdateCheckThrottle` service** (`ITemplateUpdateCheckThrottle` + impl) that persists a hidden `.template-update-check` file in the global winapp directory (timestamp, installed pack version, last-seen latest version).
- **`NewCommand` (Default version mode)** now reuses a cached result when a check ran within the last 24h against the *same* installed pack version; otherwise it performs the feed check and records the result. Update prompts for a stale pack still fire — only the redundant network latency is removed.
- The cache is **keyed on the installed pack version**, so if the pack changes the stale cached "latest" is discarded and a fresh check runs.

## Behavior notes

- A **failed** feed check (offline, non-zero exit) is **not** cached — the next run retries rather than suppressing update detection for a day.
- `--template-version latest` still forces the newest pack immediately, bypassing the throttle.
- No new commands, options, or flags; no CLI schema/doc surface changed. The throttle logs only at Debug, so default/`--verbose`/`--quiet`/`--json` output is unaffected.

## Testing

- New unit tests for the throttle: freshness window, expiry after the interval, version-keyed invalidation, up-to-date reuse, hidden-file persistence.
- New `NewCommand` handler tests: recent cache skips the feed check (while still offering an available update), up-to-date cache skips both check and install, and a **failed check is not cached**.
- `dotnet build` clean; template/handler tests (67) and `AtomicFile` tests (5) all pass.

## Review follow-ups (already applied)

- Only cache checks that actually reached the feed, so a transient failure retries next run instead of being cached as "up-to-date" for 24h.
- Route the cache write through a new `AtomicFile.WriteAllText` helper instead of a hand-rolled temp+move, removing duplicated atomic-write logic and a shared-temp-name collision risk.