### PR TITLE
Add OneFuzz harness for ZipRangeExtractor and fix a bounds gap it found

### DIFF
--- a/.pipelines/fuzz.yml
+++ b/.pipelines/fuzz.yml
@@ -1,0 +1,66 @@
+# Fuzzing runs on demand, not per-build: OneFuzz jobs are long-running (hours) and file bugs, so
+# they are triggered manually against a chosen branch.
+trigger: none
+pr: none
+
+parameters:
+  - name: configuration
+    type: string
+    default: Release
+
+resources:
+  repositories:
+    - repository: 1esPipelines
+      type: git
+      name: 1ESPipelineTemplates/1ESPipelineTemplates
+      ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Unofficial.PipelineTemplate.yml@1esPipelines
+  parameters:
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean
+    sdl:
+      sourceAnalysisPool:
+        name: Azure-Pipelines-1ESPT-ExDShared
+        image: windows-latest
+        os: windows
+    stages:
+      - stage: Fuzz
+        jobs:
+          - job: OneFuzz
+            timeoutInMinutes: 120
+            pool:
+              name: Azure-Pipelines-1ESPT-ExDShared
+              image: windows-latest
+              os: windows
+              hostArchitecture: amd64
+            steps:
+              - checkout: self
+                fetchDepth: 1
+                fetchTags: false
+
+              - task: UseDotNet@2
+                displayName: Setup .NET 10
+                inputs:
+                  version: 10.0.x
+
+              - script: |
+                  if not exist "%APPDATA%\NuGet" mkdir "%APPDATA%\NuGet"
+                  copy /Y $(Build.SourcesDirectory)\.pipelines\release-nuget.config "%APPDATA%\NuGet\NuGet.Config"
+                displayName: Add release package source
+
+              - task: NuGetAuthenticate@1
+
+              # Built here rather than downloaded from the CI drop: the fuzz harness is not part of
+              # the shipping artifacts, so there is nothing to download.
+              - script: dotnet build src\winapp-CLI\WinApp.Cli.Fuzz\WinApp.Cli.Fuzz.csproj -c ${{ parameters.configuration }}
+                displayName: Build fuzz harness
+
+              - task: onefuzz-task@0
+                displayName: Submit OneFuzz job
+                inputs:
+                  onefuzzOSes: Windows
+                env:
+                  onefuzzDropDirectory: $(Build.SourcesDirectory)\src\winapp-CLI\WinApp.Cli.Fuzz\bin\${{ parameters.configuration }}\net10.0-windows10.0.19041.0
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/src/winapp-CLI/WinApp.Cli.Fuzz/FuzzableCode.cs
+++ b/src/winapp-CLI/WinApp.Cli.Fuzz/FuzzableCode.cs
@@ -1,0 +1,123 @@
+﻿﻿// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using WinApp.Cli.Helpers;
+
+namespace WinApp.Cli.Fuzz;
+
+/// <summary>
+/// libFuzzer entry points for <see cref="ZipRangeExtractor"/> — the only hand-written parser in
+/// winapp that consumes bytes originating off the network.
+/// </summary>
+/// <remarks>
+/// <c>WinDbgJsProviderAcquirer</c> range-downloads the WinDbg <c>.msixbundle</c> and parses its
+/// ZIP64 central directory, and then a nested inner <c>.msix</c>, in order to locate
+/// <c>JsProvider.dll</c>. That parsing necessarily happens <i>before</i> the extracted DLL's
+/// Authenticode signature can be verified, so the archive bytes are untrusted at this point.
+/// <para>
+/// Each entry point must stay <c>public static void</c> taking <c>ReadOnlySpan&lt;byte&gt;</c> —
+/// that is the signature libFuzzer binds to via <c>LibFuzzerDotnetLoader</c>.
+/// </para>
+/// </remarks>
+public static class FuzzableCode
+{
+    // A malformed central directory can declare far more entries than the input could hold. Production
+    // looks up one entry by name and stops; walking an unbounded list here would tank iteration rate
+    // without covering new code.
+    private const int MaxEntriesToVisit = 16;
+
+    /// <summary>
+    /// Targets <see cref="ZipRangeExtractor.ParseCentralDirectory"/> in isolation. This is a pure
+    /// function over a byte array, so it delivers the highest iteration rate of the two targets.
+    /// </summary>
+    /// <remarks>
+    /// Filtering here is deliberately strict. <c>ParseCentralDirectory</c> reads attacker-controlled
+    /// 16-bit name/extra/comment lengths and slices on them, so a bounds exception escaping this
+    /// method means the parser is missing a length check rather than rejecting bad input — exactly
+    /// what this target exists to surface. <see cref="InvalidDataException"/> is tolerated so the
+    /// target keeps working if those checks are later added as explicit rejections.
+    /// </remarks>
+    public static void FuzzParseCentralDirectory(ReadOnlySpan<byte> input)
+    {
+        try
+        {
+            ZipRangeExtractor.ParseCentralDirectory(input.ToArray(), archiveBase: 0);
+        }
+        catch (Exception ex) when (ex is InvalidDataException or NotSupportedException)
+        {
+            // Deliberate rejection of a malformed archive.
+        }
+    }
+
+    /// <summary>
+    /// Targets the full acquisition sequence — outer central directory, nested inner archive, entry
+    /// extraction — mirroring <c>WinDbgJsProviderAcquirer.ExtractJsProviderAsync</c>.
+    /// </summary>
+    public static void FuzzArchive(ReadOnlySpan<byte> input)
+    {
+        if (input.Length < 22)
+        {
+            // Smaller than a minimal end-of-central-directory record; cannot reach the parser.
+            return;
+        }
+
+        var bytes = input.ToArray();
+
+        try
+        {
+            var reader = new MemoryRangeReader(bytes);
+            var total = Await(reader.GetLengthAsync(CancellationToken.None));
+
+            var (cdOffset, cdSize) = Await(
+                ZipRangeExtractor.FindCentralDirectoryAsync(reader, 0, total, CancellationToken.None));
+            var outerEntries = ZipRangeExtractor.ParseCentralDirectory(
+                Await(reader.ReadAsync(cdOffset, checked((int)cdSize), CancellationToken.None)), 0);
+
+            // Production selects the inner .msix by exact file name. A fuzzer will never synthesise
+            // that name, so index into the entries instead to keep the nested path reachable.
+            foreach (var inner in outerEntries.Take(MaxEntriesToVisit))
+            {
+                VisitAsInnerArchive(reader, inner);
+            }
+        }
+        catch (Exception ex) when (IsExpectedArchiveRejection(ex))
+        {
+            // Malformed archive. WinDbgJsProviderAcquirer.TryAcquireCoreAsync swallows these and
+            // degrades gracefully, so they are not defects.
+        }
+    }
+
+    private static void VisitAsInnerArchive(MemoryRangeReader reader, ZipEntry inner)
+    {
+        // Extracting the entry directly exercises the stored/deflate paths...
+        _ = Await(ZipRangeExtractor.ExtractEntryAsync(reader, inner, CancellationToken.None));
+
+        // ...and treating it as a nested archive exercises the bundle -> msix descent, where a
+        // non-zero archiveBase makes every offset calculation relative.
+        var innerStart = Await(ZipRangeExtractor.GetDataStartAsync(reader, inner, CancellationToken.None));
+        var (innerCdOffset, innerCdSize) = Await(ZipRangeExtractor.FindCentralDirectoryAsync(
+            reader, innerStart, inner.CompressedSize, CancellationToken.None));
+        var innerEntries = ZipRangeExtractor.ParseCentralDirectory(
+            Await(reader.ReadAsync(innerCdOffset, checked((int)innerCdSize), CancellationToken.None)), innerStart);
+
+        foreach (var entry in innerEntries.Take(MaxEntriesToVisit))
+        {
+            _ = Await(ZipRangeExtractor.ExtractEntryAsync(reader, entry, CancellationToken.None));
+        }
+    }
+
+    /// <summary>
+    /// Exceptions the production caller already treats as "this archive is not usable".
+    /// <see cref="OutOfMemoryException"/> is intentionally absent: entry sizes are attacker-controlled
+    /// independently of input length, so an allocation blow-up is a finding worth reporting.
+    /// </summary>
+    private static bool IsExpectedArchiveRejection(Exception ex) => ex
+        is InvalidDataException          // the parser's own deliberate rejections
+        or NotSupportedException         // unsupported compression method
+        or OverflowException             // checked cast of an oversized central-directory size
+        or ArgumentOutOfRangeException;  // range read outside the archive, which both range readers reject
+
+    // The parser is async; libFuzzer targets must be void. These calls never touch I/O because the
+    // reader is memory-backed, so blocking cannot deadlock.
+    private static T Await<T>(Task<T> task) => task.GetAwaiter().GetResult();
+}

--- a/src/winapp-CLI/WinApp.Cli.Fuzz/FuzzableCode.cs
+++ b/src/winapp-CLI/WinApp.Cli.Fuzz/FuzzableCode.cs
@@ -65,7 +65,7 @@ public static class FuzzableCode
 
         try
         {
-            var reader = new MemoryRangeReader(bytes);
+            var reader = new BoundedRangeReader(new MemoryRangeReader(bytes));
             var total = Await(reader.GetLengthAsync(CancellationToken.None));
 
             var (cdOffset, cdSize) = Await(
@@ -77,7 +77,16 @@ public static class FuzzableCode
             // that name, so index into the entries instead to keep the nested path reachable.
             foreach (var inner in outerEntries.Take(MaxEntriesToVisit))
             {
-                VisitAsInnerArchive(reader, inner);
+                // Per entry, not around the loop: most entries are not archives, and rejecting one
+                // must not stop the walk before it reaches the nested .msix.
+                try
+                {
+                    VisitAsInnerArchive(reader, inner);
+                }
+                catch (Exception ex) when (IsExpectedArchiveRejection(ex))
+                {
+                    // This entry is not a usable nested archive; keep going.
+                }
             }
         }
         catch (Exception ex) when (IsExpectedArchiveRejection(ex))
@@ -87,7 +96,7 @@ public static class FuzzableCode
         }
     }
 
-    private static void VisitAsInnerArchive(MemoryRangeReader reader, ZipEntry inner)
+    private static void VisitAsInnerArchive(BoundedRangeReader reader, ZipEntry inner)
     {
         // Extracting the entry directly exercises the stored/deflate paths...
         _ = Await(ZipRangeExtractor.ExtractEntryAsync(reader, inner, CancellationToken.None));
@@ -107,17 +116,51 @@ public static class FuzzableCode
     }
 
     /// <summary>
-    /// Exceptions the production caller already treats as "this archive is not usable".
-    /// <see cref="OutOfMemoryException"/> is intentionally absent: entry sizes are attacker-controlled
-    /// independently of input length, so an allocation blow-up is a finding worth reporting.
+    /// Exceptions that mean "this archive is not usable" rather than "the parser has a gap".
+    /// <para>
+    /// <see cref="ArgumentOutOfRangeException"/> is deliberately absent. A range read that runs off
+    /// the end of the archive is a legitimate rejection, but <see cref="BoundedRangeReader"/> reports
+    /// that as <see cref="InvalidDataException"/>, so anything still surfacing as out-of-range came
+    /// from the parser indexing a buffer it already holds — the bug class this target exists to find.
+    /// </para>
+    /// <para>
+    /// <see cref="OutOfMemoryException"/> is absent for the same reason: entry sizes are
+    /// attacker-controlled independently of input length, so an allocation blow-up is a finding.
+    /// </para>
     /// </summary>
     private static bool IsExpectedArchiveRejection(Exception ex) => ex
-        is InvalidDataException          // the parser's own deliberate rejections
+        is InvalidDataException          // the parser's own deliberate rejections, and short reads
         or NotSupportedException         // unsupported compression method
-        or OverflowException             // checked cast of an oversized central-directory size
-        or ArgumentOutOfRangeException;  // range read outside the archive, which both range readers reject
+        or OverflowException;            // checked cast of an oversized central-directory size
 
     // The parser is async; libFuzzer targets must be void. These calls never touch I/O because the
     // reader is memory-backed, so blocking cannot deadlock.
     private static T Await<T>(Task<T> task) => task.GetAwaiter().GetResult();
+}
+
+/// <summary>
+/// Wraps <see cref="MemoryRangeReader"/> so that asking for bytes outside the archive reads as a
+/// rejected archive instead of an out-of-range access.
+/// </summary>
+/// <remarks>
+/// Without this the harness cannot tell "the parser asked for a range past EOF", which is a normal
+/// consequence of malformed input, apart from "the parser indexed past a buffer it already holds",
+/// which is a bounds bug. Collapsing both into <see cref="ArgumentOutOfRangeException"/> is what
+/// previously made this target blind to the latter.
+/// </remarks>
+internal sealed class BoundedRangeReader(MemoryRangeReader inner) : IRangeReader
+{
+    public Task<long> GetLengthAsync(CancellationToken cancellationToken) => inner.GetLengthAsync(cancellationToken);
+
+    public Task<byte[]> ReadAsync(long offset, int length, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return inner.ReadAsync(offset, length, cancellationToken);
+        }
+        catch (ArgumentOutOfRangeException ex)
+        {
+            throw new InvalidDataException($"Range {offset}..{offset + length} is outside the archive.", ex);
+        }
+    }
 }

--- a/src/winapp-CLI/WinApp.Cli.Fuzz/FuzzableCode.cs
+++ b/src/winapp-CLI/WinApp.Cli.Fuzz/FuzzableCode.cs
@@ -1,4 +1,4 @@
-﻿﻿// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
 // Licensed under the MIT License.
 
 using WinApp.Cli.Helpers;

--- a/src/winapp-CLI/WinApp.Cli.Fuzz/OneFuzzConfig.json
+++ b/src/winapp-CLI/WinApp.Cli.Fuzz/OneFuzzConfig.json
@@ -1,0 +1,75 @@
+{
+  "configVersion": 3,
+  "entries": [
+    {
+      "fuzzer": {
+        "$type": "libfuzzerDotNet",
+        "dll": "WinApp.Cli.Fuzz.dll",
+        "class": "WinApp.Cli.Fuzz.FuzzableCode",
+        "method": "FuzzArchive",
+        "FuzzingTargetBinaries": [
+          "winapp.dll"
+        ]
+      },
+      "adoTemplate": {
+        "org": "microsoft",
+        "project": "OS",
+        "AssignedTo": "alzollin@microsoft.com",
+        "AreaPath": "OS\\Windows Client and Services\\WinPD\\DFX-Developer Fundamentals and Experiences\\Modern Frameworks\\WinApp",
+        "IterationPath": "OS\\Future"
+      },
+      "jobNotificationEmail": "alzollin@microsoft.com",
+      "skip": false,
+      "rebootAfterSetup": false,
+      "oneFuzzJobs": [
+        {
+          "projectName": "WinAppCli",
+          "targetName": "ziprangeextractor-archive",
+          "SeedCorpusContainer": "winappcli-ziprangeextractor-archive-seeds"
+        }
+      ],
+      "jobDependencies": [
+        "WinApp.Cli.Fuzz.dll",
+        "WinApp.Cli.Fuzz.pdb",
+        "winapp.dll",
+        "winapp.pdb"
+      ],
+      "SdlWorkItemId": 63509499
+    },
+    {
+      "fuzzer": {
+        "$type": "libfuzzerDotNet",
+        "dll": "WinApp.Cli.Fuzz.dll",
+        "class": "WinApp.Cli.Fuzz.FuzzableCode",
+        "method": "FuzzParseCentralDirectory",
+        "FuzzingTargetBinaries": [
+          "winapp.dll"
+        ]
+      },
+      "adoTemplate": {
+        "org": "microsoft",
+        "project": "OS",
+        "AssignedTo": "alzollin@microsoft.com",
+        "AreaPath": "OS\\Windows Client and Services\\WinPD\\DFX-Developer Fundamentals and Experiences\\Modern Frameworks\\WinApp",
+        "IterationPath": "OS\\Future"
+      },
+      "jobNotificationEmail": "alzollin@microsoft.com",
+      "skip": false,
+      "rebootAfterSetup": false,
+      "oneFuzzJobs": [
+        {
+          "projectName": "WinAppCli",
+          "targetName": "ziprangeextractor-centraldirectory",
+          "SeedCorpusContainer": "winappcli-ziprangeextractor-cd-seeds"
+        }
+      ],
+      "jobDependencies": [
+        "WinApp.Cli.Fuzz.dll",
+        "WinApp.Cli.Fuzz.pdb",
+        "winapp.dll",
+        "winapp.pdb"
+      ],
+      "SdlWorkItemId": 63509499
+    }
+  ]
+}

--- a/src/winapp-CLI/WinApp.Cli.Fuzz/WinApp.Cli.Fuzz.csproj
+++ b/src/winapp-CLI/WinApp.Cli.Fuzz/WinApp.Cli.Fuzz.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- Matches WinApp.Cli so the harness exercises the shipping assembly itself, which is what
+         OneFuzz attributes the compliance claim to via FuzzingTargetBinaries. -->
+    <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <IsPublishable>false</IsPublishable>
+    <!-- libFuzzer resolves the target by name via reflection, so symbols must ship alongside it. -->
+    <DebugType>portable</DebugType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\WinApp.Cli\WinApp.Cli.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="OneFuzzConfig.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+</Project>

--- a/src/winapp-CLI/WinApp.Cli.Tests/FuzzHarnessTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/FuzzHarnessTests.cs
@@ -76,7 +76,7 @@ public class FuzzHarnessTests
     [TestMethod]
     public void OneFuzzConfig_ReferencesTargetsThatActuallyResolve()
     {
-        var configPath = Path.Combine(AppContext.BaseDirectory, "OneFuzzConfig.json");
+        var configPath = Path.Join(AppContext.BaseDirectory, "OneFuzzConfig.json");
         Assert.IsTrue(File.Exists(configPath),
             $"OneFuzzConfig.json must reach the build output so it lands in the OneFuzz drop directory. Looked in {AppContext.BaseDirectory}.");
 
@@ -136,9 +136,14 @@ public class FuzzHarnessTests
         return reader.ReadAsync(offset, (int)size, CancellationToken.None).GetAwaiter().GetResult();
     }
 
-    private static string Describe(List<Exception> escapes) =>
-        string.Join("; ", escapes.GroupBy(e => e.GetType().Name)
-                                 .Select(g => $"{g.Key} x{g.Count()} (e.g. {g.First().Message})"));
+    private static string Describe(List<Exception> escapes)
+    {
+        var summary = string.Join("; ", escapes.GroupBy(e => e.GetType().Name)
+                                               .Select(g => $"{g.Key} x{g.Count()} (e.g. {g.First().Message})"));
+
+        // The counts say how reachable a gap is; the first stack says where it is.
+        return $"{summary}{Environment.NewLine}First escape:{Environment.NewLine}{escapes[0]}";
+    }
 
     /// <summary>
     /// Writes the seed corpus for both fuzz targets and asserts every seed is structurally valid.
@@ -155,9 +160,9 @@ public class FuzzHarnessTests
     [TestMethod]
     public void GenerateSeedCorpus_ProducesValidSeedsForBothTargets()
     {
-        var root = Path.Combine(AppContext.BaseDirectory, "fuzz-corpus");
-        var archiveDir = Path.Combine(root, "ziprangeextractor-archive");
-        var directoryDir = Path.Combine(root, "ziprangeextractor-centraldirectory");
+        var root = Path.Join(AppContext.BaseDirectory, "fuzz-corpus");
+        var archiveDir = Path.Join(root, "ziprangeextractor-archive");
+        var directoryDir = Path.Join(root, "ziprangeextractor-centraldirectory");
         Directory.CreateDirectory(archiveDir);
         Directory.CreateDirectory(directoryDir);
 
@@ -178,8 +183,8 @@ public class FuzzHarnessTests
             var entries = ParseArchive(bytes);
             Assert.IsTrue(entries.Count > 0, $"Seed '{name}' produced no entries, so it would cover nothing.");
 
-            File.WriteAllBytes(Path.Combine(archiveDir, $"{name}.zip"), bytes);
-            File.WriteAllBytes(Path.Combine(directoryDir, $"{name}.cd.bin"), CarveCentralDirectory(bytes));
+            File.WriteAllBytes(Path.Join(archiveDir, $"{name}.zip"), bytes);
+            File.WriteAllBytes(Path.Join(directoryDir, $"{name}.cd.bin"), CarveCentralDirectory(bytes));
         }
 
         Assert.AreEqual(seeds.Count, Directory.GetFiles(archiveDir).Length);
@@ -259,6 +264,8 @@ public class FuzzHarnessTests
             }
             catch (Exception ex)
             {
+                // Deliberately unfiltered: anything reaching here is something the harness failed to
+                // absorb, and narrowing it would hide the unexpected types this test exists to catch.
                 escapes.Add(ex);
             }
         }

--- a/src/winapp-CLI/WinApp.Cli.Tests/FuzzHarnessTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/FuzzHarnessTests.cs
@@ -1,0 +1,270 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using System.IO.Compression;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using WinApp.Cli.Fuzz;
+
+namespace WinApp.Cli.Tests;
+
+/// <summary>
+/// Guards the OneFuzz harness for <c>ZipRangeExtractor</c>. These tests exist because the harness
+/// contract is only validated by OneFuzz at job-submission time — a renamed method or a typo in
+/// <c>OneFuzzConfig.json</c> would otherwise surface as a failed fuzzing job days later.
+/// </summary>
+[TestClass]
+public class FuzzHarnessTests
+{
+    private const int MutationIterations = 3000;
+
+    /// <summary>Builds an outer bundle that STORES an inner archive, mirroring a real .msixbundle.</summary>
+    private static byte[] BuildNestedBundle()
+    {
+        var inner = BuildZip([("AppxManifest.xml", Encoding.UTF8.GetBytes("<manifest/>"), CompressionLevel.Optimal),
+                              ("arm64/winext/JsProvider.dll", FakePe(), CompressionLevel.Optimal)]);
+
+        return BuildZip([("AppxMetadata/AppxBundleManifest.xml", Encoding.UTF8.GetBytes("<bundle/>"), CompressionLevel.Optimal),
+                         ("windbg_win-arm64.msix", inner, CompressionLevel.NoCompression)]);
+    }
+
+    private static byte[] FakePe()
+    {
+        var payload = new byte[2048];
+        payload[0] = (byte)'M';
+        payload[1] = (byte)'Z';
+        for (var i = 2; i < payload.Length; i++)
+        {
+            payload[i] = (byte)(i % 7);
+        }
+
+        return payload;
+    }
+
+    private static byte[] BuildZip(IEnumerable<(string Name, byte[] Data, CompressionLevel Level)> entries)
+    {
+        using var ms = new MemoryStream();
+        using (var archive = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            foreach (var (name, data, level) in entries)
+            {
+                using var stream = archive.CreateEntry(name, level).Open();
+                stream.Write(data, 0, data.Length);
+            }
+        }
+
+        return ms.ToArray();
+    }
+
+    [TestMethod]
+    public void FuzzTargets_MatchTheSignatureLibFuzzerBindsTo()
+    {
+        foreach (var name in new[] { nameof(FuzzableCode.FuzzArchive), nameof(FuzzableCode.FuzzParseCentralDirectory) })
+        {
+            var method = typeof(FuzzableCode).GetMethod(name, BindingFlags.Public | BindingFlags.Static);
+            Assert.IsNotNull(method, $"{name} must be public and static.");
+            Assert.AreEqual(typeof(void), method.ReturnType, $"{name} must return void.");
+
+            var parameters = method.GetParameters();
+            Assert.AreEqual(1, parameters.Length, $"{name} must take exactly one parameter.");
+            Assert.AreEqual(typeof(ReadOnlySpan<byte>), parameters[0].ParameterType,
+                $"{name} must take ReadOnlySpan<byte>.");
+        }
+    }
+
+    [TestMethod]
+    public void OneFuzzConfig_ReferencesTargetsThatActuallyResolve()
+    {
+        var configPath = Path.Combine(AppContext.BaseDirectory, "OneFuzzConfig.json");
+        Assert.IsTrue(File.Exists(configPath),
+            $"OneFuzzConfig.json must reach the build output so it lands in the OneFuzz drop directory. Looked in {AppContext.BaseDirectory}.");
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(configPath));
+        var entries = doc.RootElement.GetProperty("entries");
+        Assert.IsTrue(entries.GetArrayLength() > 0, "At least one fuzz entry is required.");
+
+        foreach (var entry in entries.EnumerateArray())
+        {
+            var target = entry.GetProperty("fuzzer");
+
+            // $type is the required discriminator in OneFuzzConfig v3; without it the job is rejected.
+            Assert.AreEqual("libfuzzerDotNet", target.GetProperty("$type").GetString());
+
+            var className = target.GetProperty("class").GetString();
+            var methodName = target.GetProperty("method").GetString();
+
+            var type = typeof(FuzzableCode).Assembly.GetType(className!);
+            Assert.IsNotNull(type, $"OneFuzzConfig.json names class '{className}', which does not exist.");
+            Assert.IsNotNull(type.GetMethod(methodName!, BindingFlags.Public | BindingFlags.Static),
+                $"OneFuzzConfig.json names method '{className}.{methodName}', which does not exist.");
+
+            Assert.AreEqual("WinApp.Cli.Fuzz.dll", target.GetProperty("dll").GetString());
+
+            // No compliance claim is generated when FuzzingTargetBinaries is empty, and the SDL work
+            // item link is what ties the resulting claim back to the fuzzing requirement.
+            Assert.IsTrue(target.GetProperty("FuzzingTargetBinaries").GetArrayLength() > 0,
+                "FuzzingTargetBinaries must name the shipping binary, or OneFuzz generates no claim.");
+            Assert.AreEqual(63509499, entry.GetProperty("SdlWorkItemId").GetInt32());
+        }
+    }
+
+    [TestMethod]
+    public void FuzzArchive_MutatedArchives_OnlyThrowExpectedRejections()
+    {
+        var escapes = RunMutationCampaign(FuzzableCode.FuzzArchive, BuildNestedBundle());
+        Assert.AreEqual(0, escapes.Count,
+            $"FuzzArchive let {escapes.Count} unexpected exception(s) escape: {Describe(escapes)}");
+    }
+
+    [TestMethod]
+    public void FuzzParseCentralDirectory_MutatedCentralDirectories_OnlyThrowExpectedRejections()
+    {
+        // Seeded with real central-directory bytes: the parser bails at offset 0 unless the buffer
+        // opens with PK\x01\x02, so seeding it with a whole archive would exercise nothing.
+        var escapes = RunMutationCampaign(FuzzableCode.FuzzParseCentralDirectory, CarveCentralDirectory(BuildNestedBundle()));
+        Assert.AreEqual(0, escapes.Count,
+            $"FuzzParseCentralDirectory let {escapes.Count} unexpected exception(s) escape: {Describe(escapes)}");
+    }
+
+    /// <summary>Extracts just the central-directory bytes from an archive.</summary>
+    private static byte[] CarveCentralDirectory(byte[] archive)
+    {
+        var reader = new WinApp.Cli.Helpers.MemoryRangeReader(archive);
+        var (offset, size) = WinApp.Cli.Helpers.ZipRangeExtractor
+            .FindCentralDirectoryAsync(reader, 0, archive.Length, CancellationToken.None).GetAwaiter().GetResult();
+        return reader.ReadAsync(offset, (int)size, CancellationToken.None).GetAwaiter().GetResult();
+    }
+
+    private static string Describe(List<Exception> escapes) =>
+        string.Join("; ", escapes.GroupBy(e => e.GetType().Name)
+                                 .Select(g => $"{g.Key} x{g.Count()} (e.g. {g.First().Message})"));
+
+    /// <summary>
+    /// Writes the seed corpus for both fuzz targets and asserts every seed is structurally valid.
+    /// </summary>
+    /// <remarks>
+    /// libFuzzer mutates existing inputs; it will not synthesise a valid ZIP64 central directory from
+    /// random bytes, so without seeds a job burns hours at near-zero coverage. Seeds are uploaded to a
+    /// OneFuzz <c>SeedCorpusContainer</c> rather than shipped in the drop directory.
+    /// <para>
+    /// Each seed is round-tripped through the parser here: a corpus that the parser rejects at byte
+    /// zero is worse than no corpus, because the job still looks busy.
+    /// </para>
+    /// </remarks>
+    [TestMethod]
+    public void GenerateSeedCorpus_ProducesValidSeedsForBothTargets()
+    {
+        var root = Path.Combine(AppContext.BaseDirectory, "fuzz-corpus");
+        var archiveDir = Path.Combine(root, "ziprangeextractor-archive");
+        var directoryDir = Path.Combine(root, "ziprangeextractor-centraldirectory");
+        Directory.CreateDirectory(archiveDir);
+        Directory.CreateDirectory(directoryDir);
+
+        var seeds = new Dictionary<string, byte[]>
+        {
+            ["minimal-stored"] = BuildZip([("a.bin", Encoding.UTF8.GetBytes("stored"), CompressionLevel.NoCompression)]),
+            ["deflate"] = BuildZip([("a.bin", FakePe(), CompressionLevel.Optimal)]),
+            ["multi-entry"] = BuildZip([("a.bin", Encoding.UTF8.GetBytes("one"), CompressionLevel.NoCompression),
+                                        ("dir/b.bin", FakePe(), CompressionLevel.Optimal),
+                                        ("dir/sub/c.txt", Encoding.UTF8.GetBytes("three"), CompressionLevel.Optimal)]),
+            ["nested-bundle"] = BuildNestedBundle(),
+            ["archive-comment"] = WithArchiveComment(BuildNestedBundle(), "seed-comment"),
+        };
+
+        foreach (var (name, bytes) in seeds)
+        {
+            // Proves the seed reaches real parsing rather than being rejected immediately.
+            var entries = ParseArchive(bytes);
+            Assert.IsTrue(entries.Count > 0, $"Seed '{name}' produced no entries, so it would cover nothing.");
+
+            File.WriteAllBytes(Path.Combine(archiveDir, $"{name}.zip"), bytes);
+            File.WriteAllBytes(Path.Combine(directoryDir, $"{name}.cd.bin"), CarveCentralDirectory(bytes));
+        }
+
+        Assert.AreEqual(seeds.Count, Directory.GetFiles(archiveDir).Length);
+        Assert.AreEqual(seeds.Count, Directory.GetFiles(directoryDir).Length);
+
+        Console.WriteLine($"Seed corpus written to {root}");
+    }
+
+    private static IReadOnlyList<WinApp.Cli.Helpers.ZipEntry> ParseArchive(byte[] archive)
+    {
+        var reader = new WinApp.Cli.Helpers.MemoryRangeReader(archive);
+        var (offset, size) = WinApp.Cli.Helpers.ZipRangeExtractor
+            .FindCentralDirectoryAsync(reader, 0, archive.Length, CancellationToken.None).GetAwaiter().GetResult();
+        return WinApp.Cli.Helpers.ZipRangeExtractor.ParseCentralDirectory(
+            reader.ReadAsync(offset, (int)size, CancellationToken.None).GetAwaiter().GetResult(), 0);
+    }
+
+    /// <summary>Appends an archive comment, which pushes the EOCD record away from the end of the file.</summary>
+    private static byte[] WithArchiveComment(byte[] archive, string comment)
+    {
+        var commentBytes = Encoding.UTF8.GetBytes(comment);
+        var eocd = LastIndexOfEocd(archive);
+        Assert.IsTrue(eocd >= 0, "Expected a well-formed archive to contain an EOCD record.");
+
+        var result = new byte[archive.Length + commentBytes.Length];
+        archive.CopyTo(result, 0);
+        commentBytes.CopyTo(result, archive.Length);
+        WriteU16(result, eocd + 20, (ushort)commentBytes.Length);
+        return result;
+    }
+
+    private static int LastIndexOfEocd(byte[] buffer)
+    {
+        for (var i = buffer.Length - 4; i >= 0; i--)
+        {
+            if (buffer[i] == 0x50 && buffer[i + 1] == 0x4b && buffer[i + 2] == 0x05 && buffer[i + 3] == 0x06)
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private static void WriteU16(byte[] buffer, int offset, ushort value)
+    {
+        buffer[offset] = (byte)(value & 0xFF);
+        buffer[offset + 1] = (byte)(value >> 8);
+    }
+
+    /// <summary>
+    /// Deterministically mutates a valid nested bundle and drives it through <paramref name="target"/>,
+    /// collecting anything the harness did not absorb. This is a smoke test, not a substitute for a
+    /// OneFuzz run — it has no coverage feedback — but it proves the harness executes and that its
+    /// exception filter matches what the parser actually throws.
+    /// </summary>
+    private static List<Exception> RunMutationCampaign(FuzzTarget target, byte[] seed)
+    {
+        var random = new Random(20260814);
+        var escapes = new List<Exception>();
+
+        for (var i = 0; i < MutationIterations; i++)
+        {
+            var candidate = (byte[])seed.Clone();
+            var mutations = random.Next(1, 12);
+            for (var m = 0; m < mutations; m++)
+            {
+                candidate[random.Next(candidate.Length)] = (byte)random.Next(256);
+            }
+
+            // Truncation is the cheapest way to reach the length-handling paths.
+            var length = random.Next(0, 8) == 0 ? random.Next(0, candidate.Length) : candidate.Length;
+
+            try
+            {
+                target(candidate.AsSpan(0, length));
+            }
+            catch (Exception ex)
+            {
+                escapes.Add(ex);
+            }
+        }
+
+        return escapes;
+    }
+
+    private delegate void FuzzTarget(ReadOnlySpan<byte> input);
+}

--- a/src/winapp-CLI/WinApp.Cli.Tests/FuzzHarnessTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/FuzzHarnessTests.cs
@@ -193,6 +193,7 @@ public class FuzzHarnessTests
             ["archive-comment"] = WithArchiveComment(BuildNestedBundle(), "seed-comment"),
             ["zip64"] = ToZip64(BuildZip([("a.bin", FakePe(), CompressionLevel.Optimal)])),
             ["zip64-nested"] = ToZip64(BuildNestedBundle()),
+            ["zip64-extra"] = WithZip64Extra(BuildZip([("a.bin", FakePe(), CompressionLevel.Optimal)])),
         };
 
         foreach (var (name, bytes) in seeds)
@@ -240,8 +241,8 @@ public class FuzzHarnessTests
     /// </summary>
     /// <remarks>
     /// <see cref="ZipArchive"/> only emits ZIP64 for archives too large to build here, so without this
-    /// the corpus never reaches the ZIP64 locator/record path or the ZIP64 extra field — the parts a
-    /// mutator cannot synthesise on its own.
+    /// the corpus never reaches the ZIP64 locator/record path — something a mutator cannot synthesise
+    /// on its own. See <see cref="WithZip64Extra"/> for the extra-field path.
     /// </remarks>
     private static byte[] ToZip64(byte[] archive)
     {
@@ -277,6 +278,53 @@ public class FuzzHarnessTests
         BinaryPrimitives.WriteUInt32LittleEndian(tail.AsSpan(16), 0xFFFFFFFF);
 
         return [.. body, .. record, .. locator, .. tail];
+    }
+
+    /// <summary>
+    /// Moves a single-entry archive's sizes and local-header offset into a ZIP64 extra field, leaving
+    /// <c>0xFFFFFFFF</c> markers in the fixed fields.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="ToZip64"/> only reaches the locator/record path; the extra field is parsed by
+    /// <c>ApplyZip64Extra</c> on a different code path, and a mutator will not synthesise a well-formed
+    /// one from a 32-bit seed.
+    /// </remarks>
+    private static byte[] WithZip64Extra(byte[] archive)
+    {
+        var eocd = LastIndexOfEocd(archive);
+        Assert.IsTrue(eocd >= 0, "Expected a well-formed archive to contain an EOCD record.");
+
+        var cdSize = (int)BinaryPrimitives.ReadUInt32LittleEndian(archive.AsSpan(eocd + 12));
+        var cdOffset = (int)BinaryPrimitives.ReadUInt32LittleEndian(archive.AsSpan(eocd + 16));
+
+        var header = archive.AsSpan(cdOffset, cdSize).ToArray();
+        var nameLen = BinaryPrimitives.ReadUInt16LittleEndian(header.AsSpan(28));
+        var extraLen = BinaryPrimitives.ReadUInt16LittleEndian(header.AsSpan(30));
+
+        // The parser reads the ZIP64 extra in this fixed order, for whichever fields are marked.
+        var extra = new byte[28];
+        WriteU16(extra, 0, 0x0001);
+        WriteU16(extra, 2, 24);
+        BinaryPrimitives.WriteUInt64LittleEndian(extra.AsSpan(4), BinaryPrimitives.ReadUInt32LittleEndian(header.AsSpan(24)));
+        BinaryPrimitives.WriteUInt64LittleEndian(extra.AsSpan(12), BinaryPrimitives.ReadUInt32LittleEndian(header.AsSpan(20)));
+        BinaryPrimitives.WriteUInt64LittleEndian(extra.AsSpan(20), BinaryPrimitives.ReadUInt32LittleEndian(header.AsSpan(42)));
+
+        BinaryPrimitives.WriteUInt32LittleEndian(header.AsSpan(20), 0xFFFFFFFF);
+        BinaryPrimitives.WriteUInt32LittleEndian(header.AsSpan(24), 0xFFFFFFFF);
+        BinaryPrimitives.WriteUInt32LittleEndian(header.AsSpan(42), 0xFFFFFFFF);
+        WriteU16(header, 30, (ushort)(extraLen + extra.Length));
+
+        var insertAt = 46 + nameLen + extraLen;
+        var newHeader = new byte[header.Length + extra.Length];
+        header.AsSpan(0, insertAt).CopyTo(newHeader);
+        extra.CopyTo(newHeader.AsSpan(insertAt));
+        header.AsSpan(insertAt).CopyTo(newHeader.AsSpan(insertAt + extra.Length));
+
+        var tail = new byte[22];
+        archive.AsSpan(eocd, 22).CopyTo(tail);
+        BinaryPrimitives.WriteUInt32LittleEndian(tail.AsSpan(12), (uint)newHeader.Length);
+
+        return [.. archive.AsSpan(0, cdOffset), .. newHeader, .. tail];
     }
 
     private static int LastIndexOfEocd(byte[] buffer)

--- a/src/winapp-CLI/WinApp.Cli.Tests/FuzzHarnessTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/FuzzHarnessTests.cs
@@ -101,10 +101,13 @@ public class FuzzHarnessTests
 
             Assert.AreEqual("WinApp.Cli.Fuzz.dll", target.GetProperty("dll").GetString());
 
-            // No compliance claim is generated when FuzzingTargetBinaries is empty, and the SDL work
-            // item link is what ties the resulting claim back to the fuzzing requirement.
-            Assert.IsTrue(target.GetProperty("FuzzingTargetBinaries").GetArrayLength() > 0,
-                "FuzzingTargetBinaries must name the shipping binary, or OneFuzz generates no claim.");
+            // The claim is attributed to the binary named here, so it has to be the shipping one:
+            // a non-empty array containing only the harness would still produce no useful claim.
+            var targetBinaries = target.GetProperty("FuzzingTargetBinaries").EnumerateArray()
+                                       .Select(b => b.GetString())
+                                       .ToList();
+            CollectionAssert.Contains(targetBinaries, "winapp.dll",
+                $"FuzzingTargetBinaries must name winapp.dll, or the claim is not attributed to the shipping binary. Found: {string.Join(", ", targetBinaries)}");
             Assert.AreEqual(63509499, entry.GetProperty("SdlWorkItemId").GetInt32());
         }
     }
@@ -168,6 +171,13 @@ public class FuzzHarnessTests
         var root = Path.Join(AppContext.BaseDirectory, "fuzz-corpus");
         var archiveDir = Path.Join(root, "ziprangeextractor-archive");
         var directoryDir = Path.Join(root, "ziprangeextractor-centraldirectory");
+
+        // Stale files from an earlier seed set would survive under bin and break the counts below.
+        if (Directory.Exists(root))
+        {
+            Directory.Delete(root, recursive: true);
+        }
+
         Directory.CreateDirectory(archiveDir);
         Directory.CreateDirectory(directoryDir);
 

--- a/src/winapp-CLI/WinApp.Cli.Tests/FuzzHarnessTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/FuzzHarnessTests.cs
@@ -138,6 +138,11 @@ public class FuzzHarnessTests
 
     private static string Describe(List<Exception> escapes)
     {
+        if (escapes.Count == 0)
+        {
+            return "no escapes";
+        }
+
         var summary = string.Join("; ", escapes.GroupBy(e => e.GetType().Name)
                                                .Select(g => $"{g.Key} x{g.Count()} (e.g. {g.First().Message})"));
 

--- a/src/winapp-CLI/WinApp.Cli.Tests/FuzzHarnessTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/FuzzHarnessTests.cs
@@ -262,10 +262,11 @@ public class FuzzHarnessTests
             {
                 target(candidate.AsSpan(0, length));
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not OutOfMemoryException)
             {
-                // Deliberately unfiltered: anything reaching here is something the harness failed to
+                // Otherwise unfiltered: anything reaching here is something the harness failed to
                 // absorb, and narrowing it would hide the unexpected types this test exists to catch.
+                // OOM is let through instead, since looping on to allocate more after it is unsound.
                 escapes.Add(ex);
             }
         }

--- a/src/winapp-CLI/WinApp.Cli.Tests/FuzzHarnessTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/FuzzHarnessTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Buffers.Binary;
 using System.IO.Compression;
 using System.Reflection;
 using System.Text;
@@ -190,6 +191,8 @@ public class FuzzHarnessTests
                                         ("dir/sub/c.txt", Encoding.UTF8.GetBytes("three"), CompressionLevel.Optimal)]),
             ["nested-bundle"] = BuildNestedBundle(),
             ["archive-comment"] = WithArchiveComment(BuildNestedBundle(), "seed-comment"),
+            ["zip64"] = ToZip64(BuildZip([("a.bin", FakePe(), CompressionLevel.Optimal)])),
+            ["zip64-nested"] = ToZip64(BuildNestedBundle()),
         };
 
         foreach (var (name, bytes) in seeds)
@@ -229,6 +232,51 @@ public class FuzzHarnessTests
         commentBytes.CopyTo(result, archive.Length);
         WriteU16(result, eocd + 20, (ushort)commentBytes.Length);
         return result;
+    }
+
+    /// <summary>
+    /// Rewrites an archive's tail into ZIP64 form: an EOCD full of markers, preceded by a ZIP64
+    /// locator and record carrying the real values.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="ZipArchive"/> only emits ZIP64 for archives too large to build here, so without this
+    /// the corpus never reaches the ZIP64 locator/record path or the ZIP64 extra field — the parts a
+    /// mutator cannot synthesise on its own.
+    /// </remarks>
+    private static byte[] ToZip64(byte[] archive)
+    {
+        var eocd = LastIndexOfEocd(archive);
+        Assert.IsTrue(eocd >= 0, "Expected a well-formed archive to contain an EOCD record.");
+
+        var count = BinaryPrimitives.ReadUInt16LittleEndian(archive.AsSpan(eocd + 10));
+        var cdSize = BinaryPrimitives.ReadUInt32LittleEndian(archive.AsSpan(eocd + 12));
+        var cdOffset = BinaryPrimitives.ReadUInt32LittleEndian(archive.AsSpan(eocd + 16));
+
+        var body = archive.AsSpan(0, eocd).ToArray();
+
+        var record = new byte[56];
+        BinaryPrimitives.WriteUInt32LittleEndian(record.AsSpan(0), 0x06064b50);
+        BinaryPrimitives.WriteUInt64LittleEndian(record.AsSpan(4), 44);   // bytes following this field
+        WriteU16(record, 12, 45);
+        WriteU16(record, 14, 45);
+        BinaryPrimitives.WriteUInt64LittleEndian(record.AsSpan(24), count);
+        BinaryPrimitives.WriteUInt64LittleEndian(record.AsSpan(32), count);
+        BinaryPrimitives.WriteUInt64LittleEndian(record.AsSpan(40), cdSize);
+        BinaryPrimitives.WriteUInt64LittleEndian(record.AsSpan(48), cdOffset);
+
+        var locator = new byte[20];
+        BinaryPrimitives.WriteUInt32LittleEndian(locator.AsSpan(0), 0x07064b50);
+        BinaryPrimitives.WriteUInt64LittleEndian(locator.AsSpan(8), (ulong)body.Length);
+        BinaryPrimitives.WriteUInt32LittleEndian(locator.AsSpan(16), 1);
+
+        var tail = new byte[22];
+        BinaryPrimitives.WriteUInt32LittleEndian(tail.AsSpan(0), 0x06054b50);
+        WriteU16(tail, 8, 0xFFFF);
+        WriteU16(tail, 10, 0xFFFF);
+        BinaryPrimitives.WriteUInt32LittleEndian(tail.AsSpan(12), 0xFFFFFFFF);
+        BinaryPrimitives.WriteUInt32LittleEndian(tail.AsSpan(16), 0xFFFFFFFF);
+
+        return [.. body, .. record, .. locator, .. tail];
     }
 
     private static int LastIndexOfEocd(byte[] buffer)

--- a/src/winapp-CLI/WinApp.Cli.Tests/WinApp.Cli.Tests.csproj
+++ b/src/winapp-CLI/WinApp.Cli.Tests/WinApp.Cli.Tests.csproj
@@ -41,6 +41,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\WinApp.Cli\WinApp.Cli.csproj" />
+    <ProjectReference Include="..\WinApp.Cli.Fuzz\WinApp.Cli.Fuzz.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/winapp-CLI/WinApp.Cli.Tests/ZipRangeExtractorTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/ZipRangeExtractorTests.cs
@@ -232,6 +232,8 @@ public class ZipRangeExtractorTests
     [DataRow((ushort)0, 0u, 0u, DisplayName = "zeroed fake record")]
     [DataRow((ushort)1, 1u, 0u, DisplayName = "fake record pointing at offset zero")]
     [DataRow((ushort)1, 64u, 8u, DisplayName = "fake record pointing into file data")]
+    [DataRow((ushort)1, 4u, 0u, DisplayName = "fake record with a header-sized truncated directory")]
+    [DataRow((ushort)0xFFFF, 0xFFFFFFFFu, 0xFFFFFFFFu, DisplayName = "fake record claiming ZIP64")]
     public async Task FindCentralDirectory_FakeEocdInComment_StillFindsTheRealDirectory(
         ushort fakeCount, uint fakeSize, uint fakeOffset)
     {

--- a/src/winapp-CLI/WinApp.Cli.Tests/ZipRangeExtractorTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/ZipRangeExtractorTests.cs
@@ -186,6 +186,24 @@ public class ZipRangeExtractorTests
     }
 
     [TestMethod]
+    [DataRow(0, DisplayName = "signature is the whole tail")]
+    [DataRow(8, DisplayName = "signature 8 bytes from the end")]
+    [DataRow(17, DisplayName = "one byte short of a full record")]
+    public async Task FindCentralDirectory_TruncatedEocdRecord_ThrowsInvalidData(int trailingBytes)
+    {
+        // The EOCD signature can legitimately appear within the final 21 bytes, leaving the fixed
+        // fields past the end of the buffer. Reading them unguarded is a bounds gap, not a rejection.
+        var archive = new byte[64 + trailingBytes];
+        WriteU32(archive, 64 - 4, 0x06054b50);
+
+        var reader = new MemoryRangeReader(archive);
+
+        var ex = await Assert.ThrowsExactlyAsync<InvalidDataException>(async () =>
+            await ZipRangeExtractor.FindCentralDirectoryAsync(reader, 0, archive.Length, CancellationToken.None));
+        StringAssert.Contains(ex.Message, "truncated");
+    }
+
+    [TestMethod]
     public void ParseCentralDirectory_Zip64ExtraField_Applies64BitValues()
     {
         const long compressed = 0x1_0000_0001;   // > 4 GiB, forcing the 0xFFFFFFFF marker

--- a/src/winapp-CLI/WinApp.Cli.Tests/ZipRangeExtractorTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/ZipRangeExtractorTests.cs
@@ -229,6 +229,31 @@ public class ZipRangeExtractorTests
     }
 
     [TestMethod]
+    public async Task FindCentralDirectory_FakeEmptyEocdInComment_StillFindsTheRealDirectory()
+    {
+        // A whole zeroed EOCD hidden in the comment satisfies the comment-length rule, so a naive
+        // backward scan returns it and the archive parses as empty.
+        var archive = BuildZip([("a.bin", Encoding.UTF8.GetBytes("stored"), CompressionLevel.NoCompression)]);
+
+        var fake = new byte[22];
+        WriteU32(fake, 0, 0x06054b50);
+
+        var withComment = new byte[archive.Length + fake.Length];
+        Array.Copy(archive, withComment, archive.Length);
+        Array.Copy(fake, 0, withComment, archive.Length, fake.Length);
+        WriteU16(withComment, archive.Length - 2, (ushort)fake.Length);
+
+        var reader = new MemoryRangeReader(withComment);
+        var (offset, size) = await ZipRangeExtractor.FindCentralDirectoryAsync(
+            reader, 0, withComment.Length, CancellationToken.None);
+
+        var entries = ZipRangeExtractor.ParseCentralDirectory(
+            await reader.ReadAsync(offset, (int)size, CancellationToken.None), 0);
+        Assert.AreEqual(1, entries.Count, "The real directory should win over a zeroed record in the comment.");
+        Assert.AreEqual("a.bin", entries[0].Name);
+    }
+
+    [TestMethod]
     public void ParseCentralDirectory_Zip64ExtraField_Applies64BitValues()
     {
         const long compressed = 0x1_0000_0001;   // > 4 GiB, forcing the 0xFFFFFFFF marker

--- a/src/winapp-CLI/WinApp.Cli.Tests/ZipRangeExtractorTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/ZipRangeExtractorTests.cs
@@ -191,8 +191,8 @@ public class ZipRangeExtractorTests
     [DataRow(17, DisplayName = "one byte short of a full record")]
     public async Task FindCentralDirectory_TruncatedEocdRecord_ThrowsInvalidData(int trailingBytes)
     {
-        // The EOCD signature can legitimately appear within the final 21 bytes, leaving the fixed
-        // fields past the end of the buffer. Reading them unguarded is a bounds gap, not a rejection.
+        // The EOCD signature can sit within the final 21 bytes, leaving the fixed fields past the end
+        // of the buffer. Reading them unguarded is a bounds gap, not a rejection.
         var archive = new byte[64 + trailingBytes];
         WriteU32(archive, 64 - 4, 0x06054b50);
 
@@ -200,7 +200,32 @@ public class ZipRangeExtractorTests
 
         var ex = await Assert.ThrowsExactlyAsync<InvalidDataException>(async () =>
             await ZipRangeExtractor.FindCentralDirectoryAsync(reader, 0, archive.Length, CancellationToken.None));
-        StringAssert.Contains(ex.Message, "truncated");
+        StringAssert.Contains(ex.Message, "not found");
+    }
+
+    [TestMethod]
+    public async Task FindCentralDirectory_ArchiveCommentContainingEocdSignature_StillParses()
+    {
+        // A ZIP comment may legally contain PK\x05\x06. Taking the *last* signature match lands
+        // inside the comment rather than on the real record.
+        var archive = BuildZip([("a.bin", Encoding.UTF8.GetBytes("stored"), CompressionLevel.NoCompression)]);
+        var comment = new byte[] { 0x50, 0x4b, 0x05, 0x06 };
+
+        var withComment = new byte[archive.Length + comment.Length];
+        Array.Copy(archive, withComment, archive.Length);
+        Array.Copy(comment, 0, withComment, archive.Length, comment.Length);
+
+        // The EOCD comment-length field is the last two bytes of the fixed record.
+        WriteU16(withComment, archive.Length - 2, (ushort)comment.Length);
+
+        var reader = new MemoryRangeReader(withComment);
+        var (offset, size) = await ZipRangeExtractor.FindCentralDirectoryAsync(
+            reader, 0, withComment.Length, CancellationToken.None);
+
+        var entries = ZipRangeExtractor.ParseCentralDirectory(
+            await reader.ReadAsync(offset, (int)size, CancellationToken.None), 0);
+        Assert.AreEqual(1, entries.Count);
+        Assert.AreEqual("a.bin", entries[0].Name);
     }
 
     [TestMethod]

--- a/src/winapp-CLI/WinApp.Cli.Tests/ZipRangeExtractorTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/ZipRangeExtractorTests.cs
@@ -340,6 +340,39 @@ public class ZipRangeExtractorTests
         Assert.IsTrue(reader.Reads <= 12, $"Expected the scan to stop probing, but it issued {reader.Reads} reads.");
     }
 
+    [TestMethod]
+    public async Task FindCentralDirectory_CommentFullOfZip64ShapedRecords_StillParses()
+    {
+        // These resolve nothing and cost no reads, so they must not consume the probe budget - doing so
+        // would let comment bytes alone push the scan past the real record.
+        var archive = BuildZip([("a.bin", Encoding.UTF8.GetBytes("stored"), CompressionLevel.NoCompression)]);
+
+        const int fakes = 12;
+        var comment = new byte[fakes * 22];
+        var data = new byte[archive.Length + comment.Length];
+        archive.CopyTo(data, 0);
+        WriteU16(data, archive.Length - 2, (ushort)comment.Length);
+
+        for (var n = 0; n < fakes; n++)
+        {
+            var pos = archive.Length + (n * 22);
+            WriteU32(data, pos, 0x06054b50);
+            WriteU16(data, pos + 10, 0xFFFF);       // ZIP64 markers, with no locator anywhere
+            WriteU32(data, pos + 12, 0xFFFFFFFF);
+            WriteU32(data, pos + 16, 0xFFFFFFFF);
+            WriteU16(data, pos + 20, (ushort)(data.Length - pos - 22));
+        }
+
+        var reader = new MemoryRangeReader(data);
+        var (offset, size) = await ZipRangeExtractor.FindCentralDirectoryAsync(
+            reader, 0, data.Length, CancellationToken.None);
+
+        var entries = ZipRangeExtractor.ParseCentralDirectory(
+            await reader.ReadAsync(offset, (int)size, CancellationToken.None), 0);
+        Assert.AreEqual(1, entries.Count);
+        Assert.AreEqual("a.bin", entries[0].Name);
+    }
+
     private sealed class CountingRangeReader(byte[] data) : IRangeReader
     {
         private readonly MemoryRangeReader _inner = new(data);

--- a/src/winapp-CLI/WinApp.Cli.Tests/ZipRangeExtractorTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/ZipRangeExtractorTests.cs
@@ -131,13 +131,14 @@ public class ZipRangeExtractorTests
     [TestMethod]
     public async Task FindCentralDirectory_Zip64Eocd_ResolvesOffsetAndSize()
     {
-        // Hand-build a ZIP64 tail: [cd placeholder][zip64 eocd][zip64 locator][eocd], because
+        // Hand-build a ZIP64 tail: [cd][zip64 eocd][zip64 locator][eocd], because
         // System.IO.Compression only emits ZIP64 for archives too large to construct in a unit test.
         const long cdOffset = 0;
-        const long cdSize = 10;
+        var directory = MinimalCentralDirectory();
+        long cdSize = directory.Length;
         var buf = new List<byte>();
 
-        buf.AddRange(new byte[cdSize]);                       // central-directory placeholder
+        buf.AddRange(directory);
         var recordRelative = buf.Count;                       // offset of the ZIP64 EOCD record
 
         var record = new byte[56];
@@ -311,6 +312,17 @@ public class ZipRangeExtractorTests
         Assert.AreEqual(1000 + localOffset, entry.LocalHeaderOffset, "64-bit local-header offset must be applied then rebased.");
     }
 
+    /// <summary>One stored, empty entry: the smallest thing that is recognisably a central directory.</summary>
+    private static byte[] MinimalCentralDirectory()
+    {
+        var name = Encoding.UTF8.GetBytes("a.bin");
+        var header = new byte[46 + name.Length];
+        WriteU32(header, 0, 0x02014b50);
+        WriteU16(header, 28, (ushort)name.Length);
+        name.CopyTo(header, 46);
+        return header;
+    }
+
     private static void WriteU16(byte[] buffer, int offset, ushort value) =>
         System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian(buffer.AsSpan(offset), value);
 
@@ -396,23 +408,25 @@ public class ZipRangeExtractorTests
     [TestMethod]
     public async Task FindCentralDirectory_Zip64RecordOutsideTailWindow_ReadsViaRanged()
     {
-        // Archive larger than the EOCD search window, with the ZIP64 EOCD record near the start so
-        // it falls outside the trailing tail read and must be fetched with a separate ranged read.
+        // Archive larger than the EOCD search window, with the ZIP64 EOCD record right after the
+        // directory so it falls outside the trailing tail read and must be fetched with a ranged read.
         const long cdOffset = 0;
-        const long cdSize = 10;
+        var directory = MinimalCentralDirectory();
+        long cdSize = directory.Length;
         const int total = 66000; // > MaxEocdSearch (65557)
         var data = new byte[total];
+        directory.CopyTo(data, (int)cdOffset);
 
         var record = new byte[56];
         WriteU32(record, 0, 0x06064b50);
         WriteU64(record, 40, unchecked((ulong)cdSize));
         WriteU64(record, 48, unchecked((ulong)cdOffset));
-        record.CopyTo(data, 0); // record at offset 0 (outside the tail window)
+        record.CopyTo(data, (int)cdSize); // record follows the directory, outside the tail window
 
         var locatorOffset = total - 22 - 20;
         var locator = new byte[20];
         WriteU32(locator, 0, 0x07064b50);
-        WriteU64(locator, 8, 0); // relative offset of the ZIP64 EOCD record = 0
+        WriteU64(locator, 8, (ulong)cdSize); // relative offset of the ZIP64 EOCD record
         locator.CopyTo(data, locatorOffset);
 
         var eocd = new byte[22];

--- a/src/winapp-CLI/WinApp.Cli.Tests/ZipRangeExtractorTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/ZipRangeExtractorTests.cs
@@ -320,14 +320,14 @@ public class ZipRangeExtractorTests
         const int total = 200_000; // larger than the tail window, so candidate heads fall outside it
         var data = new byte[total];
 
-        // Fill the tail with back-to-back candidates whose comment lengths all run to the end and whose
-        // directories claim to live at the front of the archive, outside the tail.
+        // Fill the tail with back-to-back candidates whose comment lengths all run to the end. Their
+        // directories start at offset 0 - outside the tail - so confirming each one costs a real read.
         for (var pos = total - 22; pos >= total - 20_000; pos -= 22)
         {
             WriteU32(data, pos, 0x06054b50);
             WriteU16(data, pos + 10, 1);
-            WriteU32(data, pos + 12, 46);
-            WriteU32(data, pos + 16, (uint)(pos - 46));
+            WriteU32(data, pos + 12, (uint)pos);   // size: directory spans from 0 up to this record
+            WriteU32(data, pos + 16, 0);           // offset: front of the archive, outside the tail
             WriteU16(data, pos + 20, (ushort)(total - pos - 22));
         }
 

--- a/src/winapp-CLI/WinApp.Cli.Tests/ZipRangeExtractorTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/ZipRangeExtractorTests.cs
@@ -312,6 +312,49 @@ public class ZipRangeExtractorTests
         Assert.AreEqual(1000 + localOffset, entry.LocalHeaderOffset, "64-bit local-header offset must be applied then rebased.");
     }
 
+    [TestMethod]
+    public async Task FindCentralDirectory_CommentPackedWithCandidates_DoesNotProbeUnbounded()
+    {
+        // A 64 KiB comment can hold thousands of EOCD-shaped candidates. Each one that points outside
+        // the tail costs a round trip on the HTTP reader, so the scan has to stop probing.
+        const int total = 200_000; // larger than the tail window, so candidate heads fall outside it
+        var data = new byte[total];
+
+        // Fill the tail with back-to-back candidates whose comment lengths all run to the end and whose
+        // directories claim to live at the front of the archive, outside the tail.
+        for (var pos = total - 22; pos >= total - 20_000; pos -= 22)
+        {
+            WriteU32(data, pos, 0x06054b50);
+            WriteU16(data, pos + 10, 1);
+            WriteU32(data, pos + 12, 46);
+            WriteU32(data, pos + 16, (uint)(pos - 46));
+            WriteU16(data, pos + 20, (ushort)(total - pos - 22));
+        }
+
+        var reader = new CountingRangeReader(data);
+
+        await Assert.ThrowsExactlyAsync<InvalidDataException>(async () =>
+            await ZipRangeExtractor.FindCentralDirectoryAsync(reader, 0, data.Length, CancellationToken.None));
+
+        // One tail read plus a bounded number of candidate probes.
+        Assert.IsTrue(reader.Reads <= 12, $"Expected the scan to stop probing, but it issued {reader.Reads} reads.");
+    }
+
+    private sealed class CountingRangeReader(byte[] data) : IRangeReader
+    {
+        private readonly MemoryRangeReader _inner = new(data);
+
+        public int Reads { get; private set; }
+
+        public Task<long> GetLengthAsync(CancellationToken cancellationToken) => _inner.GetLengthAsync(cancellationToken);
+
+        public Task<byte[]> ReadAsync(long offset, int length, CancellationToken cancellationToken)
+        {
+            Reads++;
+            return _inner.ReadAsync(offset, length, cancellationToken);
+        }
+    }
+
     /// <summary>One stored, empty entry: the smallest thing that is recognisably a central directory.</summary>
     private static byte[] MinimalCentralDirectory()
     {

--- a/src/winapp-CLI/WinApp.Cli.Tests/ZipRangeExtractorTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/ZipRangeExtractorTests.cs
@@ -168,6 +168,24 @@ public class ZipRangeExtractorTests
     }
 
     [TestMethod]
+    [DataRow(28, DisplayName = "oversized name length")]
+    [DataRow(30, DisplayName = "oversized extra length")]
+    [DataRow(32, DisplayName = "oversized comment length")]
+    public void ParseCentralDirectory_LengthsPastEndOfDirectory_ThrowsInvalidData(int lengthFieldOffset)
+    {
+        // Found by the OneFuzz harness: these three 16-bit lengths are attacker-controlled and were
+        // sliced on without validation, surfacing as ArgumentOutOfRangeException rather than a
+        // rejected archive.
+        var header = new byte[46];
+        WriteU32(header, 0, 0x02014b50);
+        WriteU16(header, lengthFieldOffset, 0xFFFF);
+
+        var ex = Assert.ThrowsExactly<InvalidDataException>(
+            () => ZipRangeExtractor.ParseCentralDirectory(header, archiveBase: 0));
+        StringAssert.Contains(ex.Message, "extends past");
+    }
+
+    [TestMethod]
     public void ParseCentralDirectory_Zip64ExtraField_Applies64BitValues()
     {
         const long compressed = 0x1_0000_0001;   // > 4 GiB, forcing the 0xFFFFFFFF marker

--- a/src/winapp-CLI/WinApp.Cli.Tests/ZipRangeExtractorTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/ZipRangeExtractorTests.cs
@@ -229,14 +229,21 @@ public class ZipRangeExtractorTests
     }
 
     [TestMethod]
-    public async Task FindCentralDirectory_FakeEmptyEocdInComment_StillFindsTheRealDirectory()
+    [DataRow((ushort)0, 0u, 0u, DisplayName = "zeroed fake record")]
+    [DataRow((ushort)1, 1u, 0u, DisplayName = "fake record pointing at offset zero")]
+    [DataRow((ushort)1, 64u, 8u, DisplayName = "fake record pointing into file data")]
+    public async Task FindCentralDirectory_FakeEocdInComment_StillFindsTheRealDirectory(
+        ushort fakeCount, uint fakeSize, uint fakeOffset)
     {
-        // A whole zeroed EOCD hidden in the comment satisfies the comment-length rule, so a naive
-        // backward scan returns it and the archive parses as empty.
+        // A whole EOCD hidden in the comment satisfies the comment-length rule, so a scan that trusts
+        // the last match returns it and the archive parses as empty or from attacker-chosen offsets.
         var archive = BuildZip([("a.bin", Encoding.UTF8.GetBytes("stored"), CompressionLevel.NoCompression)]);
 
         var fake = new byte[22];
         WriteU32(fake, 0, 0x06054b50);
+        WriteU16(fake, 10, fakeCount);
+        WriteU32(fake, 12, fakeSize);
+        WriteU32(fake, 16, fakeOffset);
 
         var withComment = new byte[archive.Length + fake.Length];
         Array.Copy(archive, withComment, archive.Length);
@@ -249,8 +256,18 @@ public class ZipRangeExtractorTests
 
         var entries = ZipRangeExtractor.ParseCentralDirectory(
             await reader.ReadAsync(offset, (int)size, CancellationToken.None), 0);
-        Assert.AreEqual(1, entries.Count, "The real directory should win over a zeroed record in the comment.");
+        Assert.AreEqual(1, entries.Count, "The real directory should win over a record planted in the comment.");
         Assert.AreEqual("a.bin", entries[0].Name);
+    }
+
+    [TestMethod]
+    public async Task MemoryRangeReader_OffsetNearLongMaxValue_ThrowsWithoutOverflowing()
+    {
+        // offset + length overflows to a negative number, which would slip past a naive guard.
+        var reader = new MemoryRangeReader(new byte[16]);
+
+        await Assert.ThrowsExactlyAsync<ArgumentOutOfRangeException>(async () =>
+            await reader.ReadAsync(long.MaxValue - 1, 8, CancellationToken.None));
     }
 
     [TestMethod]

--- a/src/winapp-CLI/WinApp.Cli/Helpers/ZipRangeExtractor.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/ZipRangeExtractor.cs
@@ -40,6 +40,7 @@ internal static class ZipRangeExtractor
     private const uint Zip64EocdSignature = 0x06064b50;  // PK\x06\x06
     private const uint CentralHeaderSignature = 0x02014b50; // PK\x01\x02
     private const int MaxEocdSearch = 65557; // 22-byte EOCD + 64KiB max comment
+    private const int MinEocdSize = 22;      // signature through the comment-length field
     private const uint Zip64Marker = 0xFFFFFFFF;
     private const ushort Zip64ExtraId = 0x0001;
 
@@ -59,6 +60,13 @@ internal static class ZipRangeExtractor
         if (eocd < 0)
         {
             throw new InvalidDataException("End-of-central-directory record not found.");
+        }
+
+        // The signature can appear in the last 21 bytes, leaving the fixed fields below truncated.
+        if (eocd + MinEocdSize > tail.Length)
+        {
+            throw new InvalidDataException(
+                $"End-of-central-directory record at offset {eocd} is truncated: {tail.Length - eocd} of {MinEocdSize} bytes present.");
         }
 
         var count = BinaryPrimitives.ReadUInt16LittleEndian(tail.AsSpan(eocd + 10));

--- a/src/winapp-CLI/WinApp.Cli/Helpers/ZipRangeExtractor.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/ZipRangeExtractor.cs
@@ -79,8 +79,14 @@ internal static class ZipRangeExtractor
                 }
                 catch (InvalidDataException)
                 {
-                    // A marker-bearing record planted in a comment has no usable locator or record;
-                    // keep scanning rather than failing the whole archive.
+                    // A marker-bearing record planted in a comment has no usable locator or record.
+                    // Resolving it may already have cost a locator scan and a read, so it is charged
+                    // against the same budget rather than letting failures loop for free.
+                    if (++probes >= MaxDirectoryProbes)
+                    {
+                        break;
+                    }
+
                     continue;
                 }
 

--- a/src/winapp-CLI/WinApp.Cli/Helpers/ZipRangeExtractor.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/ZipRangeExtractor.cs
@@ -41,6 +41,7 @@ internal static class ZipRangeExtractor
     private const uint CentralHeaderSignature = 0x02014b50; // PK\x01\x02
     private const int MaxEocdSearch = 65557; // 22-byte EOCD + 64KiB max comment
     private const int MinEocdSize = 22;      // signature through the comment-length field
+    private const int MinCentralHeaderSize = 46; // fixed part of one central-directory header
     private const uint Zip64Marker = 0xFFFFFFFF;
     private const ushort Zip64ExtraId = 0x0001;
 
@@ -68,9 +69,20 @@ internal static class ZipRangeExtractor
 
             if (cdOffset == Zip64Marker || cdSize == Zip64Marker || count == 0xFFFF)
             {
-                // The ZIP64 record carries its own signature, so that path rejects a fake for us.
-                (cdOffset, cdSize) = await ReadZip64DirectoryAsync(
-                    reader, archiveBase, tail, tailStart, eocd, cancellationToken);
+                try
+                {
+                    // Forging this means also forging a locator and a signed ZIP64 record, so the
+                    // record's own signature check is the gate here.
+                    (cdOffset, cdSize) = await ReadZip64DirectoryAsync(
+                        reader, archiveBase, tail, tailStart, eocd, cancellationToken);
+                }
+                catch (InvalidDataException)
+                {
+                    // A marker-bearing record planted in a comment has no usable locator or record;
+                    // keep scanning rather than failing the whole archive.
+                    continue;
+                }
+
                 return (archiveBase + cdOffset, cdSize);
             }
 
@@ -82,7 +94,8 @@ internal static class ZipRangeExtractor
                 continue;
             }
 
-            if (await IsCentralDirectoryAsync(reader, archiveBase, archiveSize, cdOffset, cdSize, cancellationToken))
+            // In a ZIP32 archive the directory runs right up to the record describing it.
+            if (await IsCentralDirectoryAsync(reader, archiveBase, archiveSize, cdOffset, cdSize, tailStart + eocd, cancellationToken))
             {
                 return (archiveBase + cdOffset, cdSize);
             }
@@ -92,13 +105,20 @@ internal static class ZipRangeExtractor
     }
 
     /// <summary>
-    /// Confirms a candidate's declared central directory is inside the archive and actually starts
-    /// with a central-directory header.
+    /// Confirms a candidate's declared central directory is inside the archive, is large enough to hold
+    /// a header, and actually starts with one.
     /// </summary>
     private static async Task<bool> IsCentralDirectoryAsync(
-        IRangeReader reader, long archiveBase, long archiveSize, long cdOffset, long cdSize, CancellationToken cancellationToken)
+        IRangeReader reader, long archiveBase, long archiveSize, long cdOffset, long cdSize, long mustEndAt, CancellationToken cancellationToken)
     {
-        if (cdOffset < 0 || cdSize < 4 || cdOffset > archiveSize - cdSize)
+        // Anything shorter than one header cannot be the directory a non-empty record claims, which is
+        // what a comment-planted record uses to pass a signature-only check.
+        if (cdOffset < 0 || cdSize < MinCentralHeaderSize || cdOffset > archiveSize - cdSize)
+        {
+            return false;
+        }
+
+        if (archiveBase + cdOffset + cdSize != mustEndAt)
         {
             return false;
         }

--- a/src/winapp-CLI/WinApp.Cli/Helpers/ZipRangeExtractor.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/ZipRangeExtractor.cs
@@ -225,6 +225,8 @@ internal static class ZipRangeExtractor
     /// </remarks>
     private static int FindEocd(ReadOnlySpan<byte> tail)
     {
+        var emptyCandidate = -1;
+
         for (var i = tail.Length - MinEocdSize; i >= 0; i--)
         {
             if (BinaryPrimitives.ReadUInt32LittleEndian(tail.Slice(i)) != EocdSignature)
@@ -233,13 +235,30 @@ internal static class ZipRangeExtractor
             }
 
             var commentLen = BinaryPrimitives.ReadUInt16LittleEndian(tail.Slice(i + 20));
-            if (i + MinEocdSize + commentLen == tail.Length)
+            if (i + MinEocdSize + commentLen != tail.Length)
             {
-                return i;
+                continue;
             }
+
+            // A zeroed record sitting in a real archive's comment satisfies everything above and would
+            // otherwise win, making a non-empty archive parse as empty. Prefer a record that declares a
+            // directory, and fall back to the empty one only if there is nothing better.
+            var count = BinaryPrimitives.ReadUInt16LittleEndian(tail.Slice(i + 10));
+            var declaredSize = BinaryPrimitives.ReadUInt32LittleEndian(tail.Slice(i + 12));
+            if (count == 0 && declaredSize == 0)
+            {
+                if (emptyCandidate < 0)
+                {
+                    emptyCandidate = i;
+                }
+
+                continue;
+            }
+
+            return i;
         }
 
-        return -1;
+        return emptyCandidate;
     }
 
     private static int LastIndexOfSignature(ReadOnlySpan<byte> buffer, uint signature)

--- a/src/winapp-CLI/WinApp.Cli/Helpers/ZipRangeExtractor.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/ZipRangeExtractor.cs
@@ -56,23 +56,55 @@ internal static class ZipRangeExtractor
         var tailStart = archiveBase + archiveSize - tailLen;
         var tail = await reader.ReadAsync(tailStart, tailLen, cancellationToken);
 
-        var eocd = FindEocd(tail);
-        if (eocd < 0)
+        // A legal comment can hold a complete fake record, so a candidate is only accepted once the
+        // directory it points at is confirmed to be one.
+        (long Offset, long Size)? emptyFallback = null;
+
+        for (var eocd = NextEocdCandidate(tail, tail.Length); eocd >= 0; eocd = NextEocdCandidate(tail, eocd))
         {
-            throw new InvalidDataException("End-of-central-directory record not found.");
+            var count = BinaryPrimitives.ReadUInt16LittleEndian(tail.AsSpan(eocd + 10));
+            long cdSize = BinaryPrimitives.ReadUInt32LittleEndian(tail.AsSpan(eocd + 12));
+            long cdOffset = BinaryPrimitives.ReadUInt32LittleEndian(tail.AsSpan(eocd + 16));
+
+            if (cdOffset == Zip64Marker || cdSize == Zip64Marker || count == 0xFFFF)
+            {
+                // The ZIP64 record carries its own signature, so that path rejects a fake for us.
+                (cdOffset, cdSize) = await ReadZip64DirectoryAsync(
+                    reader, archiveBase, tail, tailStart, eocd, cancellationToken);
+                return (archiveBase + cdOffset, cdSize);
+            }
+
+            // A record declaring no directory has nothing to confirm, and a zeroed record planted in a
+            // comment looks exactly like one. Keep it only as a fallback for a genuinely empty archive.
+            if (count == 0 && cdSize == 0)
+            {
+                emptyFallback ??= (archiveBase + cdOffset, 0);
+                continue;
+            }
+
+            if (await IsCentralDirectoryAsync(reader, archiveBase, archiveSize, cdOffset, cdSize, cancellationToken))
+            {
+                return (archiveBase + cdOffset, cdSize);
+            }
         }
 
-        var count = BinaryPrimitives.ReadUInt16LittleEndian(tail.AsSpan(eocd + 10));
-        long cdSize = BinaryPrimitives.ReadUInt32LittleEndian(tail.AsSpan(eocd + 12));
-        long cdOffset = BinaryPrimitives.ReadUInt32LittleEndian(tail.AsSpan(eocd + 16));
+        return emptyFallback ?? throw new InvalidDataException("End-of-central-directory record not found.");
+    }
 
-        if (cdOffset == Zip64Marker || cdSize == Zip64Marker || count == 0xFFFF)
+    /// <summary>
+    /// Confirms a candidate's declared central directory is inside the archive and actually starts
+    /// with a central-directory header.
+    /// </summary>
+    private static async Task<bool> IsCentralDirectoryAsync(
+        IRangeReader reader, long archiveBase, long archiveSize, long cdOffset, long cdSize, CancellationToken cancellationToken)
+    {
+        if (cdOffset < 0 || cdSize < 4 || cdOffset > archiveSize - cdSize)
         {
-            (cdOffset, cdSize) = await ReadZip64DirectoryAsync(
-                reader, archiveBase, tail, tailStart, eocd, cancellationToken);
+            return false;
         }
 
-        return (archiveBase + cdOffset, cdSize);
+        var head = await reader.ReadAsync(archiveBase + cdOffset, 4, cancellationToken);
+        return BinaryPrimitives.ReadUInt32LittleEndian(head) == CentralHeaderSignature;
     }
 
     private static async Task<(long Offset, long Size)> ReadZip64DirectoryAsync(
@@ -223,11 +255,20 @@ internal static class ZipRangeExtractor
     /// <c>PK\x05\x06</c>, and a truncated tail can end mid-record. A real record has its full fixed
     /// fields and a declared comment length that runs exactly to the end of the archive.
     /// </remarks>
-    private static int FindEocd(ReadOnlySpan<byte> tail)
+    /// <summary>
+    /// Returns the next end-of-central-directory candidate strictly before <paramref name="before"/>,
+    /// scanning backward, or -1.
+    /// </summary>
+    /// <remarks>
+    /// A candidate must have its full fixed fields and a declared comment length that runs exactly to
+    /// the end of the archive. That is necessary but not sufficient: comment bytes can satisfy it too,
+    /// so the caller still has to confirm the directory the candidate points at.
+    /// </remarks>
+    private static int NextEocdCandidate(ReadOnlySpan<byte> tail, int before)
     {
-        var emptyCandidate = -1;
+        var start = Math.Min(before - 1, tail.Length - MinEocdSize);
 
-        for (var i = tail.Length - MinEocdSize; i >= 0; i--)
+        for (var i = start; i >= 0; i--)
         {
             if (BinaryPrimitives.ReadUInt32LittleEndian(tail.Slice(i)) != EocdSignature)
             {
@@ -235,30 +276,13 @@ internal static class ZipRangeExtractor
             }
 
             var commentLen = BinaryPrimitives.ReadUInt16LittleEndian(tail.Slice(i + 20));
-            if (i + MinEocdSize + commentLen != tail.Length)
+            if (i + MinEocdSize + commentLen == tail.Length)
             {
-                continue;
+                return i;
             }
-
-            // A zeroed record sitting in a real archive's comment satisfies everything above and would
-            // otherwise win, making a non-empty archive parse as empty. Prefer a record that declares a
-            // directory, and fall back to the empty one only if there is nothing better.
-            var count = BinaryPrimitives.ReadUInt16LittleEndian(tail.Slice(i + 10));
-            var declaredSize = BinaryPrimitives.ReadUInt32LittleEndian(tail.Slice(i + 12));
-            if (count == 0 && declaredSize == 0)
-            {
-                if (emptyCandidate < 0)
-                {
-                    emptyCandidate = i;
-                }
-
-                continue;
-            }
-
-            return i;
         }
 
-        return emptyCandidate;
+        return -1;
     }
 
     private static int LastIndexOfSignature(ReadOnlySpan<byte> buffer, uint signature)
@@ -285,7 +309,9 @@ internal sealed class MemoryRangeReader(byte[] data) : IRangeReader
 
     public Task<byte[]> ReadAsync(long offset, int length, CancellationToken cancellationToken)
     {
-        if (offset < 0 || length < 0 || offset + length > data.Length)
+        // Written to avoid offset + length, which overflows for a ZIP64-sized offset and would let the
+        // read through to Array.Copy.
+        if (offset < 0 || length < 0 || offset > data.Length || length > data.Length - offset)
         {
             throw new ArgumentOutOfRangeException(nameof(offset), $"Range {offset}..{offset + length} is outside the buffer ({data.Length}).");
         }

--- a/src/winapp-CLI/WinApp.Cli/Helpers/ZipRangeExtractor.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/ZipRangeExtractor.cs
@@ -56,17 +56,10 @@ internal static class ZipRangeExtractor
         var tailStart = archiveBase + archiveSize - tailLen;
         var tail = await reader.ReadAsync(tailStart, tailLen, cancellationToken);
 
-        var eocd = LastIndexOfSignature(tail, EocdSignature);
+        var eocd = FindEocd(tail);
         if (eocd < 0)
         {
             throw new InvalidDataException("End-of-central-directory record not found.");
-        }
-
-        // The signature can appear in the last 21 bytes, leaving the fixed fields below truncated.
-        if (eocd + MinEocdSize > tail.Length)
-        {
-            throw new InvalidDataException(
-                $"End-of-central-directory record at offset {eocd} is truncated: {tail.Length - eocd} of {MinEocdSize} bytes present.");
         }
 
         var count = BinaryPrimitives.ReadUInt16LittleEndian(tail.AsSpan(eocd + 10));
@@ -220,6 +213,33 @@ internal static class ZipRangeExtractor
             : new MemoryStream();
         deflate.CopyTo(output);
         return output.ToArray();
+    }
+
+    /// <summary>
+    /// Finds the end-of-central-directory record in the archive tail.
+    /// </summary>
+    /// <remarks>
+    /// The last signature match is not good enough on either side: a ZIP comment may legally contain
+    /// <c>PK\x05\x06</c>, and a truncated tail can end mid-record. A real record has its full fixed
+    /// fields and a declared comment length that runs exactly to the end of the archive.
+    /// </remarks>
+    private static int FindEocd(ReadOnlySpan<byte> tail)
+    {
+        for (var i = tail.Length - MinEocdSize; i >= 0; i--)
+        {
+            if (BinaryPrimitives.ReadUInt32LittleEndian(tail.Slice(i)) != EocdSignature)
+            {
+                continue;
+            }
+
+            var commentLen = BinaryPrimitives.ReadUInt16LittleEndian(tail.Slice(i + 20));
+            if (i + MinEocdSize + commentLen == tail.Length)
+            {
+                return i;
+            }
+        }
+
+        return -1;
     }
 
     private static int LastIndexOfSignature(ReadOnlySpan<byte> buffer, uint signature)

--- a/src/winapp-CLI/WinApp.Cli/Helpers/ZipRangeExtractor.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/ZipRangeExtractor.cs
@@ -129,6 +129,14 @@ internal static class ZipRangeExtractor
             var commentLen = BinaryPrimitives.ReadUInt16LittleEndian(centralDirectory.AsSpan(p + 32));
             long localOffset = BinaryPrimitives.ReadUInt32LittleEndian(centralDirectory.AsSpan(p + 42));
 
+            // The three lengths are attacker-controlled; without this the slices below read past the
+            // buffer and surface as ArgumentOutOfRangeException instead of a rejected archive.
+            if ((long)p + 46 + nameLen + extraLen + commentLen > centralDirectory.Length)
+            {
+                throw new InvalidDataException(
+                    $"Central-directory entry at offset {p} declares {nameLen + extraLen + commentLen} bytes of name/extra/comment, which extends past the {centralDirectory.Length}-byte directory.");
+            }
+
             var name = System.Text.Encoding.UTF8.GetString(centralDirectory, p + 46, nameLen);
             var extra = centralDirectory.AsSpan(p + 46 + nameLen, extraLen);
 

--- a/src/winapp-CLI/WinApp.Cli/Helpers/ZipRangeExtractor.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/ZipRangeExtractor.cs
@@ -42,6 +42,7 @@ internal static class ZipRangeExtractor
     private const int MaxEocdSearch = 65557; // 22-byte EOCD + 64KiB max comment
     private const int MinEocdSize = 22;      // signature through the comment-length field
     private const int MinCentralHeaderSize = 46; // fixed part of one central-directory header
+    private const int MaxDirectoryProbes = 8;    // reads outside the tail spent confirming candidates
     private const uint Zip64Marker = 0xFFFFFFFF;
     private const ushort Zip64ExtraId = 0x0001;
 
@@ -60,6 +61,7 @@ internal static class ZipRangeExtractor
         // A legal comment can hold a complete fake record, so a candidate is only accepted once the
         // directory it points at is confirmed to be one.
         (long Offset, long Size)? emptyFallback = null;
+        var probes = 0;
 
         for (var eocd = NextEocdCandidate(tail, tail.Length); eocd >= 0; eocd = NextEocdCandidate(tail, eocd))
         {
@@ -84,26 +86,47 @@ internal static class ZipRangeExtractor
 
                 // A comment can carry a forged locator and record too, so the resolved directory gets
                 // the same confirmation. It runs up to the record describing it rather than the EOCD.
-                if (await IsCentralDirectoryAsync(reader, archiveBase, archiveSize, cdOffset, cdSize, recordOffset, cancellationToken))
+                var (isZip64Directory, zip64Probed) = await IsCentralDirectoryAsync(
+                    reader, archiveBase, archiveSize, cdOffset, cdSize, recordOffset, tail, tailStart, cancellationToken);
+                if (isZip64Directory)
                 {
                     return (archiveBase + cdOffset, cdSize);
+                }
+
+                if (zip64Probed && ++probes >= MaxDirectoryProbes)
+                {
+                    break;
                 }
 
                 continue;
             }
 
             // A record declaring no directory has nothing to confirm, and a zeroed record planted in a
-            // comment looks exactly like one. Keep it only as a fallback for a genuinely empty archive.
+            // comment looks exactly like one. Require it to sit where an empty directory would, and let
+            // an earlier candidate replace a later one so the comment cannot win.
             if (count == 0 && cdSize == 0)
             {
-                emptyFallback ??= (archiveBase + cdOffset, 0);
+                if (archiveBase + cdOffset == tailStart + eocd)
+                {
+                    emptyFallback = (archiveBase + cdOffset, 0);
+                }
+
                 continue;
             }
 
             // In a ZIP32 archive the directory runs right up to the record describing it.
-            if (await IsCentralDirectoryAsync(reader, archiveBase, archiveSize, cdOffset, cdSize, tailStart + eocd, cancellationToken))
+            var (isDirectory, probed) = await IsCentralDirectoryAsync(
+                reader, archiveBase, archiveSize, cdOffset, cdSize, tailStart + eocd, tail, tailStart, cancellationToken);
+            if (isDirectory)
             {
                 return (archiveBase + cdOffset, cdSize);
+            }
+
+            // Every candidate that points outside the tail costs a round trip on the HTTP reader, and a
+            // 64 KiB comment can hold thousands of them. A real archive needs one.
+            if (probed && ++probes >= MaxDirectoryProbes)
+            {
+                break;
             }
         }
 
@@ -112,25 +135,34 @@ internal static class ZipRangeExtractor
 
     /// <summary>
     /// Confirms a candidate's declared central directory is inside the archive, is large enough to hold
-    /// a header, and actually starts with one.
+    /// a header, ends where the record describing it begins, and actually starts with one.
     /// </summary>
-    private static async Task<bool> IsCentralDirectoryAsync(
-        IRangeReader reader, long archiveBase, long archiveSize, long cdOffset, long cdSize, long mustEndAt, CancellationToken cancellationToken)
+    /// <returns>Whether it is a directory, and whether confirming it cost a read outside the tail.</returns>
+    private static async Task<(bool IsDirectory, bool Probed)> IsCentralDirectoryAsync(
+        IRangeReader reader, long archiveBase, long archiveSize, long cdOffset, long cdSize, long mustEndAt,
+        byte[] tail, long tailStart, CancellationToken cancellationToken)
     {
         // Anything shorter than one header cannot be the directory a non-empty record claims, which is
         // what a comment-planted record uses to pass a signature-only check.
         if (cdOffset < 0 || cdSize < MinCentralHeaderSize || cdOffset > archiveSize - cdSize)
         {
-            return false;
+            return (false, false);
         }
 
         if (archiveBase + cdOffset + cdSize != mustEndAt)
         {
-            return false;
+            return (false, false);
         }
 
-        var head = await reader.ReadAsync(archiveBase + cdOffset, 4, cancellationToken);
-        return BinaryPrimitives.ReadUInt32LittleEndian(head) == CentralHeaderSignature;
+        var head = archiveBase + cdOffset;
+        if (head >= tailStart && head + 4 <= tailStart + tail.Length)
+        {
+            var local = BinaryPrimitives.ReadUInt32LittleEndian(tail.AsSpan((int)(head - tailStart)));
+            return (local == CentralHeaderSignature, false);
+        }
+
+        var bytes = await reader.ReadAsync(head, 4, cancellationToken);
+        return (BinaryPrimitives.ReadUInt32LittleEndian(bytes) == CentralHeaderSignature, true);
     }
 
     private static async Task<(long Offset, long Size, long RecordOffset)> ReadZip64DirectoryAsync(

--- a/src/winapp-CLI/WinApp.Cli/Helpers/ZipRangeExtractor.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/ZipRangeExtractor.cs
@@ -69,12 +69,11 @@ internal static class ZipRangeExtractor
 
             if (cdOffset == Zip64Marker || cdSize == Zip64Marker || count == 0xFFFF)
             {
+                long recordOffset;
                 try
                 {
-                    // Forging this means also forging a locator and a signed ZIP64 record, so the
-                    // record's own signature check is the gate here.
-                    (cdOffset, cdSize) = await ReadZip64DirectoryAsync(
-                        reader, archiveBase, tail, tailStart, eocd, cancellationToken);
+                    (cdOffset, cdSize, recordOffset) = await ReadZip64DirectoryAsync(
+                        reader, archiveBase, archiveSize, tail, tailStart, eocd, cancellationToken);
                 }
                 catch (InvalidDataException)
                 {
@@ -83,7 +82,14 @@ internal static class ZipRangeExtractor
                     continue;
                 }
 
-                return (archiveBase + cdOffset, cdSize);
+                // A comment can carry a forged locator and record too, so the resolved directory gets
+                // the same confirmation. It runs up to the record describing it rather than the EOCD.
+                if (await IsCentralDirectoryAsync(reader, archiveBase, archiveSize, cdOffset, cdSize, recordOffset, cancellationToken))
+                {
+                    return (archiveBase + cdOffset, cdSize);
+                }
+
+                continue;
             }
 
             // A record declaring no directory has nothing to confirm, and a zeroed record planted in a
@@ -127,8 +133,8 @@ internal static class ZipRangeExtractor
         return BinaryPrimitives.ReadUInt32LittleEndian(head) == CentralHeaderSignature;
     }
 
-    private static async Task<(long Offset, long Size)> ReadZip64DirectoryAsync(
-        IRangeReader reader, long archiveBase, byte[] tail, long tailStart, int eocd, CancellationToken cancellationToken)
+    private static async Task<(long Offset, long Size, long RecordOffset)> ReadZip64DirectoryAsync(
+        IRangeReader reader, long archiveBase, long archiveSize, byte[] tail, long tailStart, int eocd, CancellationToken cancellationToken)
     {
         var locator = LastIndexOfSignature(tail.AsSpan(0, eocd), Zip64LocatorSignature);
         if (locator < 0)
@@ -138,6 +144,15 @@ internal static class ZipRangeExtractor
 
         // Offset of the ZIP64 EOCD record, relative to the archive's base.
         var recordRelative = (long)BinaryPrimitives.ReadUInt64LittleEndian(tail.AsSpan(locator + 8));
+
+        // Attacker-controlled, and passing it straight to the reader turns a malformed archive into an
+        // out-of-range or transport error instead of a rejection.
+        if (recordRelative < 0 || recordRelative > archiveSize - 56)
+        {
+            throw new InvalidDataException(
+                $"ZIP64 locator points at offset {recordRelative}, which cannot hold a record in a {archiveSize}-byte archive.");
+        }
+
         var recordAbsolute = archiveBase + recordRelative;
 
         byte[] record;
@@ -160,7 +175,7 @@ internal static class ZipRangeExtractor
 
         var cdSize = (long)BinaryPrimitives.ReadUInt64LittleEndian(record.AsSpan(recordPos + 40));
         var cdOffset = (long)BinaryPrimitives.ReadUInt64LittleEndian(record.AsSpan(recordPos + 48));
-        return (cdOffset, cdSize);
+        return (cdOffset, cdSize, recordAbsolute);
     }
 
     /// <summary>
@@ -268,14 +283,6 @@ internal static class ZipRangeExtractor
     }
 
     /// <summary>
-    /// Finds the end-of-central-directory record in the archive tail.
-    /// </summary>
-    /// <remarks>
-    /// The last signature match is not good enough on either side: a ZIP comment may legally contain
-    /// <c>PK\x05\x06</c>, and a truncated tail can end mid-record. A real record has its full fixed
-    /// fields and a declared comment length that runs exactly to the end of the archive.
-    /// </remarks>
-    /// <summary>
     /// Returns the next end-of-central-directory candidate strictly before <paramref name="before"/>,
     /// scanning backward, or -1.
     /// </summary>
@@ -333,7 +340,7 @@ internal sealed class MemoryRangeReader(byte[] data) : IRangeReader
         // read through to Array.Copy.
         if (offset < 0 || length < 0 || offset > data.Length || length > data.Length - offset)
         {
-            throw new ArgumentOutOfRangeException(nameof(offset), $"Range {offset}..{offset + length} is outside the buffer ({data.Length}).");
+            throw new ArgumentOutOfRangeException(nameof(offset), $"Range of {length} bytes at offset {offset} is outside the buffer ({data.Length}).");
         }
 
         var slice = new byte[length];

--- a/src/winapp-CLI/WinApp.Cli/Helpers/ZipRangeExtractor.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/ZipRangeExtractor.cs
@@ -71,35 +71,27 @@ internal static class ZipRangeExtractor
 
             if (cdOffset == Zip64Marker || cdSize == Zip64Marker || count == 0xFFFF)
             {
-                long recordOffset;
-                try
+                var zip64 = await TryReadZip64DirectoryAsync(
+                    reader, archiveBase, archiveSize, tail, tailStart, eocd, cancellationToken);
+                var charged = zip64.Probed;
+
+                if (zip64.Ok)
                 {
-                    (cdOffset, cdSize, recordOffset) = await ReadZip64DirectoryAsync(
-                        reader, archiveBase, archiveSize, tail, tailStart, eocd, cancellationToken);
-                }
-                catch (InvalidDataException)
-                {
-                    // A marker-bearing record planted in a comment has no usable locator or record.
-                    // Resolving it may already have cost a locator scan and a read, so it is charged
-                    // against the same budget rather than letting failures loop for free.
-                    if (++probes >= MaxDirectoryProbes)
+                    // A comment can carry a forged locator and record too, so the resolved directory
+                    // gets the same confirmation, anchored on the record rather than the EOCD.
+                    var (isZip64Directory, zip64Probed) = await IsCentralDirectoryAsync(
+                        reader, archiveBase, archiveSize, zip64.Offset, zip64.Size, zip64.RecordOffset, tail, tailStart, cancellationToken);
+                    if (isZip64Directory)
                     {
-                        break;
+                        return (archiveBase + zip64.Offset, zip64.Size);
                     }
 
-                    continue;
+                    charged |= zip64Probed;
                 }
 
-                // A comment can carry a forged locator and record too, so the resolved directory gets
-                // the same confirmation. It runs up to the record describing it rather than the EOCD.
-                var (isZip64Directory, zip64Probed) = await IsCentralDirectoryAsync(
-                    reader, archiveBase, archiveSize, cdOffset, cdSize, recordOffset, tail, tailStart, cancellationToken);
-                if (isZip64Directory)
-                {
-                    return (archiveBase + cdOffset, cdSize);
-                }
-
-                if (zip64Probed && ++probes >= MaxDirectoryProbes)
+                // Only reads that actually left the tail count, or a comment holding a handful of
+                // ZIP64-shaped records would exhaust the budget and reject a valid archive.
+                if (charged && ++probes >= MaxDirectoryProbes)
                 {
                     break;
                 }
@@ -171,30 +163,37 @@ internal static class ZipRangeExtractor
         return (BinaryPrimitives.ReadUInt32LittleEndian(bytes) == CentralHeaderSignature, true);
     }
 
-    private static async Task<(long Offset, long Size, long RecordOffset)> ReadZip64DirectoryAsync(
+    /// <summary>
+    /// Resolves the directory a marker-bearing record points at, via its ZIP64 locator and record.
+    /// </summary>
+    /// <returns>
+    /// Whether it resolved, the directory location, the record's offset, and whether resolving cost a
+    /// read outside the tail. Failures are reported rather than thrown, because a candidate drawn from
+    /// a comment failing to resolve is ordinary and the scan continues past it.
+    /// </returns>
+    private static async Task<(bool Ok, long Offset, long Size, long RecordOffset, bool Probed)> TryReadZip64DirectoryAsync(
         IRangeReader reader, long archiveBase, long archiveSize, byte[] tail, long tailStart, int eocd, CancellationToken cancellationToken)
     {
         var locator = LastIndexOfSignature(tail.AsSpan(0, eocd), Zip64LocatorSignature);
         if (locator < 0)
         {
-            throw new InvalidDataException("ZIP64 end-of-central-directory locator not found.");
+            return (false, 0, 0, 0, false);
         }
 
-        // Offset of the ZIP64 EOCD record, relative to the archive's base.
+        // Offset of the ZIP64 EOCD record, relative to the archive's base. Attacker-controlled, and
+        // passing it straight to the reader turns a malformed archive into an out-of-range or
+        // transport error instead of a rejection.
         var recordRelative = (long)BinaryPrimitives.ReadUInt64LittleEndian(tail.AsSpan(locator + 8));
-
-        // Attacker-controlled, and passing it straight to the reader turns a malformed archive into an
-        // out-of-range or transport error instead of a rejection.
         if (recordRelative < 0 || recordRelative > archiveSize - 56)
         {
-            throw new InvalidDataException(
-                $"ZIP64 locator points at offset {recordRelative}, which cannot hold a record in a {archiveSize}-byte archive.");
+            return (false, 0, 0, 0, false);
         }
 
         var recordAbsolute = archiveBase + recordRelative;
 
         byte[] record;
         int recordPos;
+        var probed = false;
         if (recordAbsolute >= tailStart && recordAbsolute + 56 <= tailStart + tail.Length)
         {
             record = tail;
@@ -204,16 +203,17 @@ internal static class ZipRangeExtractor
         {
             record = await reader.ReadAsync(recordAbsolute, 56, cancellationToken);
             recordPos = 0;
+            probed = true;
         }
 
         if (BinaryPrimitives.ReadUInt32LittleEndian(record.AsSpan(recordPos)) != Zip64EocdSignature)
         {
-            throw new InvalidDataException("ZIP64 end-of-central-directory record signature mismatch.");
+            return (false, 0, 0, 0, probed);
         }
 
         var cdSize = (long)BinaryPrimitives.ReadUInt64LittleEndian(record.AsSpan(recordPos + 40));
         var cdOffset = (long)BinaryPrimitives.ReadUInt64LittleEndian(record.AsSpan(recordPos + 48));
-        return (cdOffset, cdSize, recordAbsolute);
+        return (true, cdOffset, cdSize, recordAbsolute, probed);
     }
 
     /// <summary>

--- a/src/winapp-CLI/WinApp.Cli/WinApp.Cli.csproj
+++ b/src/winapp-CLI/WinApp.Cli/WinApp.Cli.csproj
@@ -88,6 +88,10 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
       <_Parameter1>WinApp.Cli.Tests</_Parameter1>
     </AssemblyAttribute>
+    <!-- The OneFuzz harness targets ZipRangeExtractor, which is internal. -->
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>WinApp.Cli.Fuzz</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
 
 </Project>

--- a/src/winapp-CLI/winapp.sln
+++ b/src/winapp-CLI/winapp.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
-VisualStudioVersion = 18.0.11116.177 d18.0
+VisualStudioVersion = 18.0.11116.177
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WinApp.Cli", "WinApp.Cli\WinApp.Cli.csproj", "{8DE42773-A145-955A-960A-1AF25048E084}"
 EndProject
@@ -13,20 +13,54 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Packages.props = Directory.Packages.props
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WinApp.Cli.Fuzz", "WinApp.Cli.Fuzz\WinApp.Cli.Fuzz.csproj", "{9424B3C6-A8EE-4542-AAF2-3F21FDFA746D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{8DE42773-A145-955A-960A-1AF25048E084}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8DE42773-A145-955A-960A-1AF25048E084}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8DE42773-A145-955A-960A-1AF25048E084}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8DE42773-A145-955A-960A-1AF25048E084}.Debug|x64.Build.0 = Debug|Any CPU
+		{8DE42773-A145-955A-960A-1AF25048E084}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8DE42773-A145-955A-960A-1AF25048E084}.Debug|x86.Build.0 = Debug|Any CPU
 		{8DE42773-A145-955A-960A-1AF25048E084}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8DE42773-A145-955A-960A-1AF25048E084}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8DE42773-A145-955A-960A-1AF25048E084}.Release|x64.ActiveCfg = Release|Any CPU
+		{8DE42773-A145-955A-960A-1AF25048E084}.Release|x64.Build.0 = Release|Any CPU
+		{8DE42773-A145-955A-960A-1AF25048E084}.Release|x86.ActiveCfg = Release|Any CPU
+		{8DE42773-A145-955A-960A-1AF25048E084}.Release|x86.Build.0 = Release|Any CPU
 		{F50B2679-8DAB-405E-9F69-E9877FB0A267}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F50B2679-8DAB-405E-9F69-E9877FB0A267}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F50B2679-8DAB-405E-9F69-E9877FB0A267}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F50B2679-8DAB-405E-9F69-E9877FB0A267}.Debug|x64.Build.0 = Debug|Any CPU
+		{F50B2679-8DAB-405E-9F69-E9877FB0A267}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F50B2679-8DAB-405E-9F69-E9877FB0A267}.Debug|x86.Build.0 = Debug|Any CPU
 		{F50B2679-8DAB-405E-9F69-E9877FB0A267}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F50B2679-8DAB-405E-9F69-E9877FB0A267}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F50B2679-8DAB-405E-9F69-E9877FB0A267}.Release|x64.ActiveCfg = Release|Any CPU
+		{F50B2679-8DAB-405E-9F69-E9877FB0A267}.Release|x64.Build.0 = Release|Any CPU
+		{F50B2679-8DAB-405E-9F69-E9877FB0A267}.Release|x86.ActiveCfg = Release|Any CPU
+		{F50B2679-8DAB-405E-9F69-E9877FB0A267}.Release|x86.Build.0 = Release|Any CPU
+		{9424B3C6-A8EE-4542-AAF2-3F21FDFA746D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9424B3C6-A8EE-4542-AAF2-3F21FDFA746D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9424B3C6-A8EE-4542-AAF2-3F21FDFA746D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9424B3C6-A8EE-4542-AAF2-3F21FDFA746D}.Debug|x64.Build.0 = Debug|Any CPU
+		{9424B3C6-A8EE-4542-AAF2-3F21FDFA746D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9424B3C6-A8EE-4542-AAF2-3F21FDFA746D}.Debug|x86.Build.0 = Debug|Any CPU
+		{9424B3C6-A8EE-4542-AAF2-3F21FDFA746D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9424B3C6-A8EE-4542-AAF2-3F21FDFA746D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9424B3C6-A8EE-4542-AAF2-3F21FDFA746D}.Release|x64.ActiveCfg = Release|Any CPU
+		{9424B3C6-A8EE-4542-AAF2-3F21FDFA746D}.Release|x64.Build.0 = Release|Any CPU
+		{9424B3C6-A8EE-4542-AAF2-3F21FDFA746D}.Release|x86.ActiveCfg = Release|Any CPU
+		{9424B3C6-A8EE-4542-AAF2-3F21FDFA746D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Why

`ZipRangeExtractor` is the only hand-written parser in winapp that consumes bytes originating off the network. `WinDbgJsProviderAcquirer` range-downloads the WinDbg `.msixbundle` and parses its ZIP64 central directory — then a nested inner `.msix` — to locate `JsProvider.dll`. That parsing necessarily happens **before** the extracted DLL's Authenticode signature can be checked, so the archive bytes are untrusted at parse time.

The SDL fuzzing requirement applies to memory-safe languages that use `unsafe` code or P/Invoke, which winapp does extensively (pointer dereferencing in `SlugGenerator`/`CrashDumpService`, P/Invoke into `wintrust.dll`, `d3d11.dll`, catalog crypto APIs). This is the one parser sitting on an untrusted-input boundary.

## The bug this found

`ParseCentralDirectory` read three attacker-controlled 16-bit lengths — name, extra, comment — and sliced on all of them while only guarding the 46-byte fixed header:

```
ArgumentOutOfRangeException x608  (of 3000 seeded mutations)
"Index and count must refer to a location within the buffer."
```

It now rejects malformed directories with `InvalidDataException`. To be precise about severity: .NET's bounds checks caught this, so it is **not memory corruption**, and `TryAcquireCoreAsync` already swallowed it and degraded gracefully. The value is a correct rejection contract, plus a clean baseline for the fuzzer.

## What's here

- **`WinApp.Cli.Fuzz`** — two libFuzzer targets: the pure central-directory parser (high iteration rate) and the full outer → inner → extract descent mirroring `ExtractJsProviderAsync`.
- **`OneFuzzConfig.json`** — `fuzzer.$type`, `FuzzingTargetBinaries: winapp.dll` so the compliance claim attributes to the shipping binary, and `SdlWorkItemId` linking claims and bugs to the SDL task.
- **`.pipelines/fuzz.yml`** — `trigger: none` / `pr: none`. Fuzzing runs **on demand**, not per-build; jobs run for hours and file bugs.
- **`FuzzHarnessTests`** — guards that the target signature and `OneFuzzConfig.json` stay in sync with the code, generates a seed corpus, and asserts every seed is structurally valid.

## Verification

Both targets ran on OneFuzz against a seeded corpus:

| Target | Job | Iterations | Crashes |
|---|---|---|---|
| `ziprangeextractor-centraldirectory` | `f1646fe1-be66-48ed-b9d5-3de43e98dcd0` | ~155,000,000 | 0 |
| `ziprangeextractor-archive` | `2c2fc7a1-4c80-409c-81ac-8660a4934659` | ~127,000,000 | 0 |

Submission `dc437f41-cbf4-49eb-af73-bfc24b224536`, 2/2 job configs succeeded, no task errors.

The seed corpus matters more than it looks. libFuzzer mutates existing inputs and will not synthesise a valid ZIP64 central directory from random bytes — an unseeded run looks busy and covers nothing. `GenerateSeedCorpus` round-trips every seed through the parser and fails if any produces no entries, because a corpus the parser rejects at byte zero is worse than none.

Local: 25/25 tests pass, `build-cli.ps1` clean.
