### PR TITLE
Publish release symbols to symweb and MSDL

### DIFF
--- a/.pipelines/release.yml
+++ b/.pipelines/release.yml
@@ -311,7 +311,11 @@ extends:
     - ${{ if eq(parameters.PublishSymbols, 'true') }}:
       - stage: Publish_Symbols
         displayName: Publish Symbols
-        dependsOn: Build
+        # Build supplies the version output; Release_GitHub gates on the release actually shipping, so
+        # a failed release cannot leave century-retention symbols published for a build nobody has.
+        dependsOn:
+          - Build
+          - Release_GitHub
         variables:
           version: $[ stageDependencies.Build.Build.outputs['SetMeta.version'] ]
           # Used twice: as the PublishSymbols@2 artifact name and as the request name the symbol API
@@ -349,6 +353,9 @@ extends:
             # why the symbol project's source organization must be `microsoft` rather than the default.
             - task: PublishSymbols@2
               displayName: Upload PDBs to the Azure DevOps symbol service
+              # The artifact name is fixed per build, so a re-run after a later failure would fail here
+              # on the existing request and never reach the REST calls. Surfaces as a warning instead.
+              continueOnError: true
               inputs:
                 SymbolsFolder: $(Pipeline.Workspace)/symbolStaging
                 SearchPattern: '**/*.pdb'
@@ -385,14 +392,14 @@ extends:
                 Invoke-RestMethod -Uri $baseUri -Body ($createBody | ConvertTo-Json -Compress)
 
                 # Public symbols land on MSDL stripped: with no allowed-private-symbols policy on the
-                # project, the service runs the private data out of the PDB before it goes external.
+                # project, the service strips the private data out of the PDB before it goes external.
                 $publishBody = @{
                     publishToInternalServer = $true
                     publishToPublicServer   = $true
                 }
                 Write-Host "Promoting $($createBody.requestName) to symweb and MSDL"
                 Invoke-RestMethod -Uri "$baseUri/$($createBody.requestName)" -Body ($publishBody | ConvertTo-Json -Compress)
-              displayName: Request publication to symweb
+              displayName: Request publication to symweb and MSDL
 
     - ${{ if eq(parameters.DoEsrp, 'true') }}:
       - stage: Release_Npm

--- a/.pipelines/release.yml
+++ b/.pipelines/release.yml
@@ -37,6 +37,11 @@ parameters:
     displayName: Publish symbols to symweb and MSDL (PublishSymbols)
     type: boolean
     default: true
+  - name: symbolsIdentity
+    type: object
+    default:
+      serviceConnection: $(SymbolPublishingServiceConnection)
+      project: $(SymbolPublishingProject)
 
 variables:
   # Declared once so the URL and its hash cannot drift apart across the stages that install gh.
@@ -309,10 +314,6 @@ extends:
         dependsOn: Build
         variables:
           version: $[ stageDependencies.Build.Build.outputs['SetMeta.version'] ]
-          # Both are provisioned by the EP CDP symbols team. SymbolPublishingProject is CASE SENSITIVE
-          # and must match the created project exactly, or the publish request 404s.
-          SymbolPublishingServiceConnection: 'WinAppCLISymbolPublishing'
-          SymbolPublishingProject: 'WinAppCLI'
           # Used twice: as the PublishSymbols@2 artifact name and as the request name the symbol API
           # promotes. They must be identical or the request finds nothing to publish.
           SymbolsArtifactName: 'WinAppCLI_$(version)_$(Build.BuildNumber)'
@@ -335,7 +336,7 @@ extends:
             - task: AzurePowerShell@5
               displayName: Acquire symbol request API token
               inputs:
-                azureSubscription: $(SymbolPublishingServiceConnection)
+                azureSubscription: ${{ parameters.symbolsIdentity.serviceConnection }}
                 azurePowerShellVersion: LatestVersion
                 pwsh: true
                 ScriptType: InlineScript
@@ -370,7 +371,9 @@ extends:
                 $PSDefaultParameterValues['Invoke-RestMethod:ContentType'] = 'application/json'
                 $PSDefaultParameterValues['Invoke-RestMethod:Method'] = 'POST'
 
-                $baseUri = "https://symbolrequestprod.trafficmanager.net/projects/$(SymbolPublishingProject)/requests"
+                # The symbol project name is CASE SENSITIVE and must match the provisioned project
+                # exactly, or the request 404s.
+                $baseUri = "https://symbolrequestprod.trafficmanager.net/projects/${{ parameters.symbolsIdentity.project }}/requests"
 
                 # Round-trip UTC: the service binds this to a DateTime, and a culture-formatted
                 # string would be ambiguous on a non-en-US agent.

--- a/.pipelines/release.yml
+++ b/.pipelines/release.yml
@@ -33,6 +33,10 @@ parameters:
     displayName: GitHub Release already exists, skip uploading GitHub release (GitHubReleaseAlreadyExists)
     type: boolean
     default: false
+  - name: PublishSymbols
+    displayName: Publish private symbols to symweb (PublishSymbols)
+    type: boolean
+    default: true
 
 variables:
   # Declared once so the URL and its hash cannot drift apart across the stages that install gh.
@@ -298,6 +302,94 @@ extends:
                 addChangeLog: false
                 releaseNotesSource: 'filePath'
                 releaseNotesFilePath: '$(Pipeline.Workspace)/release-notes/full-release-notes.md'
+
+    - ${{ if eq(parameters.PublishSymbols, 'true') }}:
+      - stage: Publish_Symbols
+        displayName: Publish Symbols
+        dependsOn: Build
+        variables:
+          version: $[ stageDependencies.Build.Build.outputs['SetMeta.version'] ]
+          # Both are provisioned by the EP CDP symbols team. SymbolPublishingProject is CASE SENSITIVE
+          # and must match the created project exactly, or the publish request 404s.
+          SymbolPublishingServiceConnection: 'WinAppCLISymbolPublishing'
+          SymbolPublishingProject: 'WinAppCLI'
+          # Used twice: as the PublishSymbols@2 artifact name and as the request name the symbol API
+          # promotes. They must be identical or the request finds nothing to publish.
+          SymbolsArtifactName: 'WinAppCLI_$(version)_$(Build.BuildNumber)'
+        jobs:
+        - job: publish_symbols
+          displayName: Publish Symbols to symweb
+          pool:
+            name: Azure-Pipelines-1ESPT-ExDShared
+            image: windows-latest
+            os: windows
+            hostArchitecture: amd64
+          templateContext:
+            type: releaseJob
+            isProduction: true
+            inputs:
+            - input: pipelineArtifact
+              artifactName: cli-binaries
+              targetPath: $(Pipeline.Workspace)/symbolStaging
+          steps:
+            - task: AzurePowerShell@5
+              displayName: Acquire symbol request API token
+              inputs:
+                azureSubscription: $(SymbolPublishingServiceConnection)
+                azurePowerShellVersion: LatestVersion
+                pwsh: true
+                ScriptType: InlineScript
+                Inline: |-
+                  $token = (Get-AzAccessToken -AsSecureString -ResourceUrl api://30471ccf-0966-45b9-a979-065dbedb24c1).Token |
+                      ConvertFrom-SecureString -AsPlainText
+                  Write-Host "##vso[task.setvariable variable=SymbolAccessToken;issecret=true]$token"
+
+            # Uploads to the symbol service of the ADO org this pipeline runs in (microsoft), which is
+            # why the symbol project's source organization must be `microsoft` rather than the default.
+            - task: PublishSymbols@2
+              displayName: Upload PDBs to the Azure DevOps symbol service
+              inputs:
+                SymbolsFolder: $(Pipeline.Workspace)/symbolStaging
+                SearchPattern: '**/*.pdb'
+                SymbolServerType: TeamServices
+                SymbolsProduct: WinAppCLI
+                SymbolsVersion: $(version)
+                SymbolsArtifactName: $(SymbolsArtifactName)
+                # ~100 years. The standalone reference script defaults to 6 days, which would silently
+                # expire the symbols for a shipped release.
+                SymbolExpirationInDays: 36530
+                # Non-mandatory per the requirement, and srcsrv indexing does not map cleanly onto a
+                # GitHub-sourced NativeAOT build. Tracked separately.
+                IndexSources: false
+                DetailedLog: true
+                SymbolsMaximumWaitTime: 30
+
+            - pwsh: |-
+                $ErrorActionPreference = 'Stop'
+                $PSDefaultParameterValues['Invoke-RestMethod:Headers'] = @{ Authorization = "Bearer $(SymbolAccessToken)" }
+                $PSDefaultParameterValues['Invoke-RestMethod:ContentType'] = 'application/json'
+                $PSDefaultParameterValues['Invoke-RestMethod:Method'] = 'POST'
+
+                $baseUri = "https://symbolrequestprod.trafficmanager.net/projects/$(SymbolPublishingProject)/requests"
+
+                # Round-trip UTC: the service binds this to a DateTime, and a culture-formatted
+                # string would be ambiguous on a non-en-US agent.
+                $createBody = @{
+                    requestName    = '$(SymbolsArtifactName)'
+                    expirationTime = [DateTime]::UtcNow.AddDays(36530).ToString('o')
+                }
+                Write-Host "Registering symbol request $($createBody.requestName)"
+                Invoke-RestMethod -Uri $baseUri -Body ($createBody | ConvertTo-Json -Compress)
+
+                # publishToPublicServer stays false: MSDL requires an allowed-private-symbols policy,
+                # and the requirement only calls for the internal server.
+                $publishBody = @{
+                    publishToInternalServer = $true
+                    publishToPublicServer   = $false
+                }
+                Write-Host "Promoting $($createBody.requestName) to symweb"
+                Invoke-RestMethod -Uri "$baseUri/$($createBody.requestName)" -Body ($publishBody | ConvertTo-Json -Compress)
+              displayName: Request publication to symweb
 
     - ${{ if eq(parameters.DoEsrp, 'true') }}:
       - stage: Release_Npm

--- a/.pipelines/release.yml
+++ b/.pipelines/release.yml
@@ -34,7 +34,7 @@ parameters:
     type: boolean
     default: false
   - name: PublishSymbols
-    displayName: Publish private symbols to symweb (PublishSymbols)
+    displayName: Publish symbols to symweb and MSDL (PublishSymbols)
     type: boolean
     default: true
 
@@ -318,7 +318,7 @@ extends:
           SymbolsArtifactName: 'WinAppCLI_$(version)_$(Build.BuildNumber)'
         jobs:
         - job: publish_symbols
-          displayName: Publish Symbols to symweb
+          displayName: Publish Symbols to symweb and MSDL
           pool:
             name: Azure-Pipelines-1ESPT-ExDShared
             image: windows-latest
@@ -381,13 +381,13 @@ extends:
                 Write-Host "Registering symbol request $($createBody.requestName)"
                 Invoke-RestMethod -Uri $baseUri -Body ($createBody | ConvertTo-Json -Compress)
 
-                # publishToPublicServer stays false: MSDL requires an allowed-private-symbols policy,
-                # and the requirement only calls for the internal server.
+                # Public symbols land on MSDL stripped: with no allowed-private-symbols policy on the
+                # project, the service runs the private data out of the PDB before it goes external.
                 $publishBody = @{
                     publishToInternalServer = $true
-                    publishToPublicServer   = $false
+                    publishToPublicServer   = $true
                 }
-                Write-Host "Promoting $($createBody.requestName) to symweb"
+                Write-Host "Promoting $($createBody.requestName) to symweb and MSDL"
                 Invoke-RestMethod -Uri "$baseUri/$($createBody.requestName)" -Body ($publishBody | ConvertTo-Json -Compress)
               displayName: Request publication to symweb
 

--- a/.pipelines/release.yml
+++ b/.pipelines/release.yml
@@ -319,8 +319,9 @@ extends:
         variables:
           version: $[ stageDependencies.Build.Build.outputs['SetMeta.version'] ]
           # Used twice: as the PublishSymbols@2 artifact name and as the request name the symbol API
-          # promotes. They must be identical or the request finds nothing to publish.
-          SymbolsArtifactName: 'WinAppCLI_$(version)_$(Build.BuildNumber)'
+          # promotes. They must be identical or the request finds nothing to publish. The attempt is
+          # part of the name so a re-run creates a fresh request instead of colliding with its own.
+          SymbolsArtifactName: 'WinAppCLI_$(version)_$(Build.BuildNumber)_$(System.JobAttempt)'
         jobs:
         - job: publish_symbols
           displayName: Publish Symbols to symweb and MSDL
@@ -353,9 +354,6 @@ extends:
             # why the symbol project's source organization must be `microsoft` rather than the default.
             - task: PublishSymbols@2
               displayName: Upload PDBs to the Azure DevOps symbol service
-              # The artifact name is fixed per build, so a re-run after a later failure would fail here
-              # on the existing request and never reach the REST calls. Surfaces as a warning instead.
-              continueOnError: true
               inputs:
                 SymbolsFolder: $(Pipeline.Workspace)/symbolStaging
                 SearchPattern: '**/*.pdb'


### PR DESCRIPTION
Publishes the release PDBs so a crash dump or hang from a shipped build can actually be resolved to a function name - to the internal symbol server (symweb) for full private symbols, and to the public server (MSDL) as stripped public symbols. Today the only PDBs anywhere are the ones inside the public GitHub release zips, which is not somewhere a debugger will look.

### What this adds

A `Publish_Symbols` stage to the release pipeline, gated on a new `PublishSymbols` parameter (default `true`, so it can be turned off for a re-run without editing the pipeline). It runs off the existing `cli-binaries` artifact and does three things:

1. Acquires a token for the symbol request API via the `WinAppCLISymbolPublishing` service connection.
2. Uploads the PDBs with `PublishSymbols@2`.
3. Registers a symbol request and promotes it to both servers.

### On the public server

`publishToPublicServer` is `true`. Worth being precise about what does and does not go public, because it is easy to assume this leaks private symbols:

The symbol project has no allowed-private-symbols policy, and that policy is *not* a gate on public publishing - it only decides whether private symbols are published to MSDL **unstripped**. With no policy, `OrchestratorUtils.CreateSymbolFileStrippingInformation` sets `stripSymbolFile = true` for any non-public PDB bound for the external repo, so the service strips the private data before it goes out. What lands on MSDL is public symbols: enough to resolve a stack to function names, without source, lines, locals, or types.

So this is a strict improvement in debuggability with no new disclosure. (Full private PDBs are already inside the public release zips today, so even the stripped-vs-full distinction is not the exposure boundary it would normally be.)

### Notes for review

**Expiration is ~100 years.** NativeAOT PDBs are large, but they are the only way to debug a shipped build, and a request that quietly expires is worse than one that never existed. Note the widely-copied `Create-SymbolPublishingRequest.ps1` sample defaults to *6 days*.

**`expirationTime`, not `expirationDate`.** That same sample sends `expirationDate`. The service contract (`RegisterSymbolRequest`) declares only `RequestName` and `ExpirationTime`, and Newtonsoft drops unknown members - so the sample's expiration parameter is silently a no-op and the request falls back to the 30-year default. Please do not "fix" this field to match the sample.

**The date is round-trip UTC** (`ToString('o')`) rather than the bare `.ToString()` some existing pipelines use, since the service binds it to a `DateTime` and a culture-formatted string would be ambiguous on a non-en-US agent.

**`SymbolPublishingProject` is case sensitive** and must match the provisioned project exactly or the request 404s.

**`SymbolsArtifactName` is used twice** - as the `PublishSymbols@2` artifact name and as the request name being promoted. They must stay identical or the promote step finds nothing to publish.

`IndexSources` is off. Source indexing does not map cleanly onto a GitHub-sourced NativeAOT build, and it is not required here.

### Testing

A pipeline stage cannot be fully exercised until it runs on a real release. The YAML parses and the stage nests as a sibling of the existing conditional release stages. The request field name, the stripping behaviour on the public path, and the absence of a retention cap were each confirmed against the symbol service's own source rather than against sample scripts or docs.
