### PR TITLE
Add Windows Sandbox target lifecycle foundation

### DIFF
--- a/src/winapp-CLI/WinApp.Cli.Tests/ExecutionTargetServiceTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/ExecutionTargetServiceTests.cs
@@ -1,0 +1,110 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using WinApp.Cli.ExecutionTargets;
+
+namespace WinApp.Cli.Tests;
+
+[TestClass]
+public class ExecutionTargetServiceTests
+{
+    [TestMethod]
+    public void ExecutionTargetRef_RejectsInvalidValues()
+    {
+        Assert.ThrowsExactly<ArgumentException>(() => new ExecutionTargetRef("Windows-Sandbox", "Windows-Sandbox:default"));
+        Assert.ThrowsExactly<ArgumentException>(() => new ExecutionTargetRef("windows-sandbox", "other:default"));
+        Assert.ThrowsExactly<ArgumentException>(() => new ExecutionTargetRef("windows-sandbox", "windows-sandbox:bad/name"));
+    }
+
+    [TestMethod]
+    public void ExecutionTargetEpoch_RequiresCanonicalOpaqueValue()
+    {
+        var epoch = new ExecutionTargetEpoch("ABCDEF0123456789ABCDEF0123456789");
+
+        Assert.AreEqual("abcdef0123456789abcdef0123456789", epoch.Value);
+        Assert.ThrowsExactly<ArgumentException>(() => new ExecutionTargetEpoch("not-an-epoch"));
+    }
+
+    [TestMethod]
+    public async Task EnsureAsync_DelegatesToMatchingBackend()
+    {
+        var backend = new FakeBackend();
+        var service = new ExecutionTargetService(backend);
+
+        var result = await service.EnsureAsync(
+            ExecutionTargetRef.WindowsSandboxDefault,
+            new ExecutionTargetRequirements());
+
+        Assert.IsTrue(result.Succeeded);
+        Assert.AreEqual(1, backend.EnsureCount);
+        Assert.AreEqual(ExecutionTargetRef.WindowsSandboxDefault, result.Instance!.Target);
+    }
+
+    [TestMethod]
+    public async Task EnsureAsync_RejectsBackendMismatchWithoutCallingBackend()
+    {
+        var backend = new FakeBackend();
+        var service = new ExecutionTargetService(backend);
+
+        var result = await service.EnsureAsync(
+            new ExecutionTargetRef("other", "other:default"),
+            new ExecutionTargetRequirements());
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.AreEqual(0, backend.EnsureCount);
+        Assert.AreEqual(ExecutionTargetDiagnosticCode.BackendMismatch, result.Diagnostics.Single().Code);
+    }
+
+    [TestMethod]
+    public async Task EnsureAsync_RejectsCapabilitiesNotSatisfiedByBackend()
+    {
+        var backend = new FakeBackend
+        {
+            Capabilities = new ExecutionTargetCapabilities(true, false, false, false, false, false),
+        };
+        var service = new ExecutionTargetService(backend);
+
+        var result = await service.EnsureAsync(
+            ExecutionTargetRef.WindowsSandboxDefault,
+            new ExecutionTargetRequirements(InteractiveDesktop: true));
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.AreEqual(ExecutionTargetDiagnosticCode.CapabilityUnavailable, result.Diagnostics.Single().Code);
+    }
+
+    private sealed class FakeBackend : IExecutionTargetBackend
+    {
+        public ExecutionTargetRef Target => ExecutionTargetRef.WindowsSandboxDefault;
+
+        public ExecutionTargetCapabilities Capabilities { get; set; } =
+            new(true, false, false, false, false, false);
+
+        public int EnsureCount { get; private set; }
+
+        public Task<ExecutionTargetProbeResult> ProbeAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult(ExecutionTargetProbeResult.Supported);
+
+        public Task<ExecutionTargetStatusResult> GetStatusAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult(new ExecutionTargetStatusResult(
+                Target,
+                ExecutionTargetStatus.Running,
+                "sandbox-id",
+                new ExecutionTargetEpoch("0123456789abcdef0123456789abcdef"),
+                Capabilities,
+                []));
+
+        public Task<ExecutionTargetEnsureResult> EnsureAsync(
+            ExecutionTargetRequirements requirements,
+            CancellationToken cancellationToken = default)
+        {
+            EnsureCount++;
+            return Task.FromResult(new ExecutionTargetEnsureResult(
+                new ExecutionTargetInstance(
+                    Target,
+                    "sandbox-id",
+                    new ExecutionTargetEpoch("0123456789abcdef0123456789abcdef"),
+                    Capabilities),
+                []));
+        }
+    }
+}

--- a/src/winapp-CLI/WinApp.Cli.Tests/WindowsSandboxBackendTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/WindowsSandboxBackendTests.cs
@@ -1,0 +1,433 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using WinApp.Cli.ExecutionTargets;
+using WinApp.Cli.ExecutionTargets.WindowsSandbox;
+
+namespace WinApp.Cli.Tests;
+
+[TestClass]
+public class WindowsSandboxBackendTests
+{
+    private const string SandboxOne = "11111111-1111-1111-1111-111111111111";
+    private const string SandboxTwo = "22222222-2222-2222-2222-222222222222";
+    private const string EpochOne = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    [TestMethod]
+    public async Task ProbeAsync_UnsupportedHostDoesNotInvokeWsb()
+    {
+        var fixture = new Fixture { IsSupportedHost = false };
+
+        var result = await fixture.Backend.ProbeAsync();
+
+        Assert.IsFalse(result.IsSupported);
+        Assert.AreEqual(ExecutionTargetDiagnosticCode.UnsupportedHost, result.Diagnostics.Single().Code);
+        Assert.AreEqual(0, fixture.Cli.ListCount);
+    }
+
+    [TestMethod]
+    public async Task ProbeAsync_MissingCliReturnsSpecificDiagnostic()
+    {
+        var fixture = new Fixture();
+        fixture.Cli.ListResults.Enqueue(FailedList(WindowsSandboxCliFailure.ExecutableMissing, "missing"));
+
+        var result = await fixture.Backend.ProbeAsync();
+
+        Assert.IsFalse(result.IsSupported);
+        Assert.AreEqual(ExecutionTargetDiagnosticCode.WindowsSandboxCliMissing, result.Diagnostics.Single().Code);
+    }
+
+    [TestMethod]
+    public async Task EnsureAsync_WarmReusePreservesEpochAndDoesNotMutate()
+    {
+        var fixture = new Fixture();
+        fixture.Cli.ListResults.Enqueue(SuccessfulList(SandboxOne));
+        fixture.State.ReadResult = ValidState(SandboxOne, EpochOne, 4);
+
+        var result = await fixture.Backend.EnsureAsync(new ExecutionTargetRequirements());
+
+        Assert.IsTrue(result.Succeeded);
+        Assert.AreEqual(EpochOne, result.Instance!.Epoch.Value);
+        Assert.AreEqual(0, fixture.Cli.StartCount);
+        Assert.AreEqual(0, fixture.Cli.StopIds.Count);
+        Assert.AreEqual(0, fixture.State.Writes.Count);
+    }
+
+    [TestMethod]
+    public async Task GetStatusAsync_ReconcilesOwnedAndUnmanagedInstances()
+    {
+        var owned = new Fixture();
+        owned.Cli.ListResults.Enqueue(SuccessfulList(SandboxOne));
+        owned.State.ReadResult = ValidState(SandboxOne, EpochOne, 2);
+        var unmanaged = new Fixture();
+        unmanaged.Cli.ListResults.Enqueue(SuccessfulList(SandboxTwo));
+
+        var ownedResult = await owned.Backend.GetStatusAsync();
+        var unmanagedResult = await unmanaged.Backend.GetStatusAsync();
+
+        Assert.AreEqual(ExecutionTargetStatus.Running, ownedResult.Status);
+        Assert.AreEqual(EpochOne, ownedResult.Epoch!.Value.Value);
+        Assert.AreEqual(ExecutionTargetStatus.Unmanaged, unmanagedResult.Status);
+        Assert.AreEqual(
+            ExecutionTargetDiagnosticCode.WindowsSandboxUnmanagedInstance,
+            unmanagedResult.Diagnostics.Single().Code);
+    }
+
+    [TestMethod]
+    public async Task EnsureAsync_UnmanagedInstanceIsNeverAdoptedOrStopped()
+    {
+        var fixture = new Fixture();
+        fixture.Cli.ListResults.Enqueue(SuccessfulList(SandboxOne));
+        fixture.State.ReadResult = new WindowsSandboxStateReadResult(
+            WindowsSandboxStateReadStatus.Missing,
+            null);
+
+        var result = await fixture.Backend.EnsureAsync(new ExecutionTargetRequirements());
+
+        Assert.IsFalse(result.Succeeded);
+        var diagnostic = result.Diagnostics.Single();
+        Assert.AreEqual(ExecutionTargetDiagnosticCode.WindowsSandboxUnmanagedInstance, diagnostic.Code);
+        Assert.AreEqual($"wsb stop --id {SandboxOne}", diagnostic.RecoveryCommand);
+        Assert.AreEqual(0, fixture.Cli.StartCount);
+        Assert.AreEqual(0, fixture.Cli.StopIds.Count);
+    }
+
+    [TestMethod]
+    public async Task EnsureAsync_ExternalStopCreatesNewEpochAndIncrementsRevision()
+    {
+        var fixture = new Fixture();
+        fixture.Cli.ListResults.Enqueue(SuccessfulList());
+        fixture.Cli.ListResults.Enqueue(SuccessfulList(SandboxTwo));
+        fixture.Cli.StartResults.Enqueue(WindowsSandboxCliResult<string>.Success(SandboxTwo));
+        fixture.State.ReadResult = ValidState(SandboxOne, EpochOne, 4);
+
+        var result = await fixture.Backend.EnsureAsync(new ExecutionTargetRequirements());
+
+        Assert.IsTrue(result.Succeeded);
+        Assert.AreEqual(SandboxTwo, result.Instance!.ProviderInstanceId);
+        Assert.AreNotEqual(EpochOne, result.Instance.Epoch.Value);
+        Assert.AreEqual(5, fixture.State.Writes.Single().Revision);
+        Assert.AreEqual(SandboxTwo, fixture.State.Writes.Single().ProviderInstanceId);
+    }
+
+    [TestMethod]
+    public async Task EnsureAsync_StateCommitFailureRollsBackOnlyStartedInstance()
+    {
+        var fixture = new Fixture();
+        fixture.Cli.ListResults.Enqueue(SuccessfulList());
+        fixture.Cli.ListResults.Enqueue(SuccessfulList(SandboxOne));
+        fixture.Cli.StartResults.Enqueue(WindowsSandboxCliResult<string>.Success(SandboxOne));
+        fixture.State.WriteException = new IOException("disk full");
+
+        var result = await fixture.Backend.EnsureAsync(new ExecutionTargetRequirements());
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.AreEqual(ExecutionTargetDiagnosticCode.WindowsSandboxStateUnavailable, result.Diagnostics.Single().Code);
+        CollectionAssert.AreEqual(new[] { SandboxOne }, fixture.Cli.StopIds);
+    }
+
+    [TestMethod]
+    public async Task EnsureAsync_StateCommitCancellationRollsBackOnceAndPropagates()
+    {
+        var fixture = new Fixture();
+        fixture.Cli.ListResults.Enqueue(SuccessfulList());
+        fixture.Cli.ListResults.Enqueue(SuccessfulList(SandboxOne));
+        fixture.Cli.StartResults.Enqueue(WindowsSandboxCliResult<string>.Success(SandboxOne));
+        fixture.State.WriteException = new OperationCanceledException();
+
+        await Assert.ThrowsExactlyAsync<OperationCanceledException>(
+            () => fixture.Backend.EnsureAsync(new ExecutionTargetRequirements()));
+
+        CollectionAssert.AreEqual(new[] { SandboxOne }, fixture.Cli.StopIds);
+    }
+
+    [TestMethod]
+    public async Task EnsureAsync_StartCancellationDoesNotMutateUnprovenInstance()
+    {
+        var fixture = new Fixture();
+        fixture.Cli.ListResults.Enqueue(SuccessfulList());
+        fixture.Cli.StartException = new OperationCanceledException();
+
+        await Assert.ThrowsExactlyAsync<OperationCanceledException>(
+            () => fixture.Backend.EnsureAsync(new ExecutionTargetRequirements()));
+
+        Assert.AreEqual(1, fixture.Cli.ListCount);
+        Assert.AreEqual(0, fixture.Cli.StopIds.Count);
+    }
+
+    [TestMethod]
+    public async Task EnsureAsync_ConfirmationMismatchRollsBackOnlyStartedInstance()
+    {
+        var fixture = new Fixture();
+        fixture.Cli.ListResults.Enqueue(SuccessfulList());
+        fixture.Cli.ListResults.Enqueue(SuccessfulList(SandboxTwo));
+        fixture.Cli.StartResults.Enqueue(WindowsSandboxCliResult<string>.Success(SandboxOne));
+
+        var result = await fixture.Backend.EnsureAsync(new ExecutionTargetRequirements());
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.AreEqual(ExecutionTargetDiagnosticCode.WindowsSandboxStartFailed, result.Diagnostics.Single().Code);
+        CollectionAssert.AreEqual(new[] { SandboxOne }, fixture.Cli.StopIds);
+        Assert.AreEqual(0, fixture.State.Writes.Count);
+    }
+
+    [TestMethod]
+    public async Task EnsureAsync_RollbackFailureIsExplicitlyDiagnosed()
+    {
+        var fixture = new Fixture();
+        fixture.Cli.ListResults.Enqueue(SuccessfulList());
+        fixture.Cli.ListResults.Enqueue(SuccessfulList(SandboxTwo));
+        fixture.Cli.StartResults.Enqueue(WindowsSandboxCliResult<string>.Success(SandboxOne));
+        fixture.Cli.StopResult = WindowsSandboxCliResult<bool>.Failed(
+            WindowsSandboxCliFailure.CommandFailed,
+            "stop failed");
+
+        var result = await fixture.Backend.EnsureAsync(new ExecutionTargetRequirements());
+
+        Assert.AreEqual(2, result.Diagnostics.Count);
+        Assert.AreEqual(
+            ExecutionTargetDiagnosticCode.WindowsSandboxRollbackFailed,
+            result.Diagnostics[1].Code);
+        Assert.AreEqual($"wsb stop --id {SandboxOne}", result.Diagnostics[1].RecoveryCommand);
+    }
+
+    [TestMethod]
+    public async Task EnsureAsync_UnparseableStartDoesNotMutateUnprovenSingleton()
+    {
+        var fixture = new Fixture();
+        fixture.Cli.ListResults.Enqueue(SuccessfulList());
+        fixture.Cli.StartResults.Enqueue(WindowsSandboxCliResult<string>.Failed(
+            WindowsSandboxCliFailure.IncompatibleOutput,
+            "bad json"));
+
+        var result = await fixture.Backend.EnsureAsync(new ExecutionTargetRequirements());
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.AreEqual(ExecutionTargetDiagnosticCode.WindowsSandboxCliIncompatible, result.Diagnostics.Single().Code);
+        Assert.AreEqual(0, fixture.Cli.StopIds.Count);
+    }
+
+    [TestMethod]
+    public async Task EnsureAsync_CorruptStateWithLiveInstanceFailsClosed()
+    {
+        var fixture = new Fixture();
+        fixture.Cli.ListResults.Enqueue(SuccessfulList(SandboxOne));
+        fixture.State.ReadResult = new WindowsSandboxStateReadResult(
+            WindowsSandboxStateReadStatus.Corrupt,
+            null,
+            "corrupt");
+
+        var result = await fixture.Backend.EnsureAsync(new ExecutionTargetRequirements());
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.AreEqual(ExecutionTargetDiagnosticCode.WindowsSandboxStateUnavailable, result.Diagnostics.Single().Code);
+        Assert.AreEqual(0, fixture.Cli.StopIds.Count);
+    }
+
+    [TestMethod]
+    public async Task EnsureAsync_CorruptStateWithoutLiveInstanceIsReplaced()
+    {
+        var fixture = new Fixture();
+        fixture.Cli.ListResults.Enqueue(SuccessfulList());
+        fixture.Cli.ListResults.Enqueue(SuccessfulList(SandboxOne));
+        fixture.Cli.StartResults.Enqueue(WindowsSandboxCliResult<string>.Success(SandboxOne));
+        fixture.State.ReadResult = new WindowsSandboxStateReadResult(
+            WindowsSandboxStateReadStatus.Corrupt,
+            null,
+            "corrupt");
+
+        var result = await fixture.Backend.EnsureAsync(new ExecutionTargetRequirements());
+
+        Assert.IsTrue(result.Succeeded);
+        Assert.AreEqual(1, fixture.State.Writes.Single().Revision);
+    }
+
+    [TestMethod]
+    public async Task EnsureAsync_InteractiveRequirementFailsBeforeMutation()
+    {
+        var fixture = new Fixture();
+
+        var result = await fixture.Backend.EnsureAsync(
+            new ExecutionTargetRequirements(InteractiveDesktop: true));
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.AreEqual(ExecutionTargetDiagnosticCode.CapabilityUnavailable, result.Diagnostics.Single().Code);
+        Assert.AreEqual(0, fixture.Cli.ListCount);
+    }
+
+    [TestMethod]
+    public async Task EnsureAsync_ConcurrentWarmReuseIsSerializedByMutationLock()
+    {
+        var cli = new ConcurrentDetectingCli(SandboxOne);
+        var state = new FakeStateStore
+        {
+            ReadResult = ValidState(SandboxOne, EpochOne, 1),
+        };
+        var mutex = new WindowsSandboxMutationLock(
+            @"Local\WinApp.Cli.Tests." + Guid.NewGuid().ToString("N"));
+        var backend = new WindowsSandboxBackend(new FakeHost(true), cli, state, mutex);
+
+        var first = backend.EnsureAsync(new ExecutionTargetRequirements());
+        var second = backend.EnsureAsync(new ExecutionTargetRequirements());
+        await Task.WhenAll(first, second);
+
+        Assert.IsTrue(first.Result.Succeeded);
+        Assert.IsTrue(second.Result.Succeeded);
+        Assert.AreEqual(1, cli.MaxConcurrentLists);
+    }
+
+    private static WindowsSandboxCliResult<IReadOnlyList<string>> SuccessfulList(params string[] ids) =>
+        WindowsSandboxCliResult<IReadOnlyList<string>>.Success(ids);
+
+    private static WindowsSandboxCliResult<IReadOnlyList<string>> FailedList(
+        WindowsSandboxCliFailure failure,
+        string error) =>
+        WindowsSandboxCliResult<IReadOnlyList<string>>.Failed(failure, error);
+
+    private static WindowsSandboxStateReadResult ValidState(
+        string instanceId,
+        string epoch,
+        long revision) =>
+        new(
+            WindowsSandboxStateReadStatus.Valid,
+            new WindowsSandboxTargetState
+            {
+                ProviderInstanceId = instanceId,
+                Epoch = epoch,
+                Revision = revision,
+                CreatedAtUtc = "2026-08-19T12:00:00Z",
+            });
+
+    private sealed class Fixture
+    {
+        public bool IsSupportedHost { get; set; } = true;
+
+        public FakeCli Cli { get; } = new();
+
+        public FakeStateStore State { get; } = new();
+
+        public WindowsSandboxBackend Backend =>
+            new(new FakeHost(IsSupportedHost), Cli, State, new ImmediateMutationLock());
+    }
+
+    private sealed class FakeHost(bool isSupported) : IWindowsSandboxHost
+    {
+        public bool IsSupportedOperatingSystem => isSupported;
+    }
+
+    private sealed class FakeCli : IWindowsSandboxCli
+    {
+        public Queue<WindowsSandboxCliResult<IReadOnlyList<string>>> ListResults { get; } = new();
+
+        public Queue<WindowsSandboxCliResult<string>> StartResults { get; } = new();
+
+        public List<string> StopIds { get; } = [];
+
+        public int ListCount { get; private set; }
+
+        public int StartCount { get; private set; }
+
+        public Exception? StartException { get; set; }
+
+        public WindowsSandboxCliResult<bool> StopResult { get; set; } =
+            WindowsSandboxCliResult<bool>.Success(true);
+
+        public Task<WindowsSandboxCliResult<IReadOnlyList<string>>> ListAsync(
+            CancellationToken cancellationToken = default)
+        {
+            ListCount++;
+            return Task.FromResult(ListResults.Dequeue());
+        }
+
+        public Task<WindowsSandboxCliResult<string>> StartAsync(
+            CancellationToken cancellationToken = default)
+        {
+            StartCount++;
+            if (StartException is not null)
+            {
+                return Task.FromException<WindowsSandboxCliResult<string>>(StartException);
+            }
+            return Task.FromResult(StartResults.Dequeue());
+        }
+
+        public Task<WindowsSandboxCliResult<bool>> StopAsync(
+            string instanceId,
+            CancellationToken cancellationToken = default)
+        {
+            StopIds.Add(instanceId);
+            return Task.FromResult(StopResult);
+        }
+    }
+
+    private sealed class ConcurrentDetectingCli(string instanceId) : IWindowsSandboxCli
+    {
+        private int _activeLists;
+        private int _maxConcurrentLists;
+
+        public int MaxConcurrentLists => _maxConcurrentLists;
+
+        public Task<WindowsSandboxCliResult<IReadOnlyList<string>>> ListAsync(
+            CancellationToken cancellationToken = default)
+        {
+            var active = Interlocked.Increment(ref _activeLists);
+            var currentMax = Volatile.Read(ref _maxConcurrentLists);
+            while (active > currentMax)
+            {
+                currentMax = Interlocked.CompareExchange(ref _maxConcurrentLists, active, currentMax);
+            }
+            Thread.Sleep(100);
+            Interlocked.Decrement(ref _activeLists);
+            return Task.FromResult(SuccessfulList(instanceId));
+        }
+
+        public Task<WindowsSandboxCliResult<string>> StartAsync(
+            CancellationToken cancellationToken = default) =>
+            throw new AssertFailedException("Warm reuse must not start a sandbox.");
+
+        public Task<WindowsSandboxCliResult<bool>> StopAsync(
+            string instanceId,
+            CancellationToken cancellationToken = default) =>
+            throw new AssertFailedException("Warm reuse must not stop a sandbox.");
+    }
+
+    private sealed class FakeStateStore : IWindowsSandboxStateStore
+    {
+        public WindowsSandboxStateReadResult ReadResult { get; set; } =
+            new(WindowsSandboxStateReadStatus.Missing, null);
+
+        public Exception? WriteException { get; set; }
+
+        public List<WindowsSandboxTargetState> Writes { get; } = [];
+
+        public FileInfo GetStateFile() => new("unused");
+
+        public Task<WindowsSandboxStateReadResult> ReadAsync(
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(ReadResult);
+
+        public Task WriteAsync(
+            WindowsSandboxTargetState state,
+            CancellationToken cancellationToken = default)
+        {
+            if (WriteException is not null)
+            {
+                return Task.FromException(WriteException);
+            }
+            Writes.Add(state);
+            ReadResult = new WindowsSandboxStateReadResult(WindowsSandboxStateReadStatus.Valid, state);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class ImmediateMutationLock : IWindowsSandboxMutationLock
+    {
+        public IDisposable Acquire(CancellationToken cancellationToken = default) => new NoopDisposable();
+    }
+
+    private sealed class NoopDisposable : IDisposable
+    {
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/winapp-CLI/WinApp.Cli.Tests/WindowsSandboxBackendTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/WindowsSandboxBackendTests.cs
@@ -225,12 +225,10 @@ public class WindowsSandboxBackendTests
     }
 
     [TestMethod]
-    public async Task EnsureAsync_CorruptStateWithoutLiveInstanceIsReplaced()
+    public async Task EnsureAsync_CorruptStateWithoutLiveInstanceFailsClosed()
     {
         var fixture = new Fixture();
         fixture.Cli.ListResults.Enqueue(SuccessfulList());
-        fixture.Cli.ListResults.Enqueue(SuccessfulList(SandboxOne));
-        fixture.Cli.StartResults.Enqueue(WindowsSandboxCliResult<string>.Success(SandboxOne));
         fixture.State.ReadResult = new WindowsSandboxStateReadResult(
             WindowsSandboxStateReadStatus.Corrupt,
             null,
@@ -238,8 +236,57 @@ public class WindowsSandboxBackendTests
 
         var result = await fixture.Backend.EnsureAsync(new ExecutionTargetRequirements());
 
+        Assert.IsFalse(result.Succeeded);
+        Assert.AreEqual(ExecutionTargetDiagnosticCode.WindowsSandboxStateUnavailable, result.Diagnostics.Single().Code);
+        Assert.AreEqual(0, fixture.Cli.StartCount);
+        Assert.AreEqual(0, fixture.State.Writes.Count);
+    }
+
+    [TestMethod]
+    public async Task GetStatusAsync_CorruptStateWithoutLiveInstanceIsUnavailable()
+    {
+        var fixture = new Fixture();
+        fixture.Cli.ListResults.Enqueue(SuccessfulList());
+        fixture.State.ReadResult = new WindowsSandboxStateReadResult(
+            WindowsSandboxStateReadStatus.Corrupt,
+            null,
+            "corrupt");
+
+        var result = await fixture.Backend.GetStatusAsync();
+
+        Assert.AreEqual(ExecutionTargetStatus.Unavailable, result.Status);
+        Assert.AreEqual(ExecutionTargetDiagnosticCode.WindowsSandboxStateUnavailable, result.Diagnostics.Single().Code);
+    }
+
+    [TestMethod]
+    public async Task EnsureAsync_ExhaustedRevisionFailsBeforeStartingSandbox()
+    {
+        var fixture = new Fixture();
+        fixture.Cli.ListResults.Enqueue(SuccessfulList());
+        fixture.State.ReadResult = ValidState(SandboxOne, EpochOne, long.MaxValue);
+
+        var result = await fixture.Backend.EnsureAsync(new ExecutionTargetRequirements());
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.AreEqual(ExecutionTargetDiagnosticCode.WindowsSandboxStateUnavailable, result.Diagnostics.Single().Code);
+        Assert.AreEqual(0, fixture.Cli.StartCount);
+        Assert.AreEqual(0, fixture.State.Writes.Count);
+    }
+
+    [TestMethod]
+    public async Task EnsureAsync_PenultimateRevisionAdvancesWithoutRollback()
+    {
+        var fixture = new Fixture();
+        fixture.Cli.ListResults.Enqueue(SuccessfulList());
+        fixture.Cli.ListResults.Enqueue(SuccessfulList(SandboxTwo));
+        fixture.Cli.StartResults.Enqueue(WindowsSandboxCliResult<string>.Success(SandboxTwo));
+        fixture.State.ReadResult = ValidState(SandboxOne, EpochOne, long.MaxValue - 1);
+
+        var result = await fixture.Backend.EnsureAsync(new ExecutionTargetRequirements());
+
         Assert.IsTrue(result.Succeeded);
-        Assert.AreEqual(1, fixture.State.Writes.Single().Revision);
+        Assert.AreEqual(long.MaxValue, fixture.State.Writes.Single().Revision);
+        Assert.AreEqual(0, fixture.Cli.StopIds.Count);
     }
 
     [TestMethod]
@@ -292,6 +339,8 @@ public class WindowsSandboxBackendTests
             WindowsSandboxStateReadStatus.Valid,
             new WindowsSandboxTargetState
             {
+                Schema = WindowsSandboxTargetState.CurrentSchema,
+                TargetId = ExecutionTargetRef.WindowsSandboxDefaultId,
                 ProviderInstanceId = instanceId,
                 Epoch = epoch,
                 Revision = revision,

--- a/src/winapp-CLI/WinApp.Cli.Tests/WindowsSandboxCliTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/WindowsSandboxCliTests.cs
@@ -1,0 +1,154 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using System.ComponentModel;
+using WinApp.Cli.ExecutionTargets.WindowsSandbox;
+using WinApp.Cli.Services;
+
+namespace WinApp.Cli.Tests;
+
+[TestClass]
+public class WindowsSandboxCliTests
+{
+    private const string SandboxId = "7cdaf716-6807-4cb6-b23b-f71244b0ee90";
+
+    [TestMethod]
+    public async Task ListAsync_UsesRawOutputAndParsesIds()
+    {
+        var runner = new FakeProcessRunner(new ProcessRunResult(
+            0,
+            $$"""
+            {
+              "WindowsSandboxEnvironments": [
+                { "Id": "{{SandboxId.ToUpperInvariant()}}" }
+              ]
+            }
+            """,
+            ""));
+        var cli = new WindowsSandboxCli(runner);
+
+        var result = await cli.ListAsync();
+
+        Assert.IsTrue(result.Succeeded);
+        CollectionAssert.AreEqual(new[] { SandboxId }, result.Value!.ToArray());
+        AssertRequest(runner.Requests.Single(), "list", "--raw");
+    }
+
+    [TestMethod]
+    public async Task ListAsync_RejectsDuplicateOrMalformedIds()
+    {
+        var duplicateRunner = new FakeProcessRunner(new ProcessRunResult(
+            0,
+            $$"""{"WindowsSandboxEnvironments":[{"Id":"{{SandboxId}}"},{"Id":"{{SandboxId}}"}]}""",
+            ""));
+        var malformedRunner = new FakeProcessRunner(new ProcessRunResult(
+            0,
+            """{"WindowsSandboxEnvironments":[{"Id":"not-a-guid"}]}""",
+            ""));
+
+        var duplicate = await new WindowsSandboxCli(duplicateRunner).ListAsync();
+        var malformed = await new WindowsSandboxCli(malformedRunner).ListAsync();
+
+        Assert.AreEqual(WindowsSandboxCliFailure.IncompatibleOutput, duplicate.Failure);
+        Assert.AreEqual(WindowsSandboxCliFailure.IncompatibleOutput, malformed.Failure);
+    }
+
+    [TestMethod]
+    public async Task StartAsync_UsesRawOutputAndParsesId()
+    {
+        var runner = new FakeProcessRunner(new ProcessRunResult(
+            0,
+            $$"""{"Id":"{{SandboxId.ToUpperInvariant()}}"}""",
+            ""));
+        var cli = new WindowsSandboxCli(runner);
+
+        var result = await cli.StartAsync();
+
+        Assert.IsTrue(result.Succeeded);
+        Assert.AreEqual(SandboxId, result.Value);
+        AssertRequest(runner.Requests.Single(), "start", "--raw");
+    }
+
+    [TestMethod]
+    public async Task StopAsync_PreservesValidatedArgumentBoundary()
+    {
+        var runner = new FakeProcessRunner(new ProcessRunResult(0, "{}", ""));
+        var cli = new WindowsSandboxCli(runner);
+
+        var result = await cli.StopAsync(SandboxId.ToUpperInvariant());
+
+        Assert.IsTrue(result.Succeeded);
+        AssertRequest(runner.Requests.Single(), "stop", "--id", SandboxId, "--raw");
+        await Assert.ThrowsExactlyAsync<ArgumentException>(() => cli.StopAsync("bad --id"));
+    }
+
+    [TestMethod]
+    public async Task CommandFailure_ReturnsFailureWithoutParsingOutput()
+    {
+        var runner = new FakeProcessRunner(new ProcessRunResult(12, "not-json", "feature disabled"));
+        var cli = new WindowsSandboxCli(runner);
+
+        var result = await cli.ListAsync();
+
+        Assert.AreEqual(WindowsSandboxCliFailure.CommandFailed, result.Failure);
+        StringAssert.Contains(result.Error, "feature disabled");
+    }
+
+    [TestMethod]
+    public async Task MissingExecutable_ReturnsSpecificFailure()
+    {
+        var runner = new FakeProcessRunner(new Win32Exception(2, "not found"));
+        var cli = new WindowsSandboxCli(runner);
+
+        var result = await cli.ListAsync();
+
+        Assert.AreEqual(WindowsSandboxCliFailure.ExecutableMissing, result.Failure);
+    }
+
+    [TestMethod]
+    public async Task Cancellation_Propagates()
+    {
+        var runner = new FakeProcessRunner(new OperationCanceledException());
+        var cli = new WindowsSandboxCli(runner);
+
+        await Assert.ThrowsExactlyAsync<OperationCanceledException>(() => cli.ListAsync());
+    }
+
+    private static void AssertRequest(ProcessRunRequest request, params string[] expectedArguments)
+    {
+        Assert.AreEqual("wsb.exe", request.FileName);
+        CollectionAssert.AreEqual(expectedArguments, request.Arguments.ToArray());
+    }
+
+    private sealed class FakeProcessRunner : IProcessRunner
+    {
+        private readonly ProcessRunResult? _result;
+        private readonly Exception? _exception;
+
+        public FakeProcessRunner(ProcessRunResult result)
+        {
+            _result = result;
+        }
+
+        public FakeProcessRunner(Exception exception)
+        {
+            _exception = exception;
+        }
+
+        public List<ProcessRunRequest> Requests { get; } = [];
+
+        public Task<ProcessRunResult> RunAsync(
+            ProcessRunRequest request,
+            Action<string>? onOutputLine = null,
+            Action<string>? onErrorLine = null,
+            CancellationToken cancellationToken = default)
+        {
+            Requests.Add(request);
+            if (_exception is not null)
+            {
+                return Task.FromException<ProcessRunResult>(_exception);
+            }
+            return Task.FromResult(_result!);
+        }
+    }
+}

--- a/src/winapp-CLI/WinApp.Cli.Tests/WindowsSandboxCliTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/WindowsSandboxCliTests.cs
@@ -54,6 +54,19 @@ public class WindowsSandboxCliTests
     }
 
     [TestMethod]
+    public async Task ListAsync_RejectsNullEnvironmentEntries()
+    {
+        var runner = new FakeProcessRunner(new ProcessRunResult(
+            0,
+            """{"WindowsSandboxEnvironments":[null]}""",
+            ""));
+
+        var result = await new WindowsSandboxCli(runner).ListAsync();
+
+        Assert.AreEqual(WindowsSandboxCliFailure.IncompatibleOutput, result.Failure);
+    }
+
+    [TestMethod]
     public async Task StartAsync_UsesRawOutputAndParsesId()
     {
         var runner = new FakeProcessRunner(new ProcessRunResult(

--- a/src/winapp-CLI/WinApp.Cli.Tests/WindowsSandboxMutationLockTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/WindowsSandboxMutationLockTests.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using WinApp.Cli.ExecutionTargets.WindowsSandbox;
+
+namespace WinApp.Cli.Tests;
+
+[TestClass]
+public class WindowsSandboxMutationLockTests
+{
+    [TestMethod]
+    public void Acquire_WaitsForCurrentOwnerAndHonorsCancellation()
+    {
+        var mutexName = @"Local\WinApp.Cli.Tests." + Guid.NewGuid().ToString("N");
+        var mutationLock = new WindowsSandboxMutationLock(mutexName);
+        using var acquired = new ManualResetEventSlim();
+        using var release = new ManualResetEventSlim();
+        var owner = new Thread(() =>
+        {
+            using var first = mutationLock.Acquire();
+            acquired.Set();
+            release.Wait();
+        });
+        owner.Start();
+        Assert.IsTrue(acquired.Wait(TimeSpan.FromSeconds(5)));
+
+        try
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(250));
+            Assert.ThrowsExactly<OperationCanceledException>(
+                () => mutationLock.Acquire(cts.Token));
+        }
+        finally
+        {
+            release.Set();
+            Assert.IsTrue(owner.Join(TimeSpan.FromSeconds(5)));
+        }
+    }
+}

--- a/src/winapp-CLI/WinApp.Cli.Tests/WindowsSandboxMutationLockTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/WindowsSandboxMutationLockTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Security.Principal;
 using WinApp.Cli.ExecutionTargets.WindowsSandbox;
 
 namespace WinApp.Cli.Tests;
@@ -8,6 +9,18 @@ namespace WinApp.Cli.Tests;
 [TestClass]
 public class WindowsSandboxMutationLockTests
 {
+    [TestMethod]
+    public void DefaultName_IsGlobalAndScopedToCurrentUserSid()
+    {
+        using var identity = WindowsIdentity.GetCurrent(TokenAccessLevels.Query);
+        var sid = identity.User;
+        Assert.IsNotNull(sid);
+
+        var mutationLock = new WindowsSandboxMutationLock();
+
+        Assert.AreEqual(WindowsSandboxMutationLock.DefaultNamePrefix + sid.Value, mutationLock.Name);
+    }
+
     [TestMethod]
     public void Acquire_WaitsForCurrentOwnerAndHonorsCancellation()
     {

--- a/src/winapp-CLI/WinApp.Cli.Tests/WindowsSandboxStateStoreTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/WindowsSandboxStateStoreTests.cs
@@ -1,0 +1,174 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using WinApp.Cli.ExecutionTargets;
+using WinApp.Cli.ExecutionTargets.WindowsSandbox;
+
+namespace WinApp.Cli.Tests;
+
+[TestClass]
+public class WindowsSandboxStateStoreTests
+{
+    private DirectoryInfo _tempDirectory = null!;
+    private WindowsSandboxStateStore _store = null!;
+
+    public TestContext TestContext { get; set; } = null!;
+
+    [TestInitialize]
+    public void Initialize()
+    {
+        _tempDirectory = Directory.CreateDirectory(
+            Path.Combine(Path.GetTempPath(), "winapp-wsb-state-tests", Guid.NewGuid().ToString("N")));
+        _store = new WindowsSandboxStateStore(new FakeStateDirectoryProvider(_tempDirectory));
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        try
+        {
+            _tempDirectory.Delete(recursive: true);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // Best-effort cleanup of the per-test temporary directory.
+        }
+    }
+
+    [TestMethod]
+    public async Task ReadAsync_WhenMissing_ReturnsMissing()
+    {
+        var result = await _store.ReadAsync(TestContext.CancellationToken);
+
+        Assert.AreEqual(WindowsSandboxStateReadStatus.Missing, result.Status);
+        Assert.IsNull(result.State);
+    }
+
+    [TestMethod]
+    public async Task WriteAndReadAsync_RoundTripsVersionedState()
+    {
+        var expected = CreateState("sandbox-1", "0123456789abcdef0123456789abcdef", 7);
+
+        await _store.WriteAsync(expected, TestContext.CancellationToken);
+        var result = await _store.ReadAsync(TestContext.CancellationToken);
+
+        Assert.AreEqual(WindowsSandboxStateReadStatus.Valid, result.Status);
+        Assert.IsNotNull(result.State);
+        Assert.AreEqual(expected.ProviderInstanceId, result.State.ProviderInstanceId);
+        Assert.AreEqual(expected.Epoch, result.State.Epoch);
+        Assert.AreEqual(expected.Revision, result.State.Revision);
+
+        var json = await File.ReadAllTextAsync(_store.GetStateFile().FullName, TestContext.CancellationToken);
+        StringAssert.Contains(json, "\"provider_instance_id\"");
+        StringAssert.Contains(json, "\"schema\": 1");
+        Assert.IsTrue(json.EndsWith('\n'), "State JSON must end with a line feed.");
+        Assert.AreEqual(0, Directory.GetFiles(_store.GetStateFile().DirectoryName!, "*.tmp-*").Length);
+    }
+
+    [TestMethod]
+    public async Task WriteAsync_AtomicallyReplacesExistingState()
+    {
+        await _store.WriteAsync(
+            CreateState("sandbox-1", "0123456789abcdef0123456789abcdef", 1),
+            TestContext.CancellationToken);
+        await _store.WriteAsync(
+            CreateState("sandbox-2", "abcdef0123456789abcdef0123456789", 2),
+            TestContext.CancellationToken);
+
+        var result = await _store.ReadAsync(TestContext.CancellationToken);
+
+        Assert.AreEqual(WindowsSandboxStateReadStatus.Valid, result.Status);
+        Assert.AreEqual("sandbox-2", result.State!.ProviderInstanceId);
+        Assert.AreEqual(2, result.State.Revision);
+    }
+
+    [TestMethod]
+    public async Task ReadAsync_WhenJsonIsCorrupt_ReturnsCorrupt()
+    {
+        var path = _store.GetStateFile();
+        path.Directory!.Create();
+        await File.WriteAllTextAsync(path.FullName, "{not-json", TestContext.CancellationToken);
+
+        var result = await _store.ReadAsync(TestContext.CancellationToken);
+
+        Assert.AreEqual(WindowsSandboxStateReadStatus.Corrupt, result.Status);
+        Assert.IsNull(result.State);
+    }
+
+    [TestMethod]
+    public async Task ReadAsync_WhenSchemaIsNewer_ReturnsUnsupportedVersion()
+    {
+        var path = _store.GetStateFile();
+        path.Directory!.Create();
+        await File.WriteAllTextAsync(
+            path.FullName,
+            """
+            {
+              "schema": 999,
+              "target_id": "windows-sandbox:default",
+              "provider_instance_id": "sandbox-1",
+              "epoch": "0123456789abcdef0123456789abcdef",
+              "revision": 1,
+              "created_at_utc": "2026-08-19T12:00:00Z"
+            }
+            """,
+            TestContext.CancellationToken);
+
+        var result = await _store.ReadAsync(TestContext.CancellationToken);
+
+        Assert.AreEqual(WindowsSandboxStateReadStatus.UnsupportedVersion, result.Status);
+        Assert.IsNull(result.State);
+    }
+
+    [TestMethod]
+    public async Task ReadAsync_WhenRevisionCannotAdvance_ReturnsCorrupt()
+    {
+        var path = _store.GetStateFile();
+        path.Directory!.Create();
+        await File.WriteAllTextAsync(
+            path.FullName,
+            $$"""
+            {
+              "schema": 1,
+              "target_id": "windows-sandbox:default",
+              "provider_instance_id": "sandbox-1",
+              "epoch": "0123456789abcdef0123456789abcdef",
+              "revision": {{long.MaxValue}},
+              "created_at_utc": "2026-08-19T12:00:00Z"
+            }
+            """,
+            TestContext.CancellationToken);
+
+        var result = await _store.ReadAsync(TestContext.CancellationToken);
+
+        Assert.AreEqual(WindowsSandboxStateReadStatus.Corrupt, result.Status);
+        Assert.IsNull(result.State);
+    }
+
+    [TestMethod]
+    public async Task WriteAsync_RejectsMalformedStateBeforeWriting()
+    {
+        var state = CreateState("", "bad-epoch", 0);
+
+        await Assert.ThrowsExactlyAsync<ArgumentException>(
+            () => _store.WriteAsync(state, TestContext.CancellationToken));
+        Assert.IsFalse(_store.GetStateFile().Exists);
+    }
+
+    private static WindowsSandboxTargetState CreateState(string instanceId, string epoch, long revision) =>
+        new()
+        {
+            ProviderInstanceId = instanceId,
+            Epoch = epoch,
+            Revision = revision,
+            CreatedAtUtc = "2026-08-19T12:00:00Z",
+        };
+
+    private sealed class FakeStateDirectoryProvider(DirectoryInfo root) : IExecutionTargetStateDirectoryProvider
+    {
+        public DirectoryInfo GetStateRoot() => root;
+
+        public DirectoryInfo GetTargetDirectory(ExecutionTargetRef target) =>
+            new(Path.Combine(root.FullName, target.Id.Replace(':', '-')));
+    }
+}

--- a/src/winapp-CLI/WinApp.Cli.Tests/WindowsSandboxStateStoreTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/WindowsSandboxStateStoreTests.cs
@@ -96,6 +96,46 @@ public class WindowsSandboxStateStoreTests
     }
 
     [TestMethod]
+    public async Task ReadAsync_WhenSchemaMetadataIsMissing_ReturnsCorrupt()
+    {
+        await WriteRawStateAsync(
+            """
+            {
+              "target_id": "windows-sandbox:default",
+              "provider_instance_id": "sandbox-1",
+              "epoch": "0123456789abcdef0123456789abcdef",
+              "revision": 1,
+              "created_at_utc": "2026-08-19T12:00:00Z"
+            }
+            """);
+
+        var result = await _store.ReadAsync(TestContext.CancellationToken);
+
+        Assert.AreEqual(WindowsSandboxStateReadStatus.Corrupt, result.Status);
+        Assert.IsNull(result.State);
+    }
+
+    [TestMethod]
+    public async Task ReadAsync_WhenTargetMetadataIsMissing_ReturnsCorrupt()
+    {
+        await WriteRawStateAsync(
+            """
+            {
+              "schema": 1,
+              "provider_instance_id": "sandbox-1",
+              "epoch": "0123456789abcdef0123456789abcdef",
+              "revision": 1,
+              "created_at_utc": "2026-08-19T12:00:00Z"
+            }
+            """);
+
+        var result = await _store.ReadAsync(TestContext.CancellationToken);
+
+        Assert.AreEqual(WindowsSandboxStateReadStatus.Corrupt, result.Status);
+        Assert.IsNull(result.State);
+    }
+
+    [TestMethod]
     public async Task ReadAsync_WhenSchemaIsNewer_ReturnsUnsupportedVersion()
     {
         var path = _store.GetStateFile();
@@ -121,7 +161,7 @@ public class WindowsSandboxStateStoreTests
     }
 
     [TestMethod]
-    public async Task ReadAsync_WhenRevisionCannotAdvance_ReturnsCorrupt()
+    public async Task ReadAsync_WhenRevisionIsMaximum_ReturnsValidForFailClosedReconciliation()
     {
         var path = _store.GetStateFile();
         path.Directory!.Create();
@@ -141,8 +181,39 @@ public class WindowsSandboxStateStoreTests
 
         var result = await _store.ReadAsync(TestContext.CancellationToken);
 
-        Assert.AreEqual(WindowsSandboxStateReadStatus.Corrupt, result.Status);
-        Assert.IsNull(result.State);
+        Assert.AreEqual(WindowsSandboxStateReadStatus.Valid, result.Status);
+        Assert.AreEqual(long.MaxValue, result.State!.Revision);
+    }
+
+    [TestMethod]
+    public async Task ReadAsync_WhenMissingThroughJunction_ReturnsUnsafePath()
+    {
+        var realDirectory = Directory.CreateDirectory(Path.Combine(_tempDirectory.FullName, "real-target"));
+        var targetDirectory = Path.Combine(_tempDirectory.FullName, "windows-sandbox-default");
+        if (!TryCreateJunction(targetDirectory, realDirectory.FullName))
+        {
+            Assert.Inconclusive("Could not create a junction.");
+            return;
+        }
+
+        try
+        {
+            var result = await _store.ReadAsync(TestContext.CancellationToken);
+
+            Assert.AreEqual(WindowsSandboxStateReadStatus.UnsafePath, result.Status);
+            Assert.IsNull(result.State);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(targetDirectory, recursive: false);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                // Best-effort cleanup of the test junction.
+            }
+        }
     }
 
     [TestMethod]
@@ -158,11 +229,48 @@ public class WindowsSandboxStateStoreTests
     private static WindowsSandboxTargetState CreateState(string instanceId, string epoch, long revision) =>
         new()
         {
+            Schema = WindowsSandboxTargetState.CurrentSchema,
+            TargetId = ExecutionTargetRef.WindowsSandboxDefaultId,
             ProviderInstanceId = instanceId,
             Epoch = epoch,
             Revision = revision,
             CreatedAtUtc = "2026-08-19T12:00:00Z",
         };
+
+    private async Task WriteRawStateAsync(string json)
+    {
+        var path = _store.GetStateFile();
+        path.Directory!.Create();
+        await File.WriteAllTextAsync(path.FullName, json, TestContext.CancellationToken);
+    }
+
+    private static bool TryCreateJunction(string link, string target)
+    {
+        try
+        {
+            var startInfo = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "cmd.exe",
+                Arguments = $"/c mklink /J \"{link}\" \"{target}\"",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            using var process = System.Diagnostics.Process.Start(startInfo);
+            if (process is null)
+            {
+                return false;
+            }
+
+            process.WaitForExit(5000);
+            return process.ExitCode == 0 && Directory.Exists(link);
+        }
+        catch
+        {
+            return false;
+        }
+    }
 
     private sealed class FakeStateDirectoryProvider(DirectoryInfo root) : IExecutionTargetStateDirectoryProvider
     {

--- a/src/winapp-CLI/WinApp.Cli/ExecutionTargets/ExecutionTargetContracts.cs
+++ b/src/winapp-CLI/WinApp.Cli/ExecutionTargets/ExecutionTargetContracts.cs
@@ -1,0 +1,139 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+namespace WinApp.Cli.ExecutionTargets;
+
+internal sealed record ExecutionTargetRef
+{
+    public const string WindowsSandboxKind = "windows-sandbox";
+    public const string WindowsSandboxDefaultId = "windows-sandbox:default";
+
+    public static ExecutionTargetRef WindowsSandboxDefault { get; } =
+        new(WindowsSandboxKind, WindowsSandboxDefaultId);
+
+    public string Kind { get; }
+
+    public string Id { get; }
+
+    public ExecutionTargetRef(string kind, string id)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(kind);
+        ArgumentException.ThrowIfNullOrWhiteSpace(id);
+
+        if (!IsValidSegment(kind))
+        {
+            throw new ArgumentException("Execution target kinds may contain only lowercase letters, digits, and hyphens.", nameof(kind));
+        }
+
+        if (!id.StartsWith(kind + ":", StringComparison.Ordinal) ||
+            !IsValidSegment(id[(kind.Length + 1)..]))
+        {
+            throw new ArgumentException("Execution target IDs must use the form '<kind>:<name>' with lowercase letters, digits, and hyphens.", nameof(id));
+        }
+
+        Kind = kind;
+        Id = id;
+    }
+
+    private static bool IsValidSegment(string value) =>
+        value.Length > 0 &&
+        value.All(static c => c is >= 'a' and <= 'z' or >= '0' and <= '9' or '-');
+}
+
+internal readonly record struct ExecutionTargetEpoch
+{
+    public string Value { get; }
+
+    public ExecutionTargetEpoch(string value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        if (value.Length != 32 || !value.All(Uri.IsHexDigit))
+        {
+            throw new ArgumentException("Execution target epochs must be 32 hexadecimal characters.", nameof(value));
+        }
+
+        Value = value.ToLowerInvariant();
+    }
+
+    public static ExecutionTargetEpoch Create() => new(Guid.NewGuid().ToString("N"));
+
+    public override string ToString() => Value;
+}
+
+internal sealed record ExecutionTargetRequirements(
+    bool Running = true,
+    bool InteractiveDesktop = false);
+
+internal sealed record ExecutionTargetCapabilities(
+    bool Running,
+    bool InteractiveDesktop,
+    bool GuestExecution,
+    bool RealInput,
+    bool ScreenCapture,
+    bool PersistentStorage)
+{
+    public static ExecutionTargetCapabilities Stopped { get; } =
+        new(false, false, false, false, false, false);
+
+    public bool Satisfies(ExecutionTargetRequirements requirements) =>
+        (!requirements.Running || Running) &&
+        (!requirements.InteractiveDesktop || InteractiveDesktop);
+}
+
+internal enum ExecutionTargetStatus
+{
+    Unavailable,
+    Stopped,
+    Running,
+    Unmanaged,
+}
+
+internal enum ExecutionTargetDiagnosticCode
+{
+    UnsupportedHost,
+    BackendMismatch,
+    CapabilityUnavailable,
+    WindowsSandboxCliMissing,
+    WindowsSandboxCliIncompatible,
+    WindowsSandboxListFailed,
+    WindowsSandboxStartFailed,
+    WindowsSandboxRollbackFailed,
+    WindowsSandboxUnmanagedInstance,
+    WindowsSandboxStateUnavailable,
+}
+
+internal sealed record ExecutionTargetDiagnostic(
+    ExecutionTargetDiagnosticCode Code,
+    string Message,
+    string? RecoveryCommand = null);
+
+internal sealed record ExecutionTargetProbeResult(
+    bool IsSupported,
+    IReadOnlyList<ExecutionTargetDiagnostic> Diagnostics)
+{
+    public static ExecutionTargetProbeResult Supported { get; } = new(true, []);
+}
+
+internal sealed record ExecutionTargetStatusResult(
+    ExecutionTargetRef Target,
+    ExecutionTargetStatus Status,
+    string? ProviderInstanceId,
+    ExecutionTargetEpoch? Epoch,
+    ExecutionTargetCapabilities Capabilities,
+    IReadOnlyList<ExecutionTargetDiagnostic> Diagnostics);
+
+internal sealed record ExecutionTargetInstance(
+    ExecutionTargetRef Target,
+    string ProviderInstanceId,
+    ExecutionTargetEpoch Epoch,
+    ExecutionTargetCapabilities Capabilities);
+
+internal sealed record ExecutionTargetEnsureResult(
+    ExecutionTargetInstance? Instance,
+    IReadOnlyList<ExecutionTargetDiagnostic> Diagnostics)
+{
+    public bool Succeeded => Instance is not null && Diagnostics.Count == 0;
+
+    public static ExecutionTargetEnsureResult Failure(params ExecutionTargetDiagnostic[] diagnostics) =>
+        new(null, diagnostics);
+}

--- a/src/winapp-CLI/WinApp.Cli/ExecutionTargets/ExecutionTargetService.cs
+++ b/src/winapp-CLI/WinApp.Cli/ExecutionTargets/ExecutionTargetService.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+namespace WinApp.Cli.ExecutionTargets;
+
+internal sealed class ExecutionTargetService(IExecutionTargetBackend backend) : IExecutionTargetService
+{
+    public Task<ExecutionTargetProbeResult> ProbeAsync(
+        ExecutionTargetRef target,
+        CancellationToken cancellationToken = default)
+    {
+        if (target != backend.Target)
+        {
+            return Task.FromResult(new ExecutionTargetProbeResult(false, [BackendMismatch(target)]));
+        }
+
+        return backend.ProbeAsync(cancellationToken);
+    }
+
+    public Task<ExecutionTargetStatusResult> GetStatusAsync(
+        ExecutionTargetRef target,
+        CancellationToken cancellationToken = default)
+    {
+        if (target != backend.Target)
+        {
+            return Task.FromResult(new ExecutionTargetStatusResult(
+                target,
+                ExecutionTargetStatus.Unavailable,
+                null,
+                null,
+                ExecutionTargetCapabilities.Stopped,
+                [BackendMismatch(target)]));
+        }
+
+        return backend.GetStatusAsync(cancellationToken);
+    }
+
+    public async Task<ExecutionTargetEnsureResult> EnsureAsync(
+        ExecutionTargetRef target,
+        ExecutionTargetRequirements requirements,
+        CancellationToken cancellationToken = default)
+    {
+        if (target != backend.Target)
+        {
+            return ExecutionTargetEnsureResult.Failure(BackendMismatch(target));
+        }
+
+        var result = await backend.EnsureAsync(requirements, cancellationToken);
+        if (result.Instance is not null && !result.Instance.Capabilities.Satisfies(requirements))
+        {
+            return ExecutionTargetEnsureResult.Failure(new ExecutionTargetDiagnostic(
+                ExecutionTargetDiagnosticCode.CapabilityUnavailable,
+                $"Execution target '{target.Id}' does not satisfy the requested capabilities."));
+        }
+
+        return result;
+    }
+
+    private ExecutionTargetDiagnostic BackendMismatch(ExecutionTargetRef requested) =>
+        new(
+            ExecutionTargetDiagnosticCode.BackendMismatch,
+            $"Execution target backend '{backend.Target.Id}' cannot handle '{requested.Id}'.");
+}

--- a/src/winapp-CLI/WinApp.Cli/ExecutionTargets/ExecutionTargetStateDirectoryProvider.cs
+++ b/src/winapp-CLI/WinApp.Cli/ExecutionTargets/ExecutionTargetStateDirectoryProvider.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+namespace WinApp.Cli.ExecutionTargets;
+
+internal interface IExecutionTargetStateDirectoryProvider
+{
+    DirectoryInfo GetStateRoot();
+
+    DirectoryInfo GetTargetDirectory(ExecutionTargetRef target);
+}
+
+internal sealed class ExecutionTargetStateDirectoryProvider : IExecutionTargetStateDirectoryProvider
+{
+    public DirectoryInfo GetStateRoot()
+    {
+        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        if (string.IsNullOrWhiteSpace(localAppData))
+        {
+            throw new InvalidOperationException("The local application data directory is unavailable.");
+        }
+
+        return new DirectoryInfo(Path.Combine(localAppData, "Microsoft", "WinApp", "Targets"));
+    }
+
+    public DirectoryInfo GetTargetDirectory(ExecutionTargetRef target) =>
+        new(Path.Combine(GetStateRoot().FullName, target.Id.Replace(':', '-')));
+}

--- a/src/winapp-CLI/WinApp.Cli/ExecutionTargets/IExecutionTargetBackend.cs
+++ b/src/winapp-CLI/WinApp.Cli/ExecutionTargets/IExecutionTargetBackend.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+namespace WinApp.Cli.ExecutionTargets;
+
+internal interface IExecutionTargetBackend
+{
+    ExecutionTargetRef Target { get; }
+
+    Task<ExecutionTargetProbeResult> ProbeAsync(CancellationToken cancellationToken = default);
+
+    Task<ExecutionTargetStatusResult> GetStatusAsync(CancellationToken cancellationToken = default);
+
+    Task<ExecutionTargetEnsureResult> EnsureAsync(
+        ExecutionTargetRequirements requirements,
+        CancellationToken cancellationToken = default);
+}
+
+internal interface IExecutionTargetService
+{
+    Task<ExecutionTargetProbeResult> ProbeAsync(
+        ExecutionTargetRef target,
+        CancellationToken cancellationToken = default);
+
+    Task<ExecutionTargetStatusResult> GetStatusAsync(
+        ExecutionTargetRef target,
+        CancellationToken cancellationToken = default);
+
+    Task<ExecutionTargetEnsureResult> EnsureAsync(
+        ExecutionTargetRef target,
+        ExecutionTargetRequirements requirements,
+        CancellationToken cancellationToken = default);
+}

--- a/src/winapp-CLI/WinApp.Cli/ExecutionTargets/WindowsSandbox/IWindowsSandboxCli.cs
+++ b/src/winapp-CLI/WinApp.Cli/ExecutionTargets/WindowsSandbox/IWindowsSandboxCli.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+namespace WinApp.Cli.ExecutionTargets.WindowsSandbox;
+
+internal enum WindowsSandboxCliFailure
+{
+    ExecutableMissing,
+    CommandFailed,
+    IncompatibleOutput,
+}
+
+internal sealed record WindowsSandboxCliResult<T>(
+    T? Value,
+    WindowsSandboxCliFailure? Failure,
+    string? Error)
+{
+    public bool Succeeded => Failure is null;
+
+    public static WindowsSandboxCliResult<T> Success(T value) => new(value, null, null);
+
+    public static WindowsSandboxCliResult<T> Failed(
+        WindowsSandboxCliFailure failure,
+        string error) => new(default, failure, error);
+}
+
+internal interface IWindowsSandboxCli
+{
+    Task<WindowsSandboxCliResult<IReadOnlyList<string>>> ListAsync(
+        CancellationToken cancellationToken = default);
+
+    Task<WindowsSandboxCliResult<string>> StartAsync(
+        CancellationToken cancellationToken = default);
+
+    Task<WindowsSandboxCliResult<bool>> StopAsync(
+        string instanceId,
+        CancellationToken cancellationToken = default);
+}

--- a/src/winapp-CLI/WinApp.Cli/ExecutionTargets/WindowsSandbox/IWindowsSandboxStateStore.cs
+++ b/src/winapp-CLI/WinApp.Cli/ExecutionTargets/WindowsSandbox/IWindowsSandboxStateStore.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+namespace WinApp.Cli.ExecutionTargets.WindowsSandbox;
+
+internal interface IWindowsSandboxStateStore
+{
+    FileInfo GetStateFile();
+
+    Task<WindowsSandboxStateReadResult> ReadAsync(CancellationToken cancellationToken = default);
+
+    Task WriteAsync(WindowsSandboxTargetState state, CancellationToken cancellationToken = default);
+}

--- a/src/winapp-CLI/WinApp.Cli/ExecutionTargets/WindowsSandbox/WindowsSandboxBackend.cs
+++ b/src/winapp-CLI/WinApp.Cli/ExecutionTargets/WindowsSandbox/WindowsSandboxBackend.cs
@@ -1,0 +1,317 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Globalization;
+
+namespace WinApp.Cli.ExecutionTargets.WindowsSandbox;
+
+internal sealed class WindowsSandboxBackend(
+    IWindowsSandboxHost host,
+    IWindowsSandboxCli cli,
+    IWindowsSandboxStateStore stateStore,
+    IWindowsSandboxMutationLock mutationLock) : IExecutionTargetBackend
+{
+    private static readonly ExecutionTargetCapabilities RunningCapabilities =
+        new(true, false, false, false, false, false);
+
+    public ExecutionTargetRef Target => ExecutionTargetRef.WindowsSandboxDefault;
+
+    public async Task<ExecutionTargetProbeResult> ProbeAsync(
+        CancellationToken cancellationToken = default)
+    {
+        if (!host.IsSupportedOperatingSystem)
+        {
+            return new ExecutionTargetProbeResult(false, [UnsupportedHost()]);
+        }
+
+        var list = await cli.ListAsync(cancellationToken);
+        if (!list.Succeeded)
+        {
+            return new ExecutionTargetProbeResult(false, [CliDiagnostic(list)]);
+        }
+
+        return ExecutionTargetProbeResult.Supported;
+    }
+
+    public async Task<ExecutionTargetStatusResult> GetStatusAsync(
+        CancellationToken cancellationToken = default)
+    {
+        if (!host.IsSupportedOperatingSystem)
+        {
+            return UnavailableStatus(UnsupportedHost());
+        }
+
+        var list = await cli.ListAsync(cancellationToken);
+        if (!list.Succeeded)
+        {
+            return UnavailableStatus(CliDiagnostic(list));
+        }
+
+        var state = await stateStore.ReadAsync(cancellationToken);
+        return ReconcileStatus(list.Value!, state);
+    }
+
+    public Task<ExecutionTargetEnsureResult> EnsureAsync(
+        ExecutionTargetRequirements requirements,
+        CancellationToken cancellationToken = default)
+    {
+        if (requirements.InteractiveDesktop)
+        {
+            return Task.FromResult(ExecutionTargetEnsureResult.Failure(new ExecutionTargetDiagnostic(
+                ExecutionTargetDiagnosticCode.CapabilityUnavailable,
+                "The Windows Sandbox foundation does not establish an interactive guest session.")));
+        }
+
+        return Task.Run(() => EnsureUnderLock(cancellationToken), cancellationToken);
+    }
+
+    private ExecutionTargetEnsureResult EnsureUnderLock(CancellationToken cancellationToken)
+    {
+        using var lease = mutationLock.Acquire(cancellationToken);
+
+        if (!host.IsSupportedOperatingSystem)
+        {
+            return ExecutionTargetEnsureResult.Failure(UnsupportedHost());
+        }
+
+        var list = cli.ListAsync(cancellationToken).GetAwaiter().GetResult();
+        if (!list.Succeeded)
+        {
+            return ExecutionTargetEnsureResult.Failure(CliDiagnostic(list));
+        }
+
+        var stateRead = stateStore.ReadAsync(cancellationToken).GetAwaiter().GetResult();
+        var runningIds = list.Value!;
+        if (runningIds.Count > 0)
+        {
+            return EnsureExisting(runningIds, stateRead);
+        }
+
+        if (stateRead.Status is WindowsSandboxStateReadStatus.UnsupportedVersion
+            or WindowsSandboxStateReadStatus.UnsafePath)
+        {
+            return ExecutionTargetEnsureResult.Failure(StateDiagnostic(stateRead));
+        }
+
+        // Without a returned ID, a post-cancellation singleton cannot be distinguished
+        // from an externally started Sandbox and must not be stopped automatically.
+        var start = cli.StartAsync(cancellationToken).GetAwaiter().GetResult();
+        if (!start.Succeeded)
+        {
+            return ExecutionTargetEnsureResult.Failure(StartDiagnostic(start));
+        }
+
+        var startedId = start.Value!;
+        try
+        {
+            var confirmation = cli.ListAsync(cancellationToken).GetAwaiter().GetResult();
+            if (!confirmation.Succeeded ||
+                confirmation.Value!.Count != 1 ||
+                !string.Equals(confirmation.Value[0], startedId, StringComparison.OrdinalIgnoreCase))
+            {
+                var detail = confirmation.Succeeded
+                    ? "The newly started Windows Sandbox could not be confirmed as the only running instance."
+                    : confirmation.Error!;
+                return FailureWithRollback(new ExecutionTargetDiagnostic(
+                    ExecutionTargetDiagnosticCode.WindowsSandboxStartFailed,
+                    detail,
+                    RecoveryCommand(startedId)),
+                    startedId);
+            }
+
+            var epoch = ExecutionTargetEpoch.Create();
+            var previousRevision = stateRead.State?.Revision ?? 0;
+            var state = new WindowsSandboxTargetState
+            {
+                ProviderInstanceId = startedId,
+                Epoch = epoch.Value,
+                Revision = checked(previousRevision + 1),
+                CreatedAtUtc = DateTimeOffset.UtcNow.ToString("O", CultureInfo.InvariantCulture),
+            };
+
+            try
+            {
+                stateStore.WriteAsync(state, cancellationToken).GetAwaiter().GetResult();
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException)
+            {
+                return FailureWithRollback(new ExecutionTargetDiagnostic(
+                    ExecutionTargetDiagnosticCode.WindowsSandboxStateUnavailable,
+                    $"Failed to commit Windows Sandbox ownership state: {ex.Message}",
+                    RecoveryCommand(startedId)),
+                    startedId);
+            }
+
+            return Success(startedId, epoch);
+        }
+        catch (OperationCanceledException)
+        {
+            _ = Rollback(startedId);
+            throw;
+        }
+    }
+
+    private ExecutionTargetEnsureResult EnsureExisting(
+        IReadOnlyList<string> runningIds,
+        WindowsSandboxStateReadResult stateRead)
+    {
+        if (stateRead.Status is WindowsSandboxStateReadStatus.Corrupt
+            or WindowsSandboxStateReadStatus.UnsupportedVersion
+            or WindowsSandboxStateReadStatus.UnsafePath)
+        {
+            return ExecutionTargetEnsureResult.Failure(StateDiagnostic(stateRead));
+        }
+
+        if (runningIds.Count == 1 &&
+            stateRead.Status == WindowsSandboxStateReadStatus.Valid &&
+            string.Equals(
+                runningIds[0],
+                stateRead.State!.ProviderInstanceId,
+                StringComparison.OrdinalIgnoreCase))
+        {
+            return Success(
+                runningIds[0],
+                new ExecutionTargetEpoch(stateRead.State.Epoch));
+        }
+
+        return ExecutionTargetEnsureResult.Failure(UnmanagedDiagnostic(runningIds));
+    }
+
+    private ExecutionTargetStatusResult ReconcileStatus(
+        IReadOnlyList<string> runningIds,
+        WindowsSandboxStateReadResult stateRead)
+    {
+        if (runningIds.Count == 0)
+        {
+            if (stateRead.Status is WindowsSandboxStateReadStatus.UnsupportedVersion
+                or WindowsSandboxStateReadStatus.UnsafePath)
+            {
+                return UnavailableStatus(StateDiagnostic(stateRead));
+            }
+
+            return new ExecutionTargetStatusResult(
+                Target,
+                ExecutionTargetStatus.Stopped,
+                null,
+                null,
+                ExecutionTargetCapabilities.Stopped,
+                []);
+        }
+
+        if (stateRead.Status is WindowsSandboxStateReadStatus.Corrupt
+            or WindowsSandboxStateReadStatus.UnsupportedVersion
+            or WindowsSandboxStateReadStatus.UnsafePath)
+        {
+            return UnavailableStatus(StateDiagnostic(stateRead));
+        }
+
+        if (runningIds.Count == 1 &&
+            stateRead.Status == WindowsSandboxStateReadStatus.Valid &&
+            string.Equals(
+                runningIds[0],
+                stateRead.State!.ProviderInstanceId,
+                StringComparison.OrdinalIgnoreCase))
+        {
+            return new ExecutionTargetStatusResult(
+                Target,
+                ExecutionTargetStatus.Running,
+                runningIds[0],
+                new ExecutionTargetEpoch(stateRead.State.Epoch),
+                RunningCapabilities,
+                []);
+        }
+
+        var diagnostic = UnmanagedDiagnostic(runningIds);
+        return new ExecutionTargetStatusResult(
+            Target,
+            ExecutionTargetStatus.Unmanaged,
+            null,
+            null,
+            ExecutionTargetCapabilities.Stopped,
+            [diagnostic]);
+    }
+
+    private ExecutionTargetEnsureResult FailureWithRollback(
+        ExecutionTargetDiagnostic primary,
+        string instanceId)
+    {
+        var rollbackDiagnostic = Rollback(instanceId);
+        return rollbackDiagnostic is null
+            ? ExecutionTargetEnsureResult.Failure(primary)
+            : ExecutionTargetEnsureResult.Failure(primary, rollbackDiagnostic);
+    }
+
+    private ExecutionTargetDiagnostic? Rollback(string instanceId)
+    {
+        var result = cli.StopAsync(instanceId, CancellationToken.None).GetAwaiter().GetResult();
+        return result.Succeeded
+            ? null
+            : new ExecutionTargetDiagnostic(
+                ExecutionTargetDiagnosticCode.WindowsSandboxRollbackFailed,
+                $"Failed to stop newly created Windows Sandbox instance {instanceId}: {result.Error}",
+                RecoveryCommand(instanceId));
+    }
+
+    private ExecutionTargetEnsureResult Success(string instanceId, ExecutionTargetEpoch epoch) =>
+        new(
+            new ExecutionTargetInstance(Target, instanceId, epoch, RunningCapabilities),
+            []);
+
+    private ExecutionTargetStatusResult UnavailableStatus(ExecutionTargetDiagnostic diagnostic) =>
+        new(
+            Target,
+            ExecutionTargetStatus.Unavailable,
+            null,
+            null,
+            ExecutionTargetCapabilities.Stopped,
+            [diagnostic]);
+
+    private static ExecutionTargetDiagnostic UnsupportedHost() =>
+        new(
+            ExecutionTargetDiagnosticCode.UnsupportedHost,
+            "Windows Sandbox execution targets require Windows 11 version 24H2 (build 26100) or newer.");
+
+    private static ExecutionTargetDiagnostic CliDiagnostic<T>(WindowsSandboxCliResult<T> result)
+    {
+        var code = result.Failure switch
+        {
+            WindowsSandboxCliFailure.ExecutableMissing =>
+                ExecutionTargetDiagnosticCode.WindowsSandboxCliMissing,
+            WindowsSandboxCliFailure.IncompatibleOutput =>
+                ExecutionTargetDiagnosticCode.WindowsSandboxCliIncompatible,
+            _ => ExecutionTargetDiagnosticCode.WindowsSandboxListFailed,
+        };
+        return new ExecutionTargetDiagnostic(code, result.Error!);
+    }
+
+    private static ExecutionTargetDiagnostic StateDiagnostic(WindowsSandboxStateReadResult state) =>
+        new(
+            ExecutionTargetDiagnosticCode.WindowsSandboxStateUnavailable,
+            state.Error ?? "Windows Sandbox ownership state is unavailable.");
+
+    private static ExecutionTargetDiagnostic StartDiagnostic(WindowsSandboxCliResult<string> result)
+    {
+        if (result.Failure is WindowsSandboxCliFailure.ExecutableMissing
+            or WindowsSandboxCliFailure.IncompatibleOutput)
+        {
+            return CliDiagnostic(result);
+        }
+
+        return new ExecutionTargetDiagnostic(
+            ExecutionTargetDiagnosticCode.WindowsSandboxStartFailed,
+            result.Error!);
+    }
+
+    private static ExecutionTargetDiagnostic UnmanagedDiagnostic(IReadOnlyList<string> runningIds)
+    {
+        var ids = string.Join(", ", runningIds);
+        var recovery = runningIds.Count == 1 ? RecoveryCommand(runningIds[0]) : null;
+        return new ExecutionTargetDiagnostic(
+            ExecutionTargetDiagnosticCode.WindowsSandboxUnmanagedInstance,
+            $"Windows Sandbox instance(s) {ids} are running but are not provably owned by winapp.",
+            recovery);
+    }
+
+    private static string RecoveryCommand(string instanceId) =>
+        $"wsb stop --id {instanceId}";
+}

--- a/src/winapp-CLI/WinApp.Cli/ExecutionTargets/WindowsSandbox/WindowsSandboxBackend.cs
+++ b/src/winapp-CLI/WinApp.Cli/ExecutionTargets/WindowsSandbox/WindowsSandboxBackend.cs
@@ -87,11 +87,21 @@ internal sealed class WindowsSandboxBackend(
             return EnsureExisting(runningIds, stateRead);
         }
 
-        if (stateRead.Status is WindowsSandboxStateReadStatus.UnsupportedVersion
+        if (stateRead.Status is WindowsSandboxStateReadStatus.Corrupt
+            or WindowsSandboxStateReadStatus.UnsupportedVersion
             or WindowsSandboxStateReadStatus.UnsafePath)
         {
             return ExecutionTargetEnsureResult.Failure(StateDiagnostic(stateRead));
         }
+
+        var previousRevision = stateRead.State?.Revision ?? 0;
+        if (previousRevision == long.MaxValue)
+        {
+            return ExecutionTargetEnsureResult.Failure(new ExecutionTargetDiagnostic(
+                ExecutionTargetDiagnosticCode.WindowsSandboxStateUnavailable,
+                "Windows Sandbox ownership state revision cannot be advanced safely."));
+        }
+        var nextRevision = previousRevision + 1;
 
         // Without a returned ID, a post-cancellation singleton cannot be distinguished
         // from an externally started Sandbox and must not be stopped automatically.
@@ -120,12 +130,13 @@ internal sealed class WindowsSandboxBackend(
             }
 
             var epoch = ExecutionTargetEpoch.Create();
-            var previousRevision = stateRead.State?.Revision ?? 0;
             var state = new WindowsSandboxTargetState
             {
+                Schema = WindowsSandboxTargetState.CurrentSchema,
+                TargetId = ExecutionTargetRef.WindowsSandboxDefaultId,
                 ProviderInstanceId = startedId,
                 Epoch = epoch.Value,
-                Revision = checked(previousRevision + 1),
+                Revision = nextRevision,
                 CreatedAtUtc = DateTimeOffset.UtcNow.ToString("O", CultureInfo.InvariantCulture),
             };
 
@@ -183,7 +194,8 @@ internal sealed class WindowsSandboxBackend(
     {
         if (runningIds.Count == 0)
         {
-            if (stateRead.Status is WindowsSandboxStateReadStatus.UnsupportedVersion
+            if (stateRead.Status is WindowsSandboxStateReadStatus.Corrupt
+                or WindowsSandboxStateReadStatus.UnsupportedVersion
                 or WindowsSandboxStateReadStatus.UnsafePath)
             {
                 return UnavailableStatus(StateDiagnostic(stateRead));

--- a/src/winapp-CLI/WinApp.Cli/ExecutionTargets/WindowsSandbox/WindowsSandboxCli.cs
+++ b/src/winapp-CLI/WinApp.Cli/ExecutionTargets/WindowsSandbox/WindowsSandboxCli.cs
@@ -36,7 +36,7 @@ internal sealed class WindowsSandboxCli(IProcessRunner processRunner) : IWindows
             var ids = new List<string>(output.WindowsSandboxEnvironments.Count);
             foreach (var environment in output.WindowsSandboxEnvironments)
             {
-                if (!TryNormalizeId(environment.Id, out var id))
+                if (environment is null || !TryNormalizeId(environment.Id, out var id))
                 {
                     return IncompatibleList("The WSB list response contained an invalid sandbox ID.");
                 }
@@ -160,7 +160,7 @@ internal sealed class WindowsSandboxCli(IProcessRunner processRunner) : IWindows
 
 internal sealed class WindowsSandboxListOutput
 {
-    public List<WindowsSandboxEnvironmentOutput>? WindowsSandboxEnvironments { get; set; }
+    public List<WindowsSandboxEnvironmentOutput?>? WindowsSandboxEnvironments { get; set; }
 }
 
 internal sealed class WindowsSandboxEnvironmentOutput

--- a/src/winapp-CLI/WinApp.Cli/ExecutionTargets/WindowsSandbox/WindowsSandboxCli.cs
+++ b/src/winapp-CLI/WinApp.Cli/ExecutionTargets/WindowsSandbox/WindowsSandboxCli.cs
@@ -1,0 +1,179 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using System.ComponentModel;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using WinApp.Cli.Services;
+
+namespace WinApp.Cli.ExecutionTargets.WindowsSandbox;
+
+internal sealed class WindowsSandboxCli(IProcessRunner processRunner) : IWindowsSandboxCli
+{
+    private const string ExecutableName = "wsb.exe";
+
+    public async Task<WindowsSandboxCliResult<IReadOnlyList<string>>> ListAsync(
+        CancellationToken cancellationToken = default)
+    {
+        var processResult = await RunAsync(["list", "--raw"], cancellationToken);
+        if (!processResult.Succeeded)
+        {
+            return WindowsSandboxCliResult<IReadOnlyList<string>>.Failed(
+                processResult.Failure!.Value,
+                processResult.Error!);
+        }
+
+        try
+        {
+            var output = JsonSerializer.Deserialize(
+                processResult.Value!.StandardOutput,
+                WindowsSandboxCliJsonContext.Default.WindowsSandboxListOutput);
+            if (output?.WindowsSandboxEnvironments is null)
+            {
+                return IncompatibleList("The WSB list response did not contain WindowsSandboxEnvironments.");
+            }
+
+            var ids = new List<string>(output.WindowsSandboxEnvironments.Count);
+            foreach (var environment in output.WindowsSandboxEnvironments)
+            {
+                if (!TryNormalizeId(environment.Id, out var id))
+                {
+                    return IncompatibleList("The WSB list response contained an invalid sandbox ID.");
+                }
+                ids.Add(id);
+            }
+
+            if (ids.Count != ids.Distinct(StringComparer.OrdinalIgnoreCase).Count())
+            {
+                return IncompatibleList("The WSB list response contained duplicate sandbox IDs.");
+            }
+
+            return WindowsSandboxCliResult<IReadOnlyList<string>>.Success(ids);
+        }
+        catch (JsonException ex)
+        {
+            return IncompatibleList($"The WSB list response was not valid JSON: {ex.Message}");
+        }
+    }
+
+    public async Task<WindowsSandboxCliResult<string>> StartAsync(
+        CancellationToken cancellationToken = default)
+    {
+        var processResult = await RunAsync(["start", "--raw"], cancellationToken);
+        if (!processResult.Succeeded)
+        {
+            return WindowsSandboxCliResult<string>.Failed(
+                processResult.Failure!.Value,
+                processResult.Error!);
+        }
+
+        try
+        {
+            var output = JsonSerializer.Deserialize(
+                processResult.Value!.StandardOutput,
+                WindowsSandboxCliJsonContext.Default.WindowsSandboxStartOutput);
+            if (output is null || !TryNormalizeId(output.Id, out var id))
+            {
+                return WindowsSandboxCliResult<string>.Failed(
+                    WindowsSandboxCliFailure.IncompatibleOutput,
+                    "The WSB start response did not contain a valid sandbox ID.");
+            }
+
+            return WindowsSandboxCliResult<string>.Success(id);
+        }
+        catch (JsonException ex)
+        {
+            return WindowsSandboxCliResult<string>.Failed(
+                WindowsSandboxCliFailure.IncompatibleOutput,
+                $"The WSB start response was not valid JSON: {ex.Message}");
+        }
+    }
+
+    public async Task<WindowsSandboxCliResult<bool>> StopAsync(
+        string instanceId,
+        CancellationToken cancellationToken = default)
+    {
+        if (!TryNormalizeId(instanceId, out var normalizedId))
+        {
+            throw new ArgumentException("Windows Sandbox instance IDs must be GUIDs.", nameof(instanceId));
+        }
+
+        var processResult = await RunAsync(
+            ["stop", "--id", normalizedId, "--raw"],
+            cancellationToken);
+        if (!processResult.Succeeded)
+        {
+            return WindowsSandboxCliResult<bool>.Failed(
+                processResult.Failure!.Value,
+                processResult.Error!);
+        }
+
+        return WindowsSandboxCliResult<bool>.Success(true);
+    }
+
+    private async Task<WindowsSandboxCliResult<ProcessRunResult>> RunAsync(
+        IReadOnlyList<string> arguments,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = await processRunner.RunAsync(
+                new ProcessRunRequest(ExecutableName, arguments),
+                cancellationToken: cancellationToken);
+            if (result.ExitCode != 0)
+            {
+                var detail = string.IsNullOrWhiteSpace(result.StandardError)
+                    ? $"wsb.exe exited with code {result.ExitCode}."
+                    : $"wsb.exe exited with code {result.ExitCode}: {result.StandardError.Trim()}";
+                return WindowsSandboxCliResult<ProcessRunResult>.Failed(
+                    WindowsSandboxCliFailure.CommandFailed,
+                    detail);
+            }
+
+            return WindowsSandboxCliResult<ProcessRunResult>.Success(result);
+        }
+        catch (Win32Exception ex)
+        {
+            return WindowsSandboxCliResult<ProcessRunResult>.Failed(
+                WindowsSandboxCliFailure.ExecutableMissing,
+                $"wsb.exe could not be started: {ex.Message}");
+        }
+    }
+
+    private static bool TryNormalizeId(string? value, out string normalized)
+    {
+        if (Guid.TryParse(value, out var id))
+        {
+            normalized = id.ToString("D");
+            return true;
+        }
+
+        normalized = string.Empty;
+        return false;
+    }
+
+    private static WindowsSandboxCliResult<IReadOnlyList<string>> IncompatibleList(string error) =>
+        WindowsSandboxCliResult<IReadOnlyList<string>>.Failed(
+            WindowsSandboxCliFailure.IncompatibleOutput,
+            error);
+}
+
+internal sealed class WindowsSandboxListOutput
+{
+    public List<WindowsSandboxEnvironmentOutput>? WindowsSandboxEnvironments { get; set; }
+}
+
+internal sealed class WindowsSandboxEnvironmentOutput
+{
+    public string? Id { get; set; }
+}
+
+internal sealed class WindowsSandboxStartOutput
+{
+    public string? Id { get; set; }
+}
+
+[JsonSerializable(typeof(WindowsSandboxListOutput))]
+[JsonSerializable(typeof(WindowsSandboxStartOutput))]
+[JsonSourceGenerationOptions(PropertyNameCaseInsensitive = false)]
+internal partial class WindowsSandboxCliJsonContext : JsonSerializerContext;

--- a/src/winapp-CLI/WinApp.Cli/ExecutionTargets/WindowsSandbox/WindowsSandboxHost.cs
+++ b/src/winapp-CLI/WinApp.Cli/ExecutionTargets/WindowsSandbox/WindowsSandboxHost.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+namespace WinApp.Cli.ExecutionTargets.WindowsSandbox;
+
+internal interface IWindowsSandboxHost
+{
+    bool IsSupportedOperatingSystem { get; }
+}
+
+internal sealed class WindowsSandboxHost : IWindowsSandboxHost
+{
+    public bool IsSupportedOperatingSystem =>
+        OperatingSystem.IsWindowsVersionAtLeast(10, 0, 26100);
+}

--- a/src/winapp-CLI/WinApp.Cli/ExecutionTargets/WindowsSandbox/WindowsSandboxMutationLock.cs
+++ b/src/winapp-CLI/WinApp.Cli/ExecutionTargets/WindowsSandbox/WindowsSandboxMutationLock.cs
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Security.AccessControl;
+using System.Security.Principal;
+
 namespace WinApp.Cli.ExecutionTargets.WindowsSandbox;
 
 internal interface IWindowsSandboxMutationLock
@@ -10,23 +13,46 @@ internal interface IWindowsSandboxMutationLock
 
 internal sealed class WindowsSandboxMutationLock : IWindowsSandboxMutationLock
 {
-    internal const string DefaultName =
-        @"Local\Microsoft.WinApp.ExecutionTarget.windows-sandbox-default";
+    internal const string DefaultNamePrefix =
+        @"Global\Microsoft.WinApp.ExecutionTarget.windows-sandbox-default.";
 
     private readonly string _name;
+    private readonly SecurityIdentifier _userSid;
 
-    public WindowsSandboxMutationLock() : this(DefaultName)
+    public WindowsSandboxMutationLock() : this(GetCurrentUserSid())
     {
     }
 
-    internal WindowsSandboxMutationLock(string name)
+    private WindowsSandboxMutationLock(SecurityIdentifier userSid)
+        : this(DefaultNamePrefix + userSid.Value, userSid)
+    {
+    }
+
+    internal WindowsSandboxMutationLock(string name) : this(name, GetCurrentUserSid())
+    {
+    }
+
+    private WindowsSandboxMutationLock(string name, SecurityIdentifier userSid)
     {
         _name = name;
+        _userSid = userSid;
     }
+
+    internal string Name => _name;
 
     public IDisposable Acquire(CancellationToken cancellationToken = default)
     {
-        var mutex = new Mutex(initiallyOwned: false, _name);
+        var security = new MutexSecurity();
+        security.SetAccessRuleProtection(isProtected: true, preserveInheritance: false);
+        security.AddAccessRule(new MutexAccessRule(
+            _userSid,
+            MutexRights.FullControl,
+            AccessControlType.Allow));
+        var mutex = MutexAcl.Create(
+            initiallyOwned: false,
+            _name,
+            out _,
+            security);
         try
         {
             while (true)
@@ -50,6 +76,13 @@ internal sealed class WindowsSandboxMutationLock : IWindowsSandboxMutationLock
             mutex.Dispose();
             throw;
         }
+    }
+
+    private static SecurityIdentifier GetCurrentUserSid()
+    {
+        using var identity = WindowsIdentity.GetCurrent(TokenAccessLevels.Query);
+        return identity.User
+            ?? throw new InvalidOperationException("The current Windows user does not have a security identifier.");
     }
 
     private sealed class Lease(Mutex mutex) : IDisposable

--- a/src/winapp-CLI/WinApp.Cli/ExecutionTargets/WindowsSandbox/WindowsSandboxMutationLock.cs
+++ b/src/winapp-CLI/WinApp.Cli/ExecutionTargets/WindowsSandbox/WindowsSandboxMutationLock.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+namespace WinApp.Cli.ExecutionTargets.WindowsSandbox;
+
+internal interface IWindowsSandboxMutationLock
+{
+    IDisposable Acquire(CancellationToken cancellationToken = default);
+}
+
+internal sealed class WindowsSandboxMutationLock : IWindowsSandboxMutationLock
+{
+    internal const string DefaultName =
+        @"Local\Microsoft.WinApp.ExecutionTarget.windows-sandbox-default";
+
+    private readonly string _name;
+
+    public WindowsSandboxMutationLock() : this(DefaultName)
+    {
+    }
+
+    internal WindowsSandboxMutationLock(string name)
+    {
+        _name = name;
+    }
+
+    public IDisposable Acquire(CancellationToken cancellationToken = default)
+    {
+        var mutex = new Mutex(initiallyOwned: false, _name);
+        try
+        {
+            while (true)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                try
+                {
+                    if (mutex.WaitOne(TimeSpan.FromMilliseconds(100)))
+                    {
+                        return new Lease(mutex);
+                    }
+                }
+                catch (AbandonedMutexException)
+                {
+                    return new Lease(mutex);
+                }
+            }
+        }
+        catch
+        {
+            mutex.Dispose();
+            throw;
+        }
+    }
+
+    private sealed class Lease(Mutex mutex) : IDisposable
+    {
+        private bool _disposed;
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            mutex.ReleaseMutex();
+            mutex.Dispose();
+            _disposed = true;
+        }
+    }
+}

--- a/src/winapp-CLI/WinApp.Cli/ExecutionTargets/WindowsSandbox/WindowsSandboxStateStore.cs
+++ b/src/winapp-CLI/WinApp.Cli/ExecutionTargets/WindowsSandbox/WindowsSandboxStateStore.cs
@@ -21,17 +21,17 @@ internal sealed class WindowsSandboxStateStore(
     public async Task<WindowsSandboxStateReadResult> ReadAsync(CancellationToken cancellationToken = default)
     {
         var stateFile = GetStateFile();
-        if (!stateFile.Exists)
-        {
-            return new WindowsSandboxStateReadResult(WindowsSandboxStateReadStatus.Missing, null);
-        }
-
         if (IsUnsafe(stateFile))
         {
             return new WindowsSandboxStateReadResult(
                 WindowsSandboxStateReadStatus.UnsafePath,
                 null,
                 $"Windows Sandbox target state path '{stateFile.FullName}' is unsafe.");
+        }
+
+        if (!stateFile.Exists)
+        {
+            return new WindowsSandboxStateReadResult(WindowsSandboxStateReadStatus.Missing, null);
         }
 
         try
@@ -81,10 +81,14 @@ internal sealed class WindowsSandboxStateStore(
             throw new ArgumentException(error, nameof(state));
         }
 
+        var stateFile = GetStateFile();
+        if (IsUnsafe(stateFile))
+        {
+            throw new IOException($"Windows Sandbox target state path '{stateFile.FullName}' is unsafe.");
+        }
+
         var targetDirectory = directoryProvider.GetTargetDirectory(ExecutionTargetRef.WindowsSandboxDefault);
         targetDirectory.Create();
-
-        var stateFile = GetStateFile();
         if (IsUnsafe(stateFile))
         {
             throw new IOException($"Windows Sandbox target state path '{stateFile.FullName}' is unsafe.");
@@ -138,7 +142,7 @@ internal sealed class WindowsSandboxStateStore(
             return false;
         }
 
-        if (state.Revision is <= 0 or long.MaxValue)
+        if (state.Revision <= 0)
         {
             error = "Windows Sandbox target state revision is outside the supported range.";
             return false;

--- a/src/winapp-CLI/WinApp.Cli/ExecutionTargets/WindowsSandbox/WindowsSandboxStateStore.cs
+++ b/src/winapp-CLI/WinApp.Cli/ExecutionTargets/WindowsSandbox/WindowsSandboxStateStore.cs
@@ -1,0 +1,163 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using WinApp.Cli.Helpers;
+
+namespace WinApp.Cli.ExecutionTargets.WindowsSandbox;
+
+internal sealed class WindowsSandboxStateStore(
+    IExecutionTargetStateDirectoryProvider directoryProvider) : IWindowsSandboxStateStore
+{
+    private const string StateFileName = "target-state.json";
+
+    public FileInfo GetStateFile() =>
+        new(Path.Combine(
+            directoryProvider.GetTargetDirectory(ExecutionTargetRef.WindowsSandboxDefault).FullName,
+            StateFileName));
+
+    public async Task<WindowsSandboxStateReadResult> ReadAsync(CancellationToken cancellationToken = default)
+    {
+        var stateFile = GetStateFile();
+        if (!stateFile.Exists)
+        {
+            return new WindowsSandboxStateReadResult(WindowsSandboxStateReadStatus.Missing, null);
+        }
+
+        if (IsUnsafe(stateFile))
+        {
+            return new WindowsSandboxStateReadResult(
+                WindowsSandboxStateReadStatus.UnsafePath,
+                null,
+                $"Windows Sandbox target state path '{stateFile.FullName}' is unsafe.");
+        }
+
+        try
+        {
+            await using var stream = File.OpenRead(stateFile.FullName);
+            var state = await JsonSerializer.DeserializeAsync(
+                stream,
+                WindowsSandboxStateJsonContext.Default.WindowsSandboxTargetState,
+                cancellationToken);
+
+            if (state is null)
+            {
+                return Corrupt("Windows Sandbox target state deserialized to null.");
+            }
+
+            if (state.Schema != WindowsSandboxTargetState.CurrentSchema)
+            {
+                return new WindowsSandboxStateReadResult(
+                    WindowsSandboxStateReadStatus.UnsupportedVersion,
+                    null,
+                    $"Windows Sandbox target state schema {state.Schema} is not supported by this version of winapp.");
+            }
+
+            if (!IsValid(state, out var error))
+            {
+                return Corrupt(error);
+            }
+
+            return new WindowsSandboxStateReadResult(WindowsSandboxStateReadStatus.Valid, state);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException)
+        {
+            return Corrupt($"Failed to read Windows Sandbox target state: {ex.Message}");
+        }
+    }
+
+    public async Task WriteAsync(
+        WindowsSandboxTargetState state,
+        CancellationToken cancellationToken = default)
+    {
+        if (!IsValid(state, out var error))
+        {
+            throw new ArgumentException(error, nameof(state));
+        }
+
+        var targetDirectory = directoryProvider.GetTargetDirectory(ExecutionTargetRef.WindowsSandboxDefault);
+        targetDirectory.Create();
+
+        var stateFile = GetStateFile();
+        if (IsUnsafe(stateFile))
+        {
+            throw new IOException($"Windows Sandbox target state path '{stateFile.FullName}' is unsafe.");
+        }
+
+        var json = JsonSerializer.Serialize(
+            state,
+            WindowsSandboxStateJsonContext.Default.WindowsSandboxTargetState);
+        await PathSafety.AtomicWriteAllTextAsync(
+            stateFile.FullName,
+            json + "\n",
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+            cancellationToken);
+    }
+
+    private bool IsUnsafe(FileInfo stateFile) =>
+        PathSafety.HasReparsePointOnPath(
+            stateFile.FullName,
+            directoryProvider.GetStateRoot().FullName);
+
+    private static bool IsValid(WindowsSandboxTargetState state, out string error)
+    {
+        if (state.Schema != WindowsSandboxTargetState.CurrentSchema)
+        {
+            error = $"Windows Sandbox target state schema must be {WindowsSandboxTargetState.CurrentSchema}.";
+            return false;
+        }
+
+        if (!string.Equals(
+                state.TargetId,
+                ExecutionTargetRef.WindowsSandboxDefaultId,
+                StringComparison.Ordinal))
+        {
+            error = $"Windows Sandbox target state must target '{ExecutionTargetRef.WindowsSandboxDefaultId}'.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(state.ProviderInstanceId))
+        {
+            error = "Windows Sandbox target state must contain a provider instance ID.";
+            return false;
+        }
+
+        try
+        {
+            _ = new ExecutionTargetEpoch(state.Epoch);
+        }
+        catch (ArgumentException)
+        {
+            error = "Windows Sandbox target state contains an invalid epoch.";
+            return false;
+        }
+
+        if (state.Revision is <= 0 or long.MaxValue)
+        {
+            error = "Windows Sandbox target state revision is outside the supported range.";
+            return false;
+        }
+
+        if (!DateTimeOffset.TryParse(
+                state.CreatedAtUtc,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                out _))
+        {
+            error = "Windows Sandbox target state contains an invalid creation timestamp.";
+            return false;
+        }
+
+        error = string.Empty;
+        return true;
+    }
+
+    private static WindowsSandboxStateReadResult Corrupt(string error) =>
+        new(WindowsSandboxStateReadStatus.Corrupt, null, error);
+}

--- a/src/winapp-CLI/WinApp.Cli/ExecutionTargets/WindowsSandbox/WindowsSandboxTargetState.cs
+++ b/src/winapp-CLI/WinApp.Cli/ExecutionTargets/WindowsSandbox/WindowsSandboxTargetState.cs
@@ -9,9 +9,9 @@ internal sealed class WindowsSandboxTargetState
 {
     public const int CurrentSchema = 1;
 
-    public int Schema { get; set; } = CurrentSchema;
+    public required int Schema { get; set; }
 
-    public string TargetId { get; set; } = ExecutionTargetRef.WindowsSandboxDefaultId;
+    public required string TargetId { get; set; }
 
     public string ProviderInstanceId { get; set; } = string.Empty;
 

--- a/src/winapp-CLI/WinApp.Cli/ExecutionTargets/WindowsSandbox/WindowsSandboxTargetState.cs
+++ b/src/winapp-CLI/WinApp.Cli/ExecutionTargets/WindowsSandbox/WindowsSandboxTargetState.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+
+namespace WinApp.Cli.ExecutionTargets.WindowsSandbox;
+
+internal sealed class WindowsSandboxTargetState
+{
+    public const int CurrentSchema = 1;
+
+    public int Schema { get; set; } = CurrentSchema;
+
+    public string TargetId { get; set; } = ExecutionTargetRef.WindowsSandboxDefaultId;
+
+    public string ProviderInstanceId { get; set; } = string.Empty;
+
+    public string Epoch { get; set; } = string.Empty;
+
+    public long Revision { get; set; }
+
+    public string CreatedAtUtc { get; set; } = string.Empty;
+}
+
+internal enum WindowsSandboxStateReadStatus
+{
+    Missing,
+    Valid,
+    Corrupt,
+    UnsupportedVersion,
+    UnsafePath,
+}
+
+internal sealed record WindowsSandboxStateReadResult(
+    WindowsSandboxStateReadStatus Status,
+    WindowsSandboxTargetState? State,
+    string? Error = null);
+
+[JsonSerializable(typeof(WindowsSandboxTargetState))]
+[JsonSourceGenerationOptions(
+    WriteIndented = true,
+    NewLine = "\n",
+    PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
+internal partial class WindowsSandboxStateJsonContext : JsonSerializerContext;

--- a/src/winapp-CLI/WinApp.Cli/Helpers/HostBuilderExtensions.cs
+++ b/src/winapp-CLI/WinApp.Cli/Helpers/HostBuilderExtensions.cs
@@ -7,6 +7,8 @@ using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.Diagnostics.CodeAnalysis;
 using WinApp.Cli.Commands;
+using WinApp.Cli.ExecutionTargets;
+using WinApp.Cli.ExecutionTargets.WindowsSandbox;
 using WinApp.Cli.Services;
 using WinApp.Cli.Services.Controls;
 
@@ -58,6 +60,13 @@ internal static class StoreHostBuilderExtensions
             .AddSingleton<IUpdateNotificationService, UpdateNotificationService>()
             // Azure Trusted Signing services
             .AddSingleton<IProcessRunner, ProcessRunner>()
+            .AddSingleton<IExecutionTargetStateDirectoryProvider, ExecutionTargetStateDirectoryProvider>()
+            .AddSingleton<IWindowsSandboxHost, WindowsSandboxHost>()
+            .AddSingleton<IWindowsSandboxCli, WindowsSandboxCli>()
+            .AddSingleton<IWindowsSandboxMutationLock, WindowsSandboxMutationLock>()
+            .AddSingleton<IWindowsSandboxStateStore, WindowsSandboxStateStore>()
+            .AddSingleton<IExecutionTargetBackend, WindowsSandboxBackend>()
+            .AddSingleton<IExecutionTargetService, ExecutionTargetService>()
             .AddSingleton<IAzureAuthService, AzureAuthService>()
             .AddSingleton<IAzureSigningService, AzureSigningService>()
             .AddSingleton<IAzureSignToolService, AzureSignToolService>()


### PR DESCRIPTION
## Summary

- add an internal execution-target reference, requirements/capability model, backend contract, and single-backend service
- add a Windows Sandbox backend over documented `wsb.exe list/start/stop --raw` operations with Windows 11 24H2 prerequisite diagnostics
- persist atomic, versioned ownership state and a stable per-created-instance epoch under `%LOCALAPPDATA%\Microsoft\WinApp\Targets`
- serialize lifecycle mutation with a per-user named mutex and fail closed for unmanaged, ambiguous, corrupt, or newer-schema state
- roll back only an exact instance ID returned by the current start operation; uncertain instances are never adopted or mutated
- cover contracts, CLI parsing, state storage, cancellation, rollback, concurrency, warm reuse, external stop/new epoch, and unmanaged-instance behavior with deterministic fakes

## Scope

This is the internal foundation for #769. It intentionally adds no public CLI/schema/npm surface and does not add guest transport, `wsb connect`, deployment, UI routing, input forwarding, recording, generic exec/cp, or provider plugins.

`IGuestConnection` is deferred because `wsb exec` does not stream stdin/stdout/stderr; the next layer will define transport alongside a private guest agent and boot nonce.

## Validation

- focused execution-target/Windows Sandbox tests: 36 passed
- Debug solution build with warnings as errors
- x64 and ARM64 NativeAOT publish
- npm generation, format, lint, TypeScript compile, package, and docs generation
- generated CLI schema and command surfaces remain unchanged

The repository-wide test run completed 4,624 tests successfully; seven existing Windows App SDK initialization E2E cases could not resolve packages from this machine's configured feeds. The repository's `azureauth` internal-feed bootstrap is not installed in this environment, so CI remains the authoritative gate for those feed-dependent cases.

Part of #769; follow-up stacked PRs will deliver the public feature.