### PR TITLE
Raise the build job timeout to 120 minutes

### DIFF
--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -33,6 +33,8 @@ extends:
     - stage: Build
       jobs:
       - job: Build
+        # Same build as the release pipeline, which has already exceeded the 60-minute default.
+        timeoutInMinutes: 120
         pool:
           name: Azure-Pipelines-1ESPT-ExDShared
           image: windows-latest

--- a/.pipelines/release.yml
+++ b/.pipelines/release.yml
@@ -73,6 +73,8 @@ extends:
     - stage: Build
       jobs:
       - job: Build
+        # NativeAOT for two architectures plus tests now runs past the 60-minute default.
+        timeoutInMinutes: 120
         pool:
           name: Azure-Pipelines-1ESPT-ExDShared
           image: windows-latest


### PR DESCRIPTION
The 0.6.2 release build was cancelled by Azure Pipelines at 60.6 minutes:

```
job 'Build' result=canceled duration=60.6 min
error: The job running on agent Azure-Pipelines-1ESPT-ExDShared 65 ran longer than
the maximum time of 60 minutes.
```

Neither pipeline set `timeoutInMinutes`, so both inherited the 60 minute default. NativeAOT for two architectures plus the test run no longer fits inside it, and the release stages that follow were all skipped as a result - nothing was published.

Raises the `Build` job to 120 minutes in both `release.yml` and `ci.yml`. CI builds the same thing, so it is on the same trajectory even though it has not tripped yet. `fuzz.yml` already used 120, so this matches the existing precedent in the repo.

This only changes the ceiling, not the build itself - a hung job now burns up to 120 minutes of agent time instead of 60. Worth a separate look at *why* the build takes this long, but that should not block the release.