### PR TITLE
Fix MS Learn docs generation: guides index rendering, broken security link, and ms.date churn

### DIFF
--- a/.pipelines/release.yml
+++ b/.pipelines/release.yml
@@ -211,6 +211,7 @@ extends:
                 New-Item -ItemType Directory -Path "$staging/scripts" -Force | Out-Null
                 Copy-Item "$(System.DefaultWorkingDirectory)/scripts/port-mslearn-docs.ps1" "$staging/scripts/" -Force
                 Copy-Item "$(System.DefaultWorkingDirectory)/scripts/validate-mslearn-docs.ps1" "$staging/scripts/" -Force
+                Copy-Item "$(System.DefaultWorkingDirectory)/scripts/prune-date-only-doc-changes.ps1" "$staging/scripts/" -Force
                 Copy-Item "$(System.DefaultWorkingDirectory)/scripts/mslearn-doc-lib.ps1" "$staging/scripts/" -Force
                 Copy-Item "$(System.DefaultWorkingDirectory)/docs" "$staging/docs" -Recurse -Force
                 Copy-Item "$(System.DefaultWorkingDirectory)/version.json" "$staging/" -Force
@@ -644,6 +645,19 @@ extends:
                 git config user.name "winapp-cli-bot"
                 git config user.email "winapp-cli-bot@users.noreply.github.com"
                 git checkout -B $branch
+
+                # Every page is restamped with today's ms.date, so pages that did not
+                # otherwise change would show up as date-only diffs and bury the real
+                # edits for the docs-repo reviewer. Drop them before staging.
+                & "$(Pipeline.Workspace)\mslearn-source\scripts\prune-date-only-doc-changes.ps1" `
+                  -RepoPath $docsDir `
+                  -PathSpec $docsRepoBase
+                if ($LASTEXITCODE -ne 0) {
+                  Pop-Location
+                  Write-Error "Failed to prune date-only doc changes. Exit code: $LASTEXITCODE"
+                  exit $LASTEXITCODE
+                }
+
                 git add -A
                 git diff --cached --quiet
                 if ($LASTEXITCODE -eq 0) {

--- a/scripts/port-mslearn-docs.ps1
+++ b/scripts/port-mslearn-docs.ps1
@@ -469,7 +469,14 @@ $portedIndexContent = Get-Content $portedIndexPath -Raw
 $frameworkSection = ""
 if ($portedIndexContent -match '(?ms)(## Supported frameworks\s*\n.+?)(?=\n## )') {
     $frameworkSection = $Matches[1]
-    # Rewrite links from index.md-relative (guides/foo.md) to guides/-relative (foo.md)
+    # The extracted links are index.md-relative (i.e. output-root-relative) but are
+    # about to be written into guides/index.md, one directory down. Rebase them:
+    #   guides/foo.md -> foo.md          (now a sibling)
+    #   security.md   -> ../security.md  (still at the root; a bare name would 404)
+    # Absolute URLs, mailto:, in-page anchors and already-relative paths are left alone.
+    # Root-relative links must be rewritten first, while the guides/ prefix still
+    # marks which targets are siblings.
+    $frameworkSection = $frameworkSection -replace '\]\((?!https?:|mailto:|#|/|\.{1,2}/)(?!guides/)([^)]+)\)', '](../$1)'
     $frameworkSection = $frameworkSection -replace '\]\(guides/', ']('
 }
 
@@ -491,10 +498,9 @@ These guides walk you through using the winapp CLI with your app framework — f
 if ($frameworkSection) {
     # Strip the "## Supported frameworks" heading and the intro line, keep just the table + additional guides
     $tableContent = $frameworkSection -replace '(?ms)^## Supported frameworks\s*\n+.*?app frameworks:\s*\n+', ''
-    $guidesIndex += $tableContent
 } else {
     Write-Warn "  Could not extract framework section from index.md — using fallback"
-    $guidesIndex += @"
+    $tableContent = @"
 | Framework | Guide |
 |-----------|-------|
 | .NET / WPF / WinForms | [Get started with .NET](dotnet.md) |
@@ -505,6 +511,12 @@ if ($frameworkSection) {
 | Flutter | [Get started with Flutter](flutter.md) |
 "@
 }
+
+# A here-string does not include the newline before its closing "@, so the blank
+# line intended to separate the intro paragraph from the table collapses away and
+# Markdown renders the table as part of that paragraph. Join explicitly rather
+# than relying on the here-string to carry the separator.
+$guidesIndex = $guidesIndex.TrimEnd() + "`r`n`r`n" + $tableContent.TrimStart()
 
 # Add Electron deep-dive section (these only exist as guides, not in README)
 # Normalize the boundary: the extracted framework/additional-guides block can

--- a/scripts/prune-date-only-doc-changes.ps1
+++ b/scripts/prune-date-only-doc-changes.ps1
@@ -1,0 +1,101 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Discard doc changes whose only difference is the ms.date stamp.
+.DESCRIPTION
+    port-mslearn-docs.ps1 stamps every generated page with today's date, so a
+    release rewrites all of them even though most are byte-identical otherwise.
+    That buries the handful of real edits in a wall of date-only diffs for the
+    docs-repo reviewer.
+
+    Run this inside a checkout of the docs repo after copying the ported docs in
+    and before committing. Any tracked file whose diff against HEAD consists
+    solely of the ms.date line is restored to HEAD, so it drops out of the commit
+    entirely and keeps the date of the last release that actually changed it.
+
+    Files that are new, deleted, or have any other change are left alone.
+.PARAMETER RepoPath
+    Path to the docs repo working tree. Defaults to the current directory.
+.PARAMETER PathSpec
+    Optional git pathspec limiting which files are considered, e.g.
+    "hub/apps/dev-tools/winapp-cli". Defaults to the whole repo.
+.PARAMETER WhatIf
+    Report what would be discarded without touching anything.
+.EXAMPLE
+    .\scripts\prune-date-only-doc-changes.ps1 -RepoPath C:\src\windows-dev-docs-pr -PathSpec hub/apps/dev-tools/winapp-cli
+#>
+
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [string]$RepoPath = ".",
+    [string]$PathSpec = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+function Write-Step { param([string]$msg) Write-Host "`n==> $msg" -ForegroundColor Cyan }
+function Write-Info { param([string]$msg) Write-Host "    $msg" -ForegroundColor Gray }
+function Write-Ok   { param([string]$msg) Write-Host "    $msg" -ForegroundColor Green }
+
+if (-not (Test-Path $RepoPath)) {
+    throw "RepoPath does not exist: $RepoPath"
+}
+$repoFull = (Resolve-Path $RepoPath).Path
+
+Push-Location $repoFull
+try {
+    # Compare against HEAD so the result is the same whether or not the caller
+    # has already staged the copied files.
+    $diffArgs = @('diff', 'HEAD', '--name-only', '--diff-filter=M')
+    if ($PathSpec) { $diffArgs += @('--', $PathSpec) }
+
+    $changed = @(& git @diffArgs 2>$null | Where-Object { $_ })
+    if ($LASTEXITCODE -ne 0) { throw "git diff failed with exit code $LASTEXITCODE" }
+
+    Write-Step "Scanning $($changed.Count) modified file(s) for date-only changes"
+
+    $pruned = @()
+    $kept = @()
+
+    foreach ($file in $changed) {
+        # Only markdown pages carry ms.date front matter; leave toc.yml and
+        # anything else to be judged on its own content.
+        if ($file -notmatch '\.md$') { $kept += $file; continue }
+
+        $patch = & git diff HEAD -- $file 2>$null
+        if ($LASTEXITCODE -ne 0) { throw "git diff failed for $file" }
+
+        # Added/removed content lines, ignoring the +++/--- file headers.
+        $changedLines = @($patch | Where-Object {
+            ($_ -match '^\+(?!\+\+)') -or ($_ -match '^-(?!--)')
+        })
+
+        if ($changedLines.Count -eq 0) { $kept += $file; continue }
+
+        $nonDate = @($changedLines | Where-Object { $_ -notmatch '^[+-]ms\.date:' })
+        if ($nonDate.Count -eq 0) {
+            $pruned += $file
+        } else {
+            $kept += $file
+        }
+    }
+
+    if ($pruned.Count -gt 0) {
+        if ($PSCmdlet.ShouldProcess("$($pruned.Count) file(s)", "restore to HEAD")) {
+            # Restores index and working tree together, so the file drops out of
+            # the commit whether or not it was already staged.
+            foreach ($batch in ($pruned | ForEach-Object { $_ })) {
+                & git checkout HEAD -- $batch
+                if ($LASTEXITCODE -ne 0) { throw "git checkout failed for $batch" }
+            }
+        }
+        foreach ($f in $pruned) { Write-Info "  date-only, discarded: $f" }
+    }
+
+    Write-Step "Done"
+    Write-Ok "Discarded $($pruned.Count) date-only change(s); kept $($kept.Count) real change(s)."
+    foreach ($f in $kept) { Write-Info "  kept: $f" }
+}
+finally {
+    Pop-Location
+}

--- a/scripts/tests/prune-date-only-doc-changes.Tests.ps1
+++ b/scripts/tests/prune-date-only-doc-changes.Tests.ps1
@@ -1,0 +1,133 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+<#
+    Pester tests for scripts/prune-date-only-doc-changes.ps1.
+
+    port-mslearn-docs.ps1 restamps ms.date on every page, so without pruning a
+    release PR is mostly date-only churn (19 of 26 files on the v0.6.2 PR). These
+    tests pin the behaviour that keeps that churn out of the commit: date-only
+    edits are discarded, everything else survives.
+#>
+
+BeforeAll {
+    $script:PruneScript = Join-Path (Split-Path $PSScriptRoot -Parent) 'prune-date-only-doc-changes.ps1'
+
+    function New-DocsFixture {
+        <#
+            A git repo with three committed pages, then a simulated port run:
+            ms.date bumped everywhere, one body edited, one page added.
+        #>
+        $root = Join-Path ([System.IO.Path]::GetTempPath()) ("prune-" + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path (Join-Path $root 'docs\sub') -Force | Out-Null
+
+        Push-Location $root
+        try {
+            & git init -q .
+            & git config user.email 'test@example.com'
+            & git config user.name 'test'
+
+            Set-Content (Join-Path $root 'docs\dateonly.md') "---`r`ntitle: A`r`nms.date: 01/01/2020`r`n---`r`n`r`n# A`r`nUnchanged body.`r`n"
+            Set-Content (Join-Path $root 'docs\realchange.md') "---`r`ntitle: B`r`nms.date: 01/01/2020`r`n---`r`n`r`n# B`r`nOld body.`r`n"
+            Set-Content (Join-Path $root 'docs\sub\nested.md') "---`r`ntitle: C`r`nms.date: 01/01/2020`r`n---`r`n`r`n# C`r`nUnchanged body.`r`n"
+            Set-Content (Join-Path $root 'docs\toc.yml') "items: 1`r`n"
+
+            & git add -A
+            & git commit -qm 'baseline'
+
+            # Simulated port run
+            Set-Content (Join-Path $root 'docs\dateonly.md') "---`r`ntitle: A`r`nms.date: 08/20/2026`r`n---`r`n`r`n# A`r`nUnchanged body.`r`n"
+            Set-Content (Join-Path $root 'docs\realchange.md') "---`r`ntitle: B`r`nms.date: 08/20/2026`r`n---`r`n`r`n# B`r`nNew body.`r`n"
+            Set-Content (Join-Path $root 'docs\sub\nested.md') "---`r`ntitle: C`r`nms.date: 08/20/2026`r`n---`r`n`r`n# C`r`nUnchanged body.`r`n"
+            Set-Content (Join-Path $root 'docs\toc.yml') "items: 2`r`n"
+            Set-Content (Join-Path $root 'docs\brandnew.md') "---`r`ntitle: D`r`nms.date: 08/20/2026`r`n---`r`n`r`n# D`r`nBrand new.`r`n"
+        }
+        finally { Pop-Location }
+
+        return $root
+    }
+
+    function Get-ChangedPaths {
+        param([string]$Root)
+        Push-Location $Root
+        try { return @(& git diff HEAD --name-only | Where-Object { $_ }) }
+        finally { Pop-Location }
+    }
+}
+
+Describe 'prune-date-only-doc-changes' {
+    Context 'unstaged changes' {
+        BeforeAll {
+            $script:Root = New-DocsFixture
+            & pwsh -NoProfile -File $script:PruneScript -RepoPath $script:Root -PathSpec 'docs' *>&1 | Out-Null
+            $script:Exit = $LASTEXITCODE
+            $script:Changed = Get-ChangedPaths $script:Root
+        }
+        AfterAll { Remove-Item $script:Root -Recurse -Force -ErrorAction SilentlyContinue }
+
+        It 'exits 0' { $script:Exit | Should -Be 0 }
+
+        It 'discards a page whose only change is ms.date' {
+            $script:Changed | Should -Not -Contain 'docs/dateonly.md'
+        }
+
+        It 'discards date-only pages in nested directories' {
+            $script:Changed | Should -Not -Contain 'docs/sub/nested.md'
+        }
+
+        It 'keeps a page whose body changed, date bump notwithstanding' {
+            $script:Changed | Should -Contain 'docs/realchange.md'
+        }
+
+        It 'keeps non-markdown files such as toc.yml' {
+            $script:Changed | Should -Contain 'docs/toc.yml'
+        }
+
+        It 'leaves a newly added page in place' {
+            Join-Path $script:Root 'docs\brandnew.md' | Should -Exist
+        }
+    }
+
+    Context 'already staged changes' {
+        BeforeAll {
+            $script:Root2 = New-DocsFixture
+            Push-Location $script:Root2
+            & git add -A
+            Pop-Location
+            & pwsh -NoProfile -File $script:PruneScript -RepoPath $script:Root2 -PathSpec 'docs' *>&1 | Out-Null
+            $script:Changed2 = Get-ChangedPaths $script:Root2
+        }
+        AfterAll { Remove-Item $script:Root2 -Recurse -Force -ErrorAction SilentlyContinue }
+
+        It 'drops date-only pages out of the staged set too' {
+            $script:Changed2 | Should -Not -Contain 'docs/dateonly.md'
+            $script:Changed2 | Should -Contain 'docs/realchange.md'
+        }
+    }
+
+    Context 'WhatIf' {
+        BeforeAll {
+            $script:Root3 = New-DocsFixture
+            & pwsh -NoProfile -File $script:PruneScript -RepoPath $script:Root3 -PathSpec 'docs' -WhatIf *>&1 | Out-Null
+            $script:Changed3 = Get-ChangedPaths $script:Root3
+        }
+        AfterAll { Remove-Item $script:Root3 -Recurse -Force -ErrorAction SilentlyContinue }
+
+        It 'reports without modifying the working tree' {
+            $script:Changed3 | Should -Contain 'docs/dateonly.md'
+        }
+    }
+
+    Context 'nothing to do' {
+        BeforeAll {
+            $script:Root4 = New-DocsFixture
+            Push-Location $script:Root4
+            & git checkout -q -- .
+            & git clean -qfd
+            Pop-Location
+            & pwsh -NoProfile -File $script:PruneScript -RepoPath $script:Root4 -PathSpec 'docs' *>&1 | Out-Null
+            $script:Exit4 = $LASTEXITCODE
+        }
+        AfterAll { Remove-Item $script:Root4 -Recurse -Force -ErrorAction SilentlyContinue }
+
+        It 'exits 0 on a clean tree' { $script:Exit4 | Should -Be 0 }
+    }
+}

--- a/scripts/tests/validate-mslearn-docs.Tests.ps1
+++ b/scripts/tests/validate-mslearn-docs.Tests.ps1
@@ -208,4 +208,48 @@ Describe 'port-mslearn-docs: generated toc.yml + guides index' {
         $gi | Should -Match '# Framework guides'
         $gi | Should -Not -Match "`r`r"
     }
+
+    It 'separates every generated table from the preceding paragraph with a blank line' {
+        # A table header glued to the paragraph above it is absorbed into that
+        # paragraph instead of rendering as a table. Here-strings drop the newline
+        # before their closing terminator, which makes this easy to reintroduce.
+        $offenders = @()
+        foreach ($file in Get-ChildItem $script:PortOut -Recurse -File -Filter *.md) {
+            $lines = Get-Content $file.FullName
+            for ($i = 1; $i -lt $lines.Count; $i++) {
+                # A delimiter row identifies a table; its header is the line above.
+                if ($lines[$i] -notmatch '^\s*\|[\s\-:|]+\|\s*$') { continue }
+                if ($lines[$i - 1] -notmatch '^\s*\|') { continue }
+                $headerIndex = $i - 1
+                if ($headerIndex -gt 0 -and $lines[$headerIndex - 1].Trim() -ne '') {
+                    $rel = [System.IO.Path]::GetRelativePath($script:PortOut, $file.FullName)
+                    $offenders += "${rel}:$($headerIndex + 1)"
+                }
+            }
+        }
+        $offenders -join ', ' | Should -BeNullOrEmpty
+    }
+
+    It 'resolves every relative link in the generated docs to a file that exists' {
+        # guides/index.md is assembled from root-relative links lifted out of
+        # index.md, so a target one directory up (security.md) silently 404s
+        # unless it is rebased to ../. Site-absolute MS Learn paths (/windows,
+        # /azure) are intentional and are not resolved against the output tree.
+        $broken = @()
+        foreach ($file in Get-ChildItem $script:PortOut -Recurse -File -Filter *.md) {
+            $content = Get-Content $file.FullName -Raw
+            foreach ($m in [regex]::Matches($content, '\]\(([^)\s]+)\)')) {
+                $href = $m.Groups[1].Value
+                if ($href -match '^(https?:|mailto:|#|/)') { continue }
+                $path = ($href -split '#')[0]
+                if (-not $path) { continue }
+                $target = Join-Path $file.DirectoryName ($path -replace '/', '\')
+                if (-not (Test-Path $target)) {
+                    $rel = [System.IO.Path]::GetRelativePath($script:PortOut, $file.FullName)
+                    $broken += "$rel -> $href"
+                }
+            }
+        }
+        $broken -join ', ' | Should -BeNullOrEmpty
+    }
 }


### PR DESCRIPTION
Three defects in the MS Learn docs generated by `scripts/port-mslearn-docs.ps1`, all visible on the v0.6.2 docs PR.

## Summary

| # | Problem | Cause | Fix |
|---|---------|-------|-----|
| 1 | Framework table rendered as a paragraph of pipe characters | A here-string drops the newline before its closing `"@`, so the blank line separating the intro from the table collapsed and Markdown absorbed the table | Build the table into `$tableContent` and join with an explicit blank line |
| 2 | "Security guidance" link 404'd | The section is copied one directory down into `guides/`. Stripping the `guides/` prefix rebased sibling guides correctly, but left root-level `security.md` resolving to `guides/security.md` | Rewrite root-relative links to `../` first, while the `guides/` prefix still identifies siblings |
| 3 | 19 of 26 files in the docs PR changed by nothing but `ms.date` | Every page is restamped with today's date on every release, regardless of content | New `prune-date-only-doc-changes.ps1` discards files whose only diff is the `ms.date` line |

## Notes

**# 2** — `security.md` was ported correctly and was already in `toc.yml`. Only the link was wrong; no page was missing.

**# 3** — 73% of the v0.6.2 docs PR was noise, leaving the docs-repo reviewer 19 no-op diffs to open before finding the 7 real edits. Pruned files keep the date of the last release that actually changed them, which is what `ms.date` is meant to convey. New, deleted, and otherwise-modified files are untouched, as is `toc.yml`. The script diffs against `HEAD` rather than the index, so it behaves the same whether or not files are staged.

The script is wired into `Release_MSLearn` between branch creation and staging, and added to the `mslearn-source` artifact — 1ES release jobs cannot check out the repo, so a script that isn't staged there does not exist at runtime. If pruning empties the change set, the existing "No changes detected" path already exits cleanly.

## Verification

| Check | Result |
|-------|--------|
| Every relative link in the generated tree resolves | pass |
| Every `toc.yml` href resolves | pass |
| `scripts/tests` suite | 52/52 pass |
| `validate-mslearn-docs.ps1` | exit 0, 24 docs, 0 errors |

Regression tests were confirmed to fail on the specific defect by reverting each fix in isolation:

| Reverted | Failure |
|----------|---------|
| Table fix only | `guides\index.md:11` |
| Link fix only | `guides\index.md -> security.md` |

The 9 tests for # 3 run against a throwaway git fixture covering date-only, nested date-only, real body edit, new page, `toc.yml`, `-WhatIf`, and clean-tree cases. `build-cli.ps1` runs the whole `scripts/tests` directory, so no CI wiring was needed.

**Not exercised end-to-end:** the pipeline wiring is validated by inspection and by the script's own tests against a synthetic repo. The real `Release_MSLearn` path runs at the next release.
