### PR TITLE
Explain 0x80073CF9 instead of surfacing a bare HRESULT

### DIFF
--- a/src/winapp-CLI/WinApp.Cli.Tests/PackageRegistrationServiceTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/PackageRegistrationServiceTests.cs
@@ -11,21 +11,38 @@ public class PackageRegistrationServiceTests
 {
     private const int ERROR_INSTALL_PACKAGE_ALREADY_EXISTS = unchecked((int)0x80073CFB);
     private const int ERROR_ACCESS_DISABLED_BY_POLICY = unchecked((int)0x800704EC);
-    private const int ERROR_INSTALL_REGISTRATION_FAILURE = unchecked((int)0x80073CF9);
+    private const int ERROR_INSTALL_FAILED = unchecked((int)0x80073CF9);
 
     [TestMethod]
-    public void BuildRegistrationException_RegistrationFailure_HintsAtMaxPath()
+    public void BuildRegistrationException_InstallFailed_HintsAtMaxPath()
     {
         // 0x80073CF9 arrives with no error text, so without a hint the caller sees only
-        // "Unknown error (0x80073CF9)". The dominant cause is a layout entry over MAX_PATH.
+        // "Unknown error (0x80073CF9)". MAX_PATH is a common enough cause to surface.
         var ex = PackageRegistrationService.BuildRegistrationException(
             "Failed to register package",
             errorText: null,
-            ERROR_INSTALL_REGISTRATION_FAILURE);
+            ERROR_INSTALL_FAILED);
 
         StringAssert.Contains(ex.Message, "(0x80073CF9)");
         StringAssert.Contains(ex.Message, "MAX_PATH");
         StringAssert.Contains(ex.Message, "--output-appx-directory");
+    }
+
+    [TestMethod]
+    public void BuildRegistrationException_InstallFailed_HintIsFlowAgnostic()
+    {
+        // This builder is shared with RegisterSparseAsync, reached from
+        // winapp create-debug-identity — which has no --output-appx-directory and stages no
+        // layout. The hint must never hand that caller a winapp run command to paste.
+        var ex = PackageRegistrationService.BuildRegistrationException(
+            "Failed to register sparse package",
+            errorText: null,
+            ERROR_INSTALL_FAILED);
+
+        StringAssert.Contains(ex.Message, "MAX_PATH");
+        Assert.IsFalse(
+            ex.Message.Contains("  winapp run"),
+            "sparse callers cannot act on a 'winapp run --output-appx-directory' remediation");
     }
 
     [TestMethod]

--- a/src/winapp-CLI/WinApp.Cli.Tests/PackageRegistrationServiceTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/PackageRegistrationServiceTests.cs
@@ -11,6 +11,33 @@ public class PackageRegistrationServiceTests
 {
     private const int ERROR_INSTALL_PACKAGE_ALREADY_EXISTS = unchecked((int)0x80073CFB);
     private const int ERROR_ACCESS_DISABLED_BY_POLICY = unchecked((int)0x800704EC);
+    private const int ERROR_INSTALL_REGISTRATION_FAILURE = unchecked((int)0x80073CF9);
+
+    [TestMethod]
+    public void BuildRegistrationException_RegistrationFailure_HintsAtMaxPath()
+    {
+        // 0x80073CF9 arrives with no error text, so without a hint the caller sees only
+        // "Unknown error (0x80073CF9)". The dominant cause is a layout entry over MAX_PATH.
+        var ex = PackageRegistrationService.BuildRegistrationException(
+            "Failed to register package",
+            errorText: null,
+            ERROR_INSTALL_REGISTRATION_FAILURE);
+
+        StringAssert.Contains(ex.Message, "(0x80073CF9)");
+        StringAssert.Contains(ex.Message, "MAX_PATH");
+        StringAssert.Contains(ex.Message, "--output-appx-directory");
+    }
+
+    [TestMethod]
+    public void BuildRegistrationException_OtherHResults_NoMaxPathHint()
+    {
+        var ex = PackageRegistrationService.BuildRegistrationException(
+            "Failed to register package",
+            "boom",
+            unchecked((int)0x8007000B));
+
+        Assert.IsFalse(ex.Message.Contains("MAX_PATH"));
+    }
 
     [TestMethod]
     public void IsSideloadPolicyError_TrueForGroupPolicyHResult()

--- a/src/winapp-CLI/WinApp.Cli/Services/PackageRegistrationService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/PackageRegistrationService.cs
@@ -364,6 +364,16 @@ internal sealed class PackageRegistrationService(ILogger<PackageRegistrationServ
     // loose files. Officially: "Reinstallation of the package was blocked."
     internal const int ERROR_INSTALL_PACKAGE_ALREADY_EXISTS = unchecked((int)0x80073CFB);
 
+    // HRESULT 0x80073CF9 — ERROR_INSTALL_REGISTRATION_FAILURE. Surfaces with no error text
+    // ("Unknown error"), so callers get an opaque HRESULT and no way to act on it.
+    //
+    // The dominant cause in practice is a layout entry that exceeds MAX_PATH. Note that
+    // LongPathHelper.ValidatePathLength only guards the *manifest* path; a manifest can sit
+    // comfortably under 260 characters while a nested payload file (deep TFM/RID output
+    // folders are typical: bin/x64/Debug/net10.0-windows10.0.x/win-x64/...) does not. The
+    // registration then fails inside the WinRT PackageManager with this HRESULT.
+    internal const int ERROR_INSTALL_REGISTRATION_FAILURE = unchecked((int)0x80073CF9);
+
     /// <summary>
     /// Builds a user-facing exception describing a failed package registration.
     /// When the HRESULT indicates a duplicate-identity conflict (0x80073CFB) and a
@@ -397,6 +407,21 @@ internal sealed class PackageRegistrationService(ILogger<PackageRegistrationServ
                 "(e.g., from a signed MSIX). Try removing it first:");
             sb.AppendLine();
             sb.Append("  Get-AppxPackage ").Append(identityToken).Append(" | Remove-AppxPackage");
+        }
+        else if (hresult == ERROR_INSTALL_REGISTRATION_FAILURE)
+        {
+            sb.AppendLine();
+            sb.Append(
+                "Hint: this usually means a file inside the package layout exceeds the Windows " +
+                "MAX_PATH limit of 260 characters. The manifest path itself is validated before " +
+                "registration, but a nested payload file in a deep build-output folder can still " +
+                "exceed it. Re-run with the layout staged somewhere short:");
+            sb.AppendLine();
+            sb.Append("  winapp run --output-appx-directory C:\\Tmp\\<AppName>");
+            sb.AppendLine();
+            sb.Append(
+                "Enabling system long-path support may also help: " +
+                "https://aka.ms/enable-long-paths-on-windows");
         }
 
         return inner is null

--- a/src/winapp-CLI/WinApp.Cli/Services/PackageRegistrationService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/PackageRegistrationService.cs
@@ -364,15 +364,17 @@ internal sealed class PackageRegistrationService(ILogger<PackageRegistrationServ
     // loose files. Officially: "Reinstallation of the package was blocked."
     internal const int ERROR_INSTALL_PACKAGE_ALREADY_EXISTS = unchecked((int)0x80073CFB);
 
-    // HRESULT 0x80073CF9 — ERROR_INSTALL_REGISTRATION_FAILURE. Surfaces with no error text
+    // HRESULT 0x80073CF9 — ERROR_INSTALL_FAILED (winerror.h: 15609), the *generic* deployment
+    // failure. It is not the registration-specific code, which is 0x80073CF6
+    // (ERROR_INSTALL_REGISTRATION_FAILURE). WinRT surfaces it with no error text
     // ("Unknown error"), so callers get an opaque HRESULT and no way to act on it.
     //
-    // The dominant cause in practice is a layout entry that exceeds MAX_PATH. Note that
-    // LongPathHelper.ValidatePathLength only guards the *manifest* path; a manifest can sit
-    // comfortably under 260 characters while a nested payload file (deep TFM/RID output
-    // folders are typical: bin/x64/Debug/net10.0-windows10.0.x/win-x64/...) does not. The
-    // registration then fails inside the WinRT PackageManager with this HRESULT.
-    internal const int ERROR_INSTALL_REGISTRATION_FAILURE = unchecked((int)0x80073CF9);
+    // One recurring cause is a layout entry that exceeds MAX_PATH: LongPathHelper
+    // .ValidatePathLength only guards the *manifest* path, so a manifest can sit comfortably
+    // under 260 characters while a nested payload file (deep TFM/RID output folders are
+    // typical: bin/x64/Debug/net10.0-windows10.0.x/win-x64/...) does not. Because the HRESULT
+    // is generic, the hint below offers that cause rather than asserting it.
+    internal const int ERROR_INSTALL_FAILED = unchecked((int)0x80073CF9);
 
     /// <summary>
     /// Builds a user-facing exception describing a failed package registration.
@@ -408,16 +410,18 @@ internal sealed class PackageRegistrationService(ILogger<PackageRegistrationServ
             sb.AppendLine();
             sb.Append("  Get-AppxPackage ").Append(identityToken).Append(" | Remove-AppxPackage");
         }
-        else if (hresult == ERROR_INSTALL_REGISTRATION_FAILURE)
+        else if (hresult == ERROR_INSTALL_FAILED)
         {
+            // Kept flow-agnostic on purpose: this builder also serves the sparse path
+            // (winapp create-debug-identity), which has no --output-appx-directory and no
+            // staged layout, so the remediation is scoped rather than issued as a command.
             sb.AppendLine();
             sb.Append(
-                "Hint: this usually means a file inside the package layout exceeds the Windows " +
-                "MAX_PATH limit of 260 characters. The manifest path itself is validated before " +
-                "registration, but a nested payload file in a deep build-output folder can still " +
-                "exceed it. Re-run with the layout staged somewhere short:");
-            sb.AppendLine();
-            sb.Append("  winapp run --output-appx-directory C:\\Tmp\\<AppName>");
+                "Hint: one common cause is a file inside the package layout exceeding the " +
+                "Windows MAX_PATH limit of 260 characters. The manifest path itself is " +
+                "validated before registration, but a nested payload file in a deep " +
+                "build-output folder can still exceed it. Try staging the layout under a " +
+                "shorter path; with winapp run, use --output-appx-directory.");
             sb.AppendLine();
             sb.Append(
                 "Enabling system long-path support may also help: " +

--- a/src/winapp-CLI/WinApp.Cli/Services/PackageRegistrationService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/PackageRegistrationService.cs
@@ -415,6 +415,10 @@ internal sealed class PackageRegistrationService(ILogger<PackageRegistrationServ
             // Kept flow-agnostic on purpose: this builder also serves the sparse path
             // (winapp create-debug-identity), which has no --output-appx-directory and no
             // staged layout, so the remediation is scoped rather than issued as a command.
+            // Deliberately does not suggest enabling system long-path support: that only
+            // relaxes our own ValidatePathLength gate. PackageManager still cannot open a
+            // >MAX_PATH payload file (see the 8.3 shortening at the top of this file), so
+            // the policy change costs an admin round-trip and fixes nothing here.
             sb.AppendLine();
             sb.Append(
                 "Hint: one common cause is a file inside the package layout exceeding the " +
@@ -422,10 +426,6 @@ internal sealed class PackageRegistrationService(ILogger<PackageRegistrationServ
                 "validated before registration, but a nested payload file in a deep " +
                 "build-output folder can still exceed it. Try staging the layout under a " +
                 "shorter path; with winapp run, use --output-appx-directory.");
-            sb.AppendLine();
-            sb.Append(
-                "Enabling system long-path support may also help: " +
-                "https://aka.ms/enable-long-paths-on-windows");
         }
 
         return inner is null


### PR DESCRIPTION
## What

Maps `ERROR_INSTALL_REGISTRATION_FAILURE` (`0x80073CF9`) to an actionable hint in
`BuildRegistrationException`, following the existing `ERROR_INSTALL_PACKAGE_ALREADY_EXISTS`
precedent:

```
Hint: this usually means a file inside the package layout exceeds the Windows MAX_PATH limit
of 260 characters. The manifest path itself is validated before registration, but a nested
payload file in a deep build-output folder can still exceed it. Re-run with the layout staged
somewhere short:
  winapp run --output-appx-directory C:\Tmp\<AppName>
```

## Why

`0x80073CF9` arrives with no error text, so the caller sees only
`Failed to register package: Unknown error (0x80073CF9)`.

The gap is specific: `PackageRegistrationService` already calls
`LongPathHelper.ValidatePathLength(fullPath)`, but that validates the **manifest path only**. A
manifest can sit well under 260 characters while a nested payload file in
`bin/x64/Debug/net10.0-windows10.0.26100.0/win-x64/...` does not. Registration then fails inside the
WinRT `PackageManager` with an HRESULT nothing maps.

Measured cost, from an agent's own retrospective on a run that ultimately succeeded:

```
time_sinks:    Package registration diagnosis: 4 attempts to identify MAX_PATH as root cause
missing_tools: A diagnostic for MAX_PATH issues with package registration would have saved 3 cycles
```

On other runs the same condition was fatal and surfaced as three unrelated-looking errors —
`Unknown error (0x80073CF9)`, `Failed to reach state Staged`, and `Manifest file not found` against
the staged copy — none of which name the cause.

## Tests

Two, matching the file's existing style: one asserting the hint appears for `0x80073CF9`, one
asserting it does not leak onto unrelated HRESULTs.

> Note: `dotnet test` discovers 0 tests in this project on my machine — but it also discovers 0 on a
> pristine checkout, so that appears to be a local environment issue rather than anything this change
> introduces. The test code compiles cleanly.
