### PR TITLE
Make agent guidance audience-aware

### DIFF
--- a/.github/skills/pr-review/SKILL.md
+++ b/.github/skills/pr-review/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: pr-review
-description: Multi-dimensional review of a PR or feature branch in the microsoft/winappcli repo. Activate when a contributor asks to "review my PR", "review my changes", "vet my branch before pushing", "do a full review", "PR review", "review this feature", or similar. Fans out parallel sub-agents covering security, correctness and tests, CLI UX, alternative solutions, necessity and simplicity, shipping surfaces (docs/samples/packaging), and an independent different-model cross-check, then validates critical/high findings by building and running the CLI the way a user would. Applies a mandatory gut check that drops findings which are true-but-not-necessary, so the review does not drive scope creep. Reports a short finding list to stdout. Does NOT apply fixes unless explicitly asked.
+description: Multi-dimensional review of a PR or feature branch in the microsoft/winappcli repo. Activate when a contributor asks to "review my PR", "review my changes", "vet my branch before pushing", "do a full review", "PR review", "review this feature", or similar. Fans out parallel sub-agents covering security, correctness and tests, CLI UX, alternative solutions, necessity and simplicity, shipping surfaces (docs/samples/packaging), and an independent different-model cross-check, then validates critical/high findings by building and running the CLI the way a user would. Applies a mandatory gut check that drops findings which are true-but-not-necessary, so the review does not drive scope creep. Reports a compact, human-first decision and finding list to stdout. Does NOT apply fixes unless explicitly asked.
 infer: true
 ---
 
 You are the **PR review orchestrator** for `microsoft/winappcli`. Fan out
-parallel reviewers, run the branch for real, and hand back a short list of things
-that actually matter.
+parallel reviewers, run the branch for real, and hand back a human-readable
+decision with only the changes that actually matter.
 
 Do **not** activate for "review this function" or "is this line correct" — those
 are direct questions, not PR scope.
@@ -50,7 +50,9 @@ as re-openable, not settled design."*
 **Necessity is conditional**: run it when the diff adds user-facing surface, adds
 new internal structure (service / interface / abstraction / config knob), **or**
 this is a re-review. Skip it for small fixes, refactors, perf, docs, tests, and
-CI on a first review, and mark it `n/a` in Coverage.
+CI on a first review. `spec-review` owns scope before implementation; this pass
+reopens it only when the implementation reveals unexpected cost,
+overengineering, or review-driven creep.
 
 Then, after those return, launch **multi-model** (`dimensions/multi-model.md`)
 with a `model` override selecting the latest model from a different family than
@@ -60,18 +62,19 @@ critical/high list is optional input it reads only after its own pass.
 
 Tell every sub-agent: if a tool call is blocked, keep going with what you have
 and still return findings. If one returns nothing or dies, re-run that one
-hardened; mark it `✗ skipped + reason` only if the retry also fails.
+hardened; record the failure internally only if the retry also fails.
 
 ## 3. Consolidate
 
 Dedupe (same file, overlapping lines, same root cause — keep the higher severity,
-append the other domain). Assign IDs: `C1`, `H1`, `M1`, `L1`. Sort by severity,
-then path. Merge overlapping additive fixes: if several reviewers each want a new
-guard or helper in the same area, that is one recommendation, not three. You are
-the only one who sees the total.
+append the other domain internally). Track IDs, severity, confidence, model, and
+domain only while consolidating; do not expose bookkeeping in the final report.
+Sort by severity, then user impact. Merge overlapping additive fixes: if several
+reviewers each want a new guard or helper in the same area, that is one
+recommendation, not three. You are the only one who sees the total.
 
-On a re-review, drop medium and low; report their count as one `Deferred polish`
-line.
+On a re-review, drop medium and low rather than carrying deferred polish into the
+final report.
 
 ## 4. The gut check
 
@@ -91,12 +94,16 @@ something that cannot happen here; if it is a "for completeness" item with no
 user-visible effect; or if you cannot finish the sentence *"a user doing X will
 hit Y."*
 
+Also delete or downgrade it if you cannot show the smallest concrete command,
+input, tree, or code path and explain it to a junior developer with no prior
+conversation context.
+
 **Never cut** security, data loss, crashes, wrong output, or broken installs —
 this removes polish and speculation, not defects.
 
 **If more than about 6 findings survive on a normal PR, go again.** Cutting a
 real-but-minor finding is cheap; padding the list is expensive, because that is
-how simple things get complicated. Report the count you kept.
+how simple things get complicated. Record the kept count internally.
 
 ## 5. Validate for real
 
@@ -114,7 +121,7 @@ critical/high finding with real evidence, and record what you could not do.
    UI-automation changes, drive a real window — test fakes mask real behavior.
 4. **Try the security red-team attempt** the security reviewer described.
 5. Mark each finding `validated` (reproduced — add the runtime evidence),
-   **drop** it (refuted — say why in Coverage notes), or leave it `static-only`
+   **drop** it (refuted — record why internally), or leave it `static-only`
    and state exactly what you'd need (cert, hardware, admin, sample app).
 
 Never mark something `validated` without real evidence.
@@ -122,58 +129,44 @@ Never mark something `validated` without real evidence.
 ## 6. Report
 
 Print this to stdout. No file output, no PR comment, and **no fixes** unless
-explicitly asked.
+explicitly asked. State each finding once.
 
-```
-PR Review — <head> vs <base>  (<N> commits, <M> files, +<add>/-<del>)
+```markdown
+# PR Review — <head> vs <base>
 
-Summary
-  Critical: 0   High: 2   Medium: 1   Low: 0
-  Gut check: kept 3 of 17
+## Decision
+<merge | changes required | blocked> — <one or two plain sentences explaining why>
 
-Coverage
-  security              ✓ clean
-  correctness           ⚠ 1 finding
-  cli-ux                ✓ clean
-  alternative-solution  ✓ clean
-  ship-surfaces         ⚠ 1 finding
-  necessity-simplicity  n/a (no new surface)
-  multi-model           ✓ 2/2 high confirmed  ·  gemini
-  validation            ⚠ 1/2 high validated; H2 static-only (no signing cert)
+## Must fix
+### <plain finding title>
+- **What is wrong:** <the defect>
+- **Show me:** <smallest command/input/code path; input -> actual -> expected>
+- **Why it matters:** <concrete consequence>
+- **Smallest fix:** <least-complex repair>
+- **Location:** `<path>:<line>`
 
-Recommended action
-  Must fix before merge  H1, H2
-  Safe to decline        M1 — a required flag is fine for a v1
+<Repeat only for critical/high findings, or write "None — mergeable as-is.">
 
-Findings
-  H1  src/.../SparsePackageService.cs:142-160   security   Process.Start with manifest-derived path
-  H2  src/.../CreateExternalCatalogCommand.cs:34-49  correctness  New command has no tests
-  M1  src/.../CreateExternalCatalogCommand.cs:18-25  cli-ux  --catalog-name has no default
+## Non-blocking
+### <plain finding title>
+- **What is wrong:** <the improvement>
+- **Show me:** <smallest concrete example>
+- **Why it matters:** <bounded consequence>
+- **Smallest fix:** <least-complex repair>
+- **Location:** `<path>:<line>`
 
-Details
-## H1  src/winapp-CLI/WinApp.Cli/Services/SparsePackageService.cs:142-160
-- Severity: high
-- Confidence: high
-- Validation: validated
-- Domain: security
-- Multi-model: confirmed
-- Finding: makeappx.exe is invoked with a path read from the input manifest without validation.
-- Evidence: Line 148 builds args via string interpolation from XElement.Attribute("Source").Value (line 131). Red-teamed on the published binary: a manifest with Source='a b" /p x' made the extra /p flag reach makeappx.
-- Recommendation: Pass arguments via ProcessStartInfo.ArgumentList instead of concatenating.
+<Repeat only for medium/low findings, or write "None.">
 
-Coverage notes
-  gut check: dropped 14 of 17 as true-but-not-necessary — mostly defensive
-    guards for input the CLI controls.
-  ship-surfaces: checked version.json, npm wrapper, NuGet targets — no impact.
+## What was exercised
+- `<build/test/command>` — <observed result>
+- Not exercised: <specific path> — <why, and how that affects confidence or action>
 ```
 
-`Recommended action` is the stop signal and is mandatory. `Must fix before merge`
-is critical/high only — if empty, print `none — mergeable as-is` and mean it.
-`Safe to decline` must be non-empty whenever medium/low findings exist; naming
-what the author may reasonably close is what stops the list being read as a
-to-do list.
-
-Zero findings is a great result. Recommending no changes is a valid outcome.
+`Decision` is the stop signal. `Must fix` is critical/high only; `Non-blocking`
+is explicitly optional work. Paths support the explanation instead of replacing
+the title. Keep coverage, domain, model, confidence, and validation bookkeeping
+out of the report unless one changes the decision or tells the author what still
+needs proof. Zero findings is a great result.
 
 ## If asked to fix
 
@@ -185,7 +178,9 @@ and a separate PR.
 
 If asked to post the review as a PR comment, open with
 `> 🤖 AI-generated review (winappcli pr-review skill) — verify before acting.`
-Never post silently, never drop the banner.
+Never post silently, never drop the banner. Production comments and documentation
+must not contain internal finding IDs, review-round numbers, model/domain coverage
+tables, or review provenance.
 
 ## Maintaining this skill
 

--- a/.github/skills/pr-review/dimensions/_shared-contract.md
+++ b/.github/skills/pr-review/dimensions/_shared-contract.md
@@ -2,31 +2,41 @@
 
 ## Output
 
-Start with one line: `# <dimension>: <N> findings`
+Sub-agent output is internal synthesis input. Keep severity, confidence,
+validation, and domain metadata here, but the orchestrator must not copy that
+bookkeeping into the user-visible report unless it changes the action or
+confidence.
+
+Start with one line: `# <dimension>: <N> findings`.
 
 Then one block per finding:
 
 ```markdown
-## <path>:<start_line>-<end_line>
+## <plain finding title>
 - **Severity**: critical | high | medium | low
 - **Confidence**: high | medium | low
 - **Validation**: static-only (needs runtime confirmation)
 - **Domain**: <dimension>
-- **Finding**: <what is wrong, one line>
-- **Evidence**: <quote 1-3 lines from the diff, cite line refs>
-- **Recommendation**: <smallest concrete fix>
+- **Location**: <repo-relative path and post-change lines>
+- **What is wrong**: <the defect, in plain language>
+- **Show me**: <smallest command/input/code path; prefer input -> actual -> expected>
+- **Why it matters**: <concrete user, build, security, or maintenance consequence>
+- **Smallest fix**: <least-complex change that resolves it>
 ```
 
-Paths are repo-relative; line numbers refer to the post-change file. Always emit
-`Validation: static-only` — the orchestrator promotes findings to `validated`
-after actually running the code.
+Always emit `Validation: static-only`; the orchestrator promotes it only after a
+real reproduction. Define unavoidable jargon on first use. If you cannot provide
+a concrete `Show me`, lower confidence or drop the finding.
 
 End with a `## What I checked` section, one bullet per area inspected. This is
-how the developer sees scope, not just verdict.
+internal evidence for consolidation, not a user-visible coverage table.
 
 ## The bar
 
 Before emitting anything, ask:
+
+> Could a junior developer with no prior conversation understand what fails, see
+> it happen, and know the smallest repair after one read?
 
 > Would a busy maintainer, looking at a PR that is otherwise ready to ship,
 > genuinely want this changed — or is this merely a true statement about the
@@ -50,6 +60,21 @@ install. This bar removes polish and speculation, not defects.
 
 **There is no quota, and zero findings is a good result.** Two precise findings
 beat eight thorough ones. Never invent one to avoid an empty report.
+
+## Compatibility gate
+
+The baseline is the latest supported published release, never an earlier commit,
+review round, current PR implementation, or unreleased release work. Before
+calling something a compatibility break or recommending an alias, fallback,
+migration path, legacy branch, or compatibility abstraction, identify:
+
+1. The supported published version containing the behavior.
+2. The public contract or persisted user data involved.
+3. A real external consumer that would break.
+
+If any is missing, it is not a compatibility finding: prefer a clean replacement
+of the unreleased behavior. A publicly supported preview contract is the only
+exception.
 
 ## Recommendations
 

--- a/.github/skills/pr-review/dimensions/alternative-solution.md
+++ b/.github/skills/pr-review/dimensions/alternative-solution.md
@@ -28,15 +28,14 @@ only.
 
 ## Structure
 
-- **Pick the right pattern.** Interface + DI service for stateful logic with
-  dependencies; static helper for pure functions; data document for wrapping a
-  file format; partial class for splitting a large tightly-coupled service. A
-  stateless three-line helper registered in DI, or a stateful class written as a
-  static, will need rework.
-- **File size.** Target ≤500 lines, soft limit ~800, hard limit ~1000. Flag a new
-  file already over the soft limit, or an existing file this diff pushes over.
-- **Premature abstraction.** An interface with one caller and no anticipated
-  second should be inlined.
+- **Use the architecture guidance in `AGENTS.md`.** DI does not require an
+  interface. Add one only for multiple implementations, an established contract,
+  or a necessary substitution/test boundary.
+- **Prefer cohesion.** One implementation is better than several one-caller
+  wrappers. Recommend extraction only when you can name the real boundary or
+  reuse it creates.
+- **Treat file size as a signal.** Flag a concrete cohesion, navigation, or test
+  problem, not a line threshold by itself.
 - **Duplication inside this PR.** If the diff repeats a near-identical block
   across commands or files, recommend one shared helper and cite each site.
   Near-duplicates silently drift.

--- a/.github/skills/pr-review/dimensions/cli-ux.md
+++ b/.github/skills/pr-review/dimensions/cli-ux.md
@@ -10,8 +10,9 @@ merely different from what you would have designed is not a finding.
 
 - **Naming.** kebab-case (`--use-defaults`), `--no-<flag>` for negation. `-a` and
   `-w` are reserved for app / window targeting — do not let a new command take
-  them for anything else. Honor existing aliases (`--use-defaults` ≡
-  `--no-prompt`).
+  them for anything else. Preserve an alias only when it passes the shared
+  compatibility gate; an alias introduced only during development is not
+  precedent.
 - **Defaults over required options.** `--cert-password` defaults to `password`
   for dev certs; `--manifest` auto-detects. A new **required** option that could
   have had a default breaks scripted use — that is `high`.

--- a/.github/skills/pr-review/dimensions/correctness-and-tests.md
+++ b/.github/skills/pr-review/dimensions/correctness-and-tests.md
@@ -38,7 +38,7 @@ is what you cannot know without this repo.
 
 Say what changes for existing users and existing flows. A gate that was dead and
 now fires is a behavior change: state whether it will start failing flows that
-used to pass. Lead the Finding line with `Regression:`.
+used to pass. Lead `What is wrong` with `Regression:`.
 
 ## Tests
 

--- a/.github/skills/pr-review/dimensions/necessity-and-simplicity.md
+++ b/.github/skills/pr-review/dimensions/necessity-and-simplicity.md
@@ -2,10 +2,9 @@
 
 Apply `_shared-contract.md`. Set `Domain: necessity-and-simplicity`.
 
-You ask the question the other dimensions skip: **should this exist at all, and
-is it as small as it could be?** *Can merge* ≠ *should merge*. You are the one
-sub-agent whose job is to say "this is well-built but shouldn't ship as-is" when
-that is genuinely true.
+`spec-review` owns feature necessity and scope before implementation. Reopen that
+question here only when the implementation reveals unexpected cost,
+overengineering, or review-driven creep. *Can merge* does not mean *should merge*.
 
 ## When you apply
 
@@ -52,6 +51,10 @@ additions — and the next reviewer treats all nine as settled design.
 - **Say when to stop.** If what remains is medium/low polish, state in
   `## What I checked` that the PR is converged and further rounds will add
   complexity rather than quality.
+
+Describe the unnecessary surface and its cost, not the review round or comment
+that introduced it. Review provenance does not belong in production comments or
+documentation.
 
 ## State a conclusion either way
 

--- a/.github/skills/pr-review/dimensions/security.md
+++ b/.github/skills/pr-review/dimensions/security.md
@@ -47,5 +47,5 @@ reproduce gets ignored, and one that gets reproduced gets fixed.
 
 - Security findings are **never** suppressed for low confidence. Emit them.
 - If the dangerous sink is in the diff but the input source is not, use
-  `Confidence: medium` and say so in the Evidence.
+  `Confidence: medium` and say so in `Show me`.
 - Do not flag what the CA-series analyzers already catch.

--- a/.github/skills/pr-review/dimensions/ship-surfaces.md
+++ b/.github/skills/pr-review/dimensions/ship-surfaces.md
@@ -1,7 +1,7 @@
 # Ship surfaces (docs, samples, packaging)
 
-You own one question for the `microsoft/winappcli` repo: **this repo ships
-several artifacts and several docs surfaces — did they all get updated?**
+You own one question for the `microsoft/winappcli` repo: **which shipped surfaces
+does this observable change affect, and were those surfaces updated?**
 
 Apply `_shared-contract.md`. Set `Domain: ship-surfaces`.
 
@@ -35,20 +35,25 @@ flag the mismatch. Review hand-authored skills only when the command changes a
 documented workflow, example, or troubleshooting path. Do not run the scripts
 yourself.
 
-## A new or changed command needs
+## Match the change to affected surfaces
 
-- `docs/usage.md`.
+- CLI syntax or help changes regenerate `docs/cli-schema.json` through the build;
+  update `docs/usage.md` when it is the canonical hand-authored reference.
 - The relevant shipped skill in `plugins/winapp/skills/winapp-<area>/SKILL.md`
   when its workflow, examples, or troubleshooting changed.
-- `plugins/winapp/com.github.copilot/agents/winapp.agent.md` — it has both a decision tree **and** a
-  command reference; a new command must appear in both. A behavior change that
-  contradicts its "Critical rules" means that rule needs updating.
+- Update `plugins/winapp/com.github.copilot/agents/winapp.agent.md` when its
+  decision tree, command reference, or critical rules are affected.
 - Forwarding in `src/winapp-npm/cli.js` for a new **top-level** command.
 - Hand-written lists that are *not* generated: `docs/usage.md`'s `### ui`
   Commands list, and `winapp.agent.md`'s "Key subcommands". A new `winapp ui`
   subcommand also needs a `### <name>` section in `docs/ui-automation.md`.
 - A new top-level command that warrants its own shipped skill needs a new
   `plugins/winapp/skills/winapp-<area>/SKILL.md` and plugin installation smoke test.
+
+Internal refactors need none of these. User documentation explains what to type,
+what happens, and how to recover from failure; it never narrates implementation
+details, review history, or review-round identifiers. Keep each fact on one
+canonical surface and link to it elsewhere.
 
 ## A new sample needs
 
@@ -60,8 +65,9 @@ finding — do not double-report).
 
 - **`version.json`** drives native CLI and NuGet versioning. A version bumped on
   one artifact but not the sibling that ships with it is `high`.
-- **Breaking changes** — renamed command, removed option, changed default — are
-  `high`: npm and NuGet consumers break.
+- **Breaking changes** — apply the shared compatibility gate first. A published
+  command/default/output contract with a real npm or NuGet consumer may be
+  `high`; behavior introduced only on this branch should be replaced cleanly.
 - `WinAppManifestPath` auto-detect in the NuGet targets must stay consistent with
   the CLI's `ManifestHelper`.
 - New NuGet `.csproj` needs `<Copyright>© Microsoft Corporation. All rights

--- a/.github/skills/spec-review/SKILL.md
+++ b/.github/skills/spec-review/SKILL.md
@@ -13,10 +13,10 @@ than trusting the spec's claims — and consolidating their judgments into a
 single decision-oriented recommendation.
 
 This is the **pre-code companion to the `pr-review` skill.** `pr-review` reviews
-code that is already written and deliberately avoids the "should this exist"
-debate. `spec-review` is the opposite: it evaluates a *proposal* and makes the
-"should this exist / is the approach right" question its whole point. If the
-work is already implemented, use `pr-review` instead.
+code that is already written. `spec-review` owns necessity and scope by default
+before implementation; `pr-review` reopens those questions only when the code
+reveals unexpected cost, overengineering, or review-driven creep. If the work is
+already implemented, use `pr-review`.
 
 ## When to activate
 
@@ -55,8 +55,8 @@ Do **not** activate when:
    the review.
 
 The shared contract (`dimensions/_shared-contract.md`) encodes both, plus the
-**Team Lead Test** signal-to-noise gate and the severity/confidence guides.
-Every sub-agent applies it.
+junior-reader and signal-to-noise gate and the severity/confidence guides. Every
+sub-agent applies it.
 
 ## Workflow
 
@@ -116,8 +116,8 @@ families**. Before fanning out:
      own family. This directly serves the skill's purpose.
    The remaining dimensions may run on your family.
 4. **Degrade gracefully.** If only your family is available, run everything on it
-   but say so plainly in the report's model line — do not fail. Record every
-   family that actually ran.
+   and record that internally. Mention it in the final report only if the missing
+   diversity changes confidence or the decision.
 
 ### 4. Fan out the dimension sub-agents
 
@@ -146,35 +146,37 @@ Collect all outputs. Then:
 1. **Dedupe.** Two findings are duplicates if they target the same spec claim
    with substantially the same root cause. Keep the higher-severity /
    higher-confidence copy; append the other domain to its `Domain:` field.
-2. **Assign IDs.** `C1, C2, …` critical, `H1, …` high, `M1, …` medium,
-   `L1, …` low.
-3. **Sort.** critical → high → medium → low; within a severity, group by domain.
+2. **Keep bookkeeping internal.** IDs, severity, confidence, domain, model, and
+   coverage help consolidation but do not belong in the final report.
+3. **Sort internally.** critical → high → medium → low; within a severity, group
+   by user impact.
 4. **Record cross-model agreement — the strongest signal.** For each
    critical/high finding, note how many **independent model families** reached it
    on their own (e.g. "confirmed by 2 of 3 families"), counting the specialists
-   plus the multi-model pass. Multi-family agreement is the highest-confidence
-   signal in this review; treat it accordingly and surface the count in the
-   report. Also carry the multi-model verdict
+   plus the multi-model pass. Keep the matrix internal; surface at most one
+   sentence when agreement or disagreement changes confidence or the decision.
+   Also carry the multi-model verdict
    (`confirmed` / `disputed` / `downgrade` / `upgrade`).
 5. **Resolve factual disagreements with evidence, not seniority.** When families
    disagree on a **factual** claim (does the tool / API / build actually behave
    this way?), do not settle by preference or by which model is "better" —
    resolve it against an authoritative source or, better, a quick experiment, and
    record the resolution and the evidence that settled it.
-6. **Collect open questions** (design decisions still to be made) from every
+6. **Collect open decisions** (design decisions still to be made) from every
    dimension into one deduped list.
-7. **Collect "must prove before ship" items** — load-bearing technical
+7. **Collect proofs required** — load-bearing technical
    assumptions that neither research nor experiment could fully close. These are
-   pre-implementation spikes/proofs, and are **distinct** from open questions
+   pre-implementation spikes/proofs, and are **distinct** from open decisions
    (which are design decisions).
-8. **Pick the single best alternative** (if any) from
-   `approach-and-alternatives` (and any the multi-model pass raised).
+8. **Describe the leanest design** using the best supported alternative from
+   `approach-and-alternatives` and any smaller scope from `necessity-and-scope`.
 9. **Synthesize the recommendation:**
    - Any unresolved **critical** → `reconsider` (or `proceed-with-changes` only
      if the critical is fully addressable by a specific, scoped change you name).
    - One or more **high**, no critical → `proceed-with-changes`.
-   - Only **medium/low**, or none → `proceed` (note the mediums).
-   - A load-bearing assumption left **unproven** (on the must-prove list) should
+   - Only **medium/low**, or none → `proceed`; fold only decision-relevant items
+     into `Leanest design` or `Open decisions`.
+   - A load-bearing assumption left **unproven** (under `Proofs required`) should
      pull the recommendation toward `proceed-with-changes` at least, since it
      gates a safe build.
    - If your synthesized recommendation **diverges from the multi-model pass's
@@ -184,82 +186,50 @@ Collect all outputs. Then:
 
 ### 6. Report to stdout
 
-Print exactly the structure below. **Do not** save to a file, **do not**
-implement the feature or modify the repo, and **do not** edit the spec unless
-the user explicitly asks. (Cheap experiments in temp directories to verify
-mechanics are expected — see the rules below — but they never touch the repo or
-the spec.) Your job ends at the recommendation.
+Print exactly the structure below. **Do not** save to a file, implement the
+feature, modify the repo, or edit the spec unless explicitly asked. Cheap
+experiments stay in temp directories. State each conclusion once.
 
-```
-Spec Review — <spec title or path>   (models: <fam A>, <fam B>, <fam C>)
+```markdown
+# Spec Review — <spec title or path>
 
-Recommendation: <proceed | proceed-with-changes | reconsider>
-  <2-4 sentence rationale grounded in the strongest findings>
+## Decision
+<proceed | proceed with changes | reconsider> — <plain rationale grounded in evidence>
 
-Summary
-  Critical: <n>   High: <n>   Medium: <n>   Low: <n>
+<Only when it changes confidence or the decision: one sentence about independent
+model agreement or disagreement and the experiment/source that resolved it.>
 
-Top risks
-  1. <highest-impact concern, one line>
-  2. ...
-  (omit the section if there are genuinely none)
+## User journey
+- **Today:** <current command/input -> observable result>
+- **Proposed:** <new command/input -> observable result>
+- **Problem demonstrated:** <smallest experiment or real example proving the gap>
 
-Best alternative
-  <the single best alternative approach with its key tradeoff, or
-   "none — the proposed approach is the simplest reasonable one">
+## Must change before implementation
+### <plain finding title>
+- **What is wrong:** <the design defect>
+- **Show me:** <independent input -> actual -> expected evidence>
+- **Why it matters:** <concrete user, delivery, or maintenance consequence>
+- **Smallest fix:** <least-complex design change>
+- **Location:** <spec section and supporting path/doc when useful>
 
-Open questions (design decisions to resolve before implementation)
-  Q1. <...>
-  Q2. <...>
-  (omit if none)
+<Repeat only for decision-affecting findings, or write "None.">
 
-Must prove before ship (load-bearing assumptions not yet closed)
-  P1. <assumption> — <the spike/experiment that would close it>
-  P2. ...
-  (omit if none)
+## Leanest design
+<smallest design that serves the demonstrated journey, plus its key tradeoff>
 
-Coverage
-  necessity-and-scope        <✓ sound | ⚠ N findings | ✗ n/a + reason>
-  approach-and-alternatives  ...
-  feasibility-vs-reality     ...
-  risks-unknowns-edge-cases  ...
-  dx-and-user-impact         ...
-  multi-model                <✓ family <X>, indep. rec: <proceed|...>>
+## Open decisions
+- <decision the author must make before implementation>
+<Or "None.">
 
-Findings
-  C1  <spec anchor>   <domain>       <one-line>
-  H1  ...
-  M1  ...
-
-Agreement matrix (load-bearing critical/high findings only; omit if none)
-              <fam-A> <fam-B> <fam-C>   experiment
-  C1           ✓       ✓       –        <what an experiment showed, or —>
-  H1           ...
-
-Details
-## C1  <spec anchor>
-- Severity: critical
-- Confidence: high
-- Domain: feasibility-vs-reality
-- Agreement: confirmed by <N> of <M> families
-- Multi-model: confirmed
-- Finding: <one-line>
-- Evidence: <independent research — prefer an experiment you ran ("built a
-  throwaway <app> in a temp dir and observed …", "invoked <tool> and its output
-  was …"); otherwise real file:line, authoritative vendor docs, or ecosystem
-  fact. Never the spec asserting itself.>
-- Recommendation: <concrete next step>
-
-## H1 ...
-
-Coverage notes
-  necessity-and-scope: <the dimension's Bottom line + what it checked>
-  ...
+## Proofs required
+- <unclosed load-bearing assumption> — <specific cheap experiment that closes it>
+<Or "None.">
 ```
 
-For each dimension with zero findings, show `✓ sound` (or `✓ clean`) in Coverage
-and carry its `Bottom line` + `What I checked` into `Coverage notes`, so the
-reader sees the research behind a positive verdict — not just the verdict.
+Fold medium/low suggestions into `Leanest design` or `Open decisions` only when
+they affect the recommendation; otherwise drop them. Do not repeat findings in a
+summary, risk list, details section, agreement matrix, or coverage notes. Keep
+paths as support, not titles.
 
 ## Rules the orchestrator must enforce
 
@@ -267,7 +237,7 @@ reader sees the research behind a positive verdict — not just the verdict.
 - **Independent research, not spec-trust.** Reject any sub-agent finding whose
   only evidence is the spec restating itself. Evidence must come from reality.
 - **No quotas.** Accept and surface clean verdicts. Reject manufactured or
-  padded concerns (Team Lead Test).
+  padded concerns using the shared junior-reader and signal-to-noise gate.
 - **No feature implementation. No repo or spec edits.** You do not build the
   *feature*, modify the repository, or edit the spec — you only research and
   report. "Read-only" means the repo and the spec stay untouched.
@@ -281,7 +251,7 @@ reader sees the research behind a positive verdict — not just the verdict.
   (never the repo working tree). Reach for an experiment first on the riskiest,
   most load-bearing claims; don't spread effort thin.
 - **Decision-oriented.** The report leads with a clear recommendation and the
-  questions that must be answered before coding starts.
+  user journey, changes, decisions, and proofs needed before coding starts.
 
 ## Sub-agent prompt template
 
@@ -319,92 +289,14 @@ yours**.
    the spec's load-bearing mechanics)               → wait for all
 5. Run #6 (multi-model, different family) w/ conclusions; it re-runs key
    experiments, not just re-reasons                 → wait
-6. Dedupe, sort, count cross-family agreement, collect open questions +
-   must-prove items, pick best alternative, synthesize rec
+6. Dedupe, sort, resolve cross-family disagreement, collect open decisions +
+   proofs, identify the leanest design, synthesize the recommendation
 7. Print the decision-oriented stdout report
-```
-
-## Example consolidated stdout
-
-```
-Spec Review — docs/proposals/share-target.md   (models: Opus, GPT, Gemini)
-
-Recommendation: proceed-with-changes
-  The feature fits winapp's platform-integration mission and fills a real need,
-  but it should ship as a smaller first stage, and one load-bearing assumption
-  (that identity is optional for Share Target) is false and must be addressed
-  before implementation.
-
-Summary
-  Critical: 0   High: 2   Medium: 2   Low: 1
-
-Top risks
-  1. Share Target requires package identity; the spec's "works unpackaged" path
-     won't function.
-  2. Proposed `winapp share` top-level command diverges from the `manifest`
-     subcommand grouping users expect.
-
-Best alternative
-  Add `winapp manifest add-share-target` under the existing manifest command
-  group and reuse AppxManifestDocument, instead of a new top-level command +
-  bespoke manifest writer. Tradeoff: slightly less discoverable, far less code.
-
-Open questions (design decisions to resolve before implementation)
-  Q1. Which frameworks must be supported at launch (all six, or MSIX-only)?
-  Q2. Is enabling identity in-scope, or a prerequisite the user must do first?
-
-Must prove before ship (load-bearing assumptions not yet closed)
-  P1. That the manifest edit leaves the existing packaged build output otherwise
-      intact — spike: build a throwaway packaged app in a temp dir, apply the
-      edit, and confirm the prior output is unchanged.
-
-Coverage
-  necessity-and-scope        ✓ sound
-  approach-and-alternatives  ⚠ 1 finding
-  feasibility-vs-reality     ⚠ 1 finding
-  risks-unknowns-edge-cases  ⚠ 2 findings
-  dx-and-user-impact         ⚠ 1 finding
-  multi-model                ✓ family GPT, indep. rec: proceed-with-changes
-
-Findings
-  H1  §Approach — "works unpackaged"        feasibility-vs-reality  Share Target needs package identity; unpackaged path is not supported
-  H2  §CLI — new `winapp share` command     approach-and-alternatives  Reuse manifest command group + AppxManifestDocument instead
-  M1  §Scope — "all six frameworks day one" necessity-and-scope     Stage to MSIX-first; broad framework matrix is unproven need
-  M2  §Errors (unspecified)                 risks-unknowns-edge-cases  No behavior defined when identity is absent
-  L1  §CLI — `--target` naming              dx-and-user-impact      Prefer `--share-target` for consistency
-
-Agreement matrix (load-bearing critical/high findings only)
-             Opus  GPT  Gemini   experiment
-  H1          ✓     ✓     ✓      built throwaway app; share entry activated only when packaged
-  H2          ✓     ✓     –      —
-
-Details
-## H1  §Approach — "works unpackaged"
-- Severity: high
-- Confidence: high
-- Domain: feasibility-vs-reality
-- Agreement: confirmed by 3 of 3 families
-- Multi-model: confirmed
-- Finding: The spec assumes Share Target activation works without package identity; it does not.
-- Evidence: Built a throwaway minimal app in a temp dir and registered it both
-  packaged and unpackaged; the share entry point activated only in the packaged
-  case. This matches the manifest-declared app-extension model (activation is
-  registered via the packaged manifest), so the "works unpackaged" path does not
-  function. Reproduced independently by all three model families.
-- Recommendation: Make package identity a documented prerequisite (or in-scope enablement step), and remove the "works unpackaged" path from the design.
-
-## H2 ...
-
-Coverage notes
-  necessity-and-scope: Fits platform-integration mission and a real user ask;
-    checked Commands/ and cli-schema.json for overlap — none. Recommend staging.
-  multi-model (GPT): Re-ran the packaged-vs-unpackaged experiment independently
-    and reproduced the result; confirmed H1 and agreed with proceed-with-changes.
 ```
 
 ## Output discipline
 
 The final stdout block is the *only* user-visible output. Do not narrate the
-process, do not summarize what each sub-agent did outside the Coverage section,
-and do not apologize for a short findings list — a clean, confident
-recommendation is the goal, not a long list of concerns.
+process, expose model/domain/coverage bookkeeping, repeat a finding in multiple
+sections, or apologize for a short list. A clean, confident recommendation is the
+goal.

--- a/.github/skills/spec-review/SKILL.md
+++ b/.github/skills/spec-review/SKILL.md
@@ -194,7 +194,7 @@ experiments stay in temp directories. State each conclusion once.
 # Spec Review — <spec title or path>
 
 ## Decision
-<proceed | proceed with changes | reconsider> — <plain rationale grounded in evidence>
+<proceed | proceed-with-changes | reconsider> — <plain rationale grounded in evidence>
 
 <Only when it changes confidence or the decision: one sentence about independent
 model agreement or disagreement and the experiment/source that resolved it.>

--- a/.github/skills/spec-review/dimensions/_shared-contract.md
+++ b/.github/skills/spec-review/dimensions/_shared-contract.md
@@ -13,99 +13,58 @@ project in a temp directory, or test a command's real behavior. You do not
 implement the feature or touch the repo/spec — but running cheap, scoped
 experiments in temp directories to confirm how things actually work is expected.
 
-## Header line
+## Internal output
 
-Start with exactly one line:
+Sub-agent output is synthesis input. Metadata may stay internal, but the
+orchestrator must rewrite surviving findings for a reader with no prior context.
 
-```
-# <dimension name>: <N> findings
-```
-
-Where `<dimension name>` is one of: `necessity-and-scope`,
-`approach-and-alternatives`, `feasibility-vs-reality`,
-`risks-unknowns-edge-cases`, `dx-and-user-impact`, `multi-model`.
-
-## Bottom line
-
-Immediately after the header, emit exactly one line:
-
-```
-Bottom line: <one-sentence assessment for this dimension>
-```
-
-This is required **even when you have zero findings** — a design review's job is
-to reach a judgment, and "the approach is the simplest reasonable one; no better
-alternative found" is a complete, valuable result. Do not manufacture a finding
-just to fill space (see *No quotas* below).
-
-## Per-finding block
-
-Each finding is a level-2 heading anchored to the **part of the spec** it is
-about, followed by labeled bullets:
+Start with `# <dimension name>: <N> findings`, then
+`Bottom line: <one-sentence assessment>`. Use this block for each finding:
 
 ```markdown
-## <spec section / heading / quoted claim>
+## <plain finding title>
 - **Severity**: critical | high | medium | low
 - **Confidence**: high | medium | low
 - **Domain**: <dimension name>
-- **Finding**: <one-line statement of the concern>
-- **Evidence**: <what your INDEPENDENT research found. Prefer an experiment you
-  ran ("invoked <tool> on a throwaway input and its output was …", "built a
-  throwaway project in a temp dir and observed …"); otherwise cite real files as
-  `path:line`, authoritative vendor docs, repo patterns, or ecosystem facts.
-  Do NOT cite the spec as evidence for itself.>
-- **Recommendation**: <concrete next step — e.g. descope, stage, use existing
-  helper X, prototype Y first, adopt alternative Z, answer question Q>
+- **Spec location**: <section or quoted claim>
+- **What is wrong**: <the design defect>
+- **Show me**: <smallest independent example; prefer input -> actual -> expected>
+- **Why it matters**: <concrete user, delivery, or maintenance consequence>
+- **Smallest fix**: <least-complex design change>
 ```
 
-Notes:
+`Show me` must come from independent research, not the spec asserting itself.
+Prefer an experiment you ran; otherwise cite authoritative docs or real
+`path:line` evidence. The hierarchy is **experiment > authoritative vendor docs
+> code-read > spec assertion (never sufficient alone)**. Keep experiments cheap,
+scoped, and outside the repo tree. Define unavoidable jargon at first use. If a
+claim is load-bearing but still unproven, show what is unknown and put the exact
+closing experiment under `## Proofs required`; otherwise lower confidence or drop
+an issue that cannot be demonstrated.
 
-- The anchor identifies the spec claim/section under review (e.g.
-  `§Approach — "shell out to makeappx with --foo"`). Keep it short.
-- **Evidence must come from reality, not the spec**, and for *mechanical* claims
-  (tool output, API/command behavior, file/artifact format, build step) a cheap
-  **experiment you ran** is the strongest evidence — reach for it before a
-  code-read. Evidence hierarchy: **experiment > authoritative vendor docs >
-  code-read > spec assertion (never sufficient alone).** If you could not verify
-  a load-bearing claim, that is itself a finding (mark `Confidence: low` or
-  `medium` and say what you could not confirm) — see `feasibility-vs-reality`.
-- Experiments are expected but must stay **cheap, scoped, and confined to temp
-  directories** — never modify the repo working tree or the spec.
-- Emit discontiguous concerns as separate findings.
-
-## Open questions
-
-After the findings, include a section listing questions the spec does **not**
-answer that must be resolved **before** implementation starts:
+After findings, add only these internal sections when they have content:
 
 ```markdown
-## Open questions
-- <a decision or unknown that blocks or materially shapes the build>
-- <e.g., "Does Windows App SDK expose an API for X, or is a P/Invoke required?">
-```
+## Open decisions
+- <decision that blocks or materially shapes implementation>
 
-Omit the bullets if there are genuinely none. Do not pad.
+## Proofs required
+- <unclosed assumption> — <specific experiment that would close it>
 
-## Trailing "what I checked" note
-
-After the open questions, include:
-
-```markdown
 ## What I checked
-- <one bullet per area you independently researched, e.g. "Read
-  MsixService.cs pack path to confirm makeappx invocation">
-- <e.g., "Grepped Commands/ for an existing `store` subcommand">
-- <e.g., "Checked Windows App SDK docs for a Share Target API">
+- <repo area, vendor source, or experiment independently examined>
 ```
 
-This appears in the orchestrator's `Coverage notes` section so the reader can
-see the depth of research behind the verdict — not just the verdict.
+## Junior-reader and signal-to-noise gate
 
-## The Team Lead Test (mandatory signal-to-noise gate)
+Before emitting a finding, ask:
 
-Before emitting a finding, ask: *"Would a senior maintainer of this repo raise
-this in a design review, or wave it off as noise?"* If you would wave it off,
-do not emit it.
+> Could a junior developer with no prior conversation understand what is wrong,
+> see the evidence, understand the consequence, and apply the smallest fix after
+> one read?
+
+Also ask whether a senior maintainer would raise it in a design review or wave it
+off as noise. If either test fails, rewrite it concretely or drop it.
 
 Specifically, **drop**:
 
@@ -125,6 +84,21 @@ Specifically, **drop**:
 - Real risks: compat/migration breakage, missing edge cases, release blockers.
 - CLI UX / API incoherence users will trip over, or breaking changes.
 - Unanswered questions that genuinely block implementation.
+
+## Compatibility boundary
+
+Backward compatibility starts at the latest supported published release, not an
+earlier commit, review round, current PR implementation, or unreleased release
+work. Before reporting a compatibility problem or proposing an alias, fallback,
+migration path, legacy branch, or compatibility abstraction, identify:
+
+1. The supported published version containing the behavior.
+2. The public contract or persisted user data involved.
+3. A real external consumer that would break.
+
+If any is missing, prefer a clean replacement and do not emit a compatibility
+finding. A preview contract counts only when the project publicly committed to
+support it.
 
 ## No quotas — a clean result is a valid result
 

--- a/.github/skills/spec-review/dimensions/approach-and-alternatives.md
+++ b/.github/skills/spec-review/dimensions/approach-and-alternatives.md
@@ -31,15 +31,10 @@ Before endorsing a new mechanism, check whether one of these already covers it:
 - **PE / MRT / PRI → `PeHelper`, `MrtAssetHelper`, `PriService`.**
 - **UI selectors → `SelectorService`.**
 - **CLI parser config → `WinAppParserConfiguration.Default`.**
-- **Service shape** (from the repo's architecture guide):
-  | Pattern | When |
-  |---------|------|
-  | Interface + DI service | stateful, needs deps |
-  | Static helper | pure functions |
-  | Data document | wraps a file/data format |
-  | Partial class | splitting a large tightly-coupled service |
-  Flag a proposal that picks the wrong shape (e.g., a stateless 3-line helper as
-  a DI service, or a stateful thing as a static).
+- **Service shape** (from `AGENTS.md`): DI does not require an interface. Add an
+  interface only for multiple implementations, an established contract, or a
+  necessary substitution/test boundary. Prefer one cohesive implementation over
+  several one-caller wrappers, and never split solely to meet a line target.
 - **Build orchestration → `scripts/build-cli.ps1`** is canonical; flag new build
   steps that bypass or duplicate it.
 

--- a/.github/skills/spec-review/dimensions/dx-and-user-impact.md
+++ b/.github/skills/spec-review/dimensions/dx-and-user-impact.md
@@ -13,8 +13,8 @@ existing commands and options actually look before judging the proposal.
 ## Conventions to check the proposal against
 
 - **Option naming.** kebab-case (`--use-defaults`); `--no-<flag>` for negations;
-  `-a` / `-w` short forms reserved for app/window targeting. Honor existing
-  aliases (e.g. `--use-defaults` ≡ `--no-prompt`) where applicable.
+  `-a` / `-w` short forms reserved for app/window targeting. Keep aliases only
+  when they pass the shared compatibility boundary.
 - **Sane defaults.** The common case should work with minimal flags (e.g.
   `--manifest` auto-detects; dev `--cert-password` defaults to `password`).
   Flag new **required** options that could reasonably have a default.
@@ -33,13 +33,12 @@ existing commands and options actually look before judging the proposal.
   name and options? Is it consistent with the verbs/nouns winapp already uses?
   Is the feature discoverable (help text, docs, guides)?
 
-## Breaking changes & cross-surface impact
+## Published contracts & cross-surface impact
 
-- **Breaking changes** are high-impact: a renamed/removed command or option, a
-  changed default, or changed output shape will break existing scripts and the
-  downstream **npm wrapper**, **NuGet MSBuild targets**, and **VS Code
-  extension**. Flag these prominently and ask whether the break is justified /
-  has a migration path.
+- Apply the shared compatibility boundary before classifying a rename, removed
+  option, changed default, or output shape as breaking. If it passes, show the
+  real script or downstream npm/NuGet/VS Code consumer and the migration needed.
+  If the behavior exists only in unreleased work, prefer a clean replacement.
 - **Cross-surface parity.** A new top-level CLI command usually needs to flow
   through the npm wrapper and be considered for the NuGet targets and VSC
   command palette. Flag a design that would silently diverge across surfaces.

--- a/.github/skills/spec-review/dimensions/feasibility-vs-reality.md
+++ b/.github/skills/spec-review/dimensions/feasibility-vs-reality.md
@@ -54,23 +54,11 @@ confidently, and do not stop at "the code looks like it does X"; where you can
    it with the effort available). Cite the evidence: quote the experiment output
    you saw, the doc, or the `path:line`. An **unproven** load-bearing claim is a
    finding in its own right — surface it and recommend the specific spike that
-   would close it (the orchestrator routes these into "Must prove before ship").
+   would close it (the orchestrator routes these into `Proofs required`).
 
-## Backward-compatibility is a load-bearing assumption
-
-When the spec **modifies existing behavior**, treat any "this won't change
-existing behavior" / "X stays untouched" / "fully backward-compatible" claim as
-a load-bearing assumption and verify it **specifically**, not by trust:
-
-- Find the **exact shared code path / tool / artifact** the change and the
-  existing behavior both go through.
-- Confirm the new path is genuinely **disjoint** from the existing one (or, if
-  shared, that existing callers hit identical behavior).
-- Look for the concrete **regression surface** — the inputs, configs, or
-  callers that could be affected.
-- Where feasible, **prove it empirically**: exercise the existing behavior
-  before and after the proposed mechanic on a throwaway input and confirm it is
-  unchanged. If you cannot, tag the compat claim **unproven** and flag it.
+For compatibility claims, apply the shared published-release boundary first.
+When it passes, treat unchanged behavior as load-bearing: identify the shared
+code path and real consumer, then prefer a before/after experiment.
 
 ## What to flag
 
@@ -98,8 +86,8 @@ a load-bearing assumption and verify it **specifically**, not by trust:
   critical.
 - An **unproven** assumption the approach depends on, needing a spike before
   commitment → high (medium if there's a clear fallback).
-- A refuted/unproven **backward-compat** claim (the change may disturb existing
-  behavior) → high, or critical if it would silently break existing users.
+- A refuted/unproven compatibility claim that passes the shared gate → high, or
+  critical if it would silently break existing users.
 - A secondary assumption that's off but easily worked around → medium.
 - A minor factual imprecision with no design impact → low (often just drop it).
 

--- a/.github/skills/spec-review/dimensions/multi-model.md
+++ b/.github/skills/spec-review/dimensions/multi-model.md
@@ -17,8 +17,8 @@ family** than the orchestrator, chosen from the latest available **GPT**,
   number in this file.** Model versions churn; the orchestrator resolves the
   newest available model in the target family at run time.
 - **Record the family you ran as** in your output (see below). The orchestrator
-  surfaces it in the report so readers know a genuinely different family
-  performed this pass.
+  keeps it as internal bookkeeping. The final report mentions model agreement or
+  disagreement only when it changes confidence or the decision.
 
 ## Your job — independent research first, cross-check second
 

--- a/.github/skills/spec-review/dimensions/necessity-and-scope.md
+++ b/.github/skills/spec-review/dimensions/necessity-and-scope.md
@@ -5,9 +5,10 @@ spec-review skill. You own the deepest question in the review: **should this be
 built at all, and at this size?** Apply the shared output contract in
 `_shared-contract.md`. Set `Domain: necessity-and-scope` on every finding.
 
-This is the home for the "should this exist?" debate that `pr-review`
-deliberately avoids. Be direct — but ground every judgment in independent
-research, not opinion.
+This is the default home for "should this exist?" and scope decisions before
+implementation. `pr-review` reopens scope only when the implementation reveals
+unexpected cost, overengineering, or review-driven creep. Be direct, but ground
+every judgment in independent research, not opinion.
 
 ## winapp's mission
 

--- a/.github/skills/spec-review/dimensions/risks-unknowns-edge-cases.md
+++ b/.github/skills/spec-review/dimensions/risks-unknowns-edge-cases.md
@@ -15,18 +15,9 @@ bugs." Do your own research into the affected surfaces.
 - **Underspecified behavior.** Where does the spec go quiet on something the
   implementer will have to invent — error handling, defaults, ordering, cleanup,
   what happens on partial failure?
-- **Compatibility & migration — a "no change to existing behavior" claim is a
-  load-bearing assumption, not a given.** Does this change behavior for existing
-  users, existing MSIX packages, existing manifests, existing certs, or existing
-  CI invocations? Is there a migration path? Back-compat for the npm wrapper, the
-  NuGet targets, and the VS Code extension surfaces? When the spec asserts it
-  "won't affect existing behavior" / "X stays untouched," **do not take that on
-  faith** — treat it as a claim to be verified: identify the exact shared code
-  path/tool/artifact, confirm the new path is genuinely disjoint, and map the
-  regression surface. Deep verification (ideally a before/after experiment) is
-  the `feasibility-vs-reality` dimension's job — coordinate with it — but flag
-  the compat risk here whenever the claim is unproven or the regression surface
-  is real.
+- **Compatibility & migration.** Apply the shared published-release boundary.
+  If it passes, name the affected user data or external consumer and coordinate
+  deep before/after verification with `feasibility-vs-reality`.
 - **Edge cases.** Empty/missing inputs; missing SDK tools (auto-download path);
   offline; non-elevated execution; multiple Windows versions / SDK versions;
   frameworks the repo supports but the spec didn't consider (Electron, .NET,
@@ -38,8 +29,7 @@ bugs." Do your own research into the affected surfaces.
   **prototyped before committing** — the areas where the risk is real enough
   that a small proof-of-concept should precede full implementation. A cheap
   experiment now (in a temp dir) may resolve the risk outright; where it can't,
-  route the item into the report's "Must prove before ship" list (a
-  pre-implementation proof), distinct from `Open questions` (design decisions).
+  route the item into `Proofs required`, distinct from `Open decisions`.
 
 ## winapp-specific risk surfaces to consider
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,61 @@
 
 This file provides focused, actionable information to help an AI coding agent be immediately productive in this repo.
 
+## Audience contracts
+
+### User documentation
+
+Write for someone using winapp. Lead with the smallest command or input that
+demonstrates the behavior, then answer: what can I do, what do I type, what
+happens, and what action should I take if it fails. Describe observable behavior,
+not implementation machinery.
+
+Keep internal deliberation, review provenance, rejected alternatives, review
+rounds/IDs, resolved blockers, and defenses of the implementation out of user
+documentation. State each user-facing fact once on its canonical surface and link
+to it elsewhere instead of copying it.
+
+Example: "For .NET projects, `winapp restore` runs `dotnet restore` and uses the
+project's standard `nuget.config` hierarchy."
+
+### Reviews and author communication
+
+Assume the reader has no prior codebase or conversation context. A junior
+developer should understand each finding after one read. Use a plain title, then:
+
+- **What is wrong:** the behavior or design defect.
+- **Show me:** the smallest concrete command, input, tree, or code path, preferably
+  as input -> actual result -> expected result.
+- **Why it matters:** the user, build, or maintenance consequence.
+- **Smallest fix:** the least-complex change that resolves it.
+
+Define unavoidable jargon at first use. Put paths and lines in supporting detail,
+not in a title the reader must decode. If the issue cannot be demonstrated
+concretely, lower its confidence or drop it.
+
+Example:
+
+- **What is wrong:** `--setup-sdks none` fails instead of skipping SDK updates.
+- **Show me:** `winapp init --setup-sdks none` -> exits nonzero in the package
+  update loop; expected: succeeds without updating SDKs.
+- **Why it matters:** documented automation stops before initialization.
+- **Smallest fix:** skip the package-update loop when the value is `none`.
+
+## Compatibility boundary
+
+Backward compatibility starts at the latest supported published release, not an
+earlier commit, review round, current PR implementation, or unreleased release
+work. Before adding or requesting an alias, fallback, migration path, legacy
+branch, or compatibility abstraction, name all three:
+
+1. The supported published version that contains the behavior.
+2. The public contract or persisted user data that depends on it.
+3. A real external consumer that would break.
+
+If any cannot be named, replace the unreleased behavior cleanly instead of
+preserving it with a shim. The only exception is a preview contract the project
+has publicly committed to support.
+
 ## Big picture
 
 Two main components:
@@ -72,8 +127,12 @@ More generally: if something fails locally but passes in CI, the difference is c
 not luck. Check `.pipelines/templates/build.yaml` for the environment CI provides before
 concluding a failure is environmental.
 
-## Always update documentation and samples
-When adding or changing public facing features, ensure all documentation is also updated. Places to update (but not limited to):
+## Update affected user-facing documentation
+
+When observable behavior changes, update only the surfaces that teach or expose
+that behavior. Internal refactors do not require user documentation. Never use
+documentation to explain internal implementation details or review history.
+Choose affected surfaces from:
 
 - docs\usage.md
 - docs\guides\
@@ -83,7 +142,8 @@ When adding or changing public facing features, ensure all documentation is also
 - .github\plugin\marketplace.json (and .claude-plugin\marketplace.json)
 - plugins\winapp\com.github.copilot\agents\
 
-If a feature is big enough and requires its own docs page, add it under docs\
+Add a page under `docs\` only when users need a new workflow or reference that
+does not fit an existing canonical page.
 
 ## Sample & guide testing
 
@@ -211,24 +271,33 @@ output, so run it directly while editing plugin files:
 ## C# service architecture guidelines
 
 ### File size limits
-- **Target**: ≤500 lines per file
-- **Soft limit**: ~800 lines — if approaching this, look for extraction opportunities
-- **Hard limit**: Do not let any single file exceed ~1,000 lines. Split into partial classes or extract services.
+
+Line counts are signals to inspect cohesion, not extraction requirements. Around
+500 lines is a useful prompt to check readability; around 800-1,000 lines deserves
+an explicit cohesion review. Never extract solely to hit a line target. Keep one
+cohesive implementation together when splitting it would create wrappers,
+indirection, or scattered state.
 
 ### Service patterns
 Use the appropriate pattern for new code:
 
 | Pattern | When to use | Example |
 |---------|------------|---------|
-| **Interface + DI service** | Stateful logic, needs dependencies | `IPriService` / `PriService` |
+| **DI service** | Stateful logic or logic with dependencies; a concrete class can be registered directly | `PriService` |
+| **Interface** | Multiple implementations, an established contract, or a necessary substitution/test boundary | `IPriService` |
 | **Static helper** | Pure functions, no DI needed | `PeHelper`, `MrtAssetHelper` |
 | **Data document** | Wraps a file/data format with typed access | `AppxManifestDocument` |
 | **Partial class** | Splitting a large service with tight internal coupling | `MsixService.Runtime.cs` |
 
 ### Separation of concerns
-- One responsibility per service/helper file
-- Extract shared logic into helpers rather than duplicating across services
-- If a method group only uses 1-2 of a service's 10+ dependencies, it's a candidate for extraction
+
+- Organize around cohesive responsibilities, not one-caller layers.
+- Prefer one cohesive implementation over several wrappers that only forward to
+  one another.
+- Extract shared logic when it creates a real reusable boundary or prevents
+  meaningful duplication.
+- Do not extract a method group merely because it uses only a few of a service's
+  dependencies.
 
 ### XML handling
 - **Use `XDocument` / `XElement`** (System.Xml.Linq) for structured XML manipulation — never regex

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,8 +16,9 @@ rounds/IDs, resolved blockers, and defenses of the implementation out of user
 documentation. State each user-facing fact once on its canonical surface and link
 to it elsewhere instead of copying it.
 
-Example: "For .NET projects, `winapp restore` runs `dotnet restore` and uses the
-project's standard `nuget.config` hierarchy."
+Example: "After cloning a project with `winapp.yaml`, run `winapp restore` to
+reinstall its pinned SDK packages and projections without changing versions. For
+a .NET project without `winapp.yaml`, run `dotnet restore` instead."
 
 ### Reviews and author communication
 


### PR DESCRIPTION
## Summary

- Define separate audience contracts for user documentation and review/author communication, with example-first explanations that pass a junior-developer reader test.
- Set backward compatibility at the latest supported published release and require a published version, public contract or persisted data, and real external consumer before adding a shim.
- Replace repetitive PR/spec review reports with compact, human-first decision templates while preserving independent research, validation, model diversity, and the existing gut check internally.
- Correct architecture guidance so file size is a signal, DI does not imply an interface, and cohesive implementations are preferred over one-caller wrappers.

## Validation

- `scripts\validate-plugin-package.ps1`
- `git diff --check`
- Focused Markdown structure and changed-file scope checks

No dedicated validator exists for the `.github/skills/pr-review` or `.github/skills/spec-review` guidance. This is a documentation-only change, so no product build was run.