### PR TITLE
Polish project restore output modes

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -754,7 +754,7 @@ Project mode requires the **.NET SDK 8.0.100 or newer** (for MSBuild `--getPrope
 - `--no-restore` - Skip restoring the project before building.
 - `-p, --property <Name=Value>` - MSBuild property, forwarded to both the build and the property evaluation. Repeatable (e.g. `-p WindowsPackageType=None`).
 
-**Build output & verbosity:** dependency restore and `dotnet build` output **stream live** to your console, followed by a fast property-evaluation pass. In an interactive terminal, dotnet's terminal logger shows in-place progress and elapsed time. For redirected output and CI, winapp streams plain lines instead. It prints each exact `dotnet restore …` or `dotnet build …` invocation first, so package downloads, feed retries, errors, and build warnings remain visible. Verbosity:
+**Build output & verbosity:** dependency restore and `dotnet build` output **stream live** to your console, followed by a fast property-evaluation pass. In an interactive terminal, dotnet's terminal logger shows in-place progress and elapsed time. For redirected output and CI, winapp streams plain lines instead. In default and verbose modes, winapp prints each exact `dotnet restore …` or `dotnet build …` invocation first, so package downloads, feed retries, errors, and build warnings remain visible. Verbosity:
 
 | Flag | dotnet verbosity | Adds |
 |------|------------------|------|
@@ -762,7 +762,7 @@ Project mode requires the **.NET SDK 8.0.100 or newer** (for MSBuild `--getPrope
 | `--verbose` | `minimal` | winapp's build decision traces |
 | `--quiet` | `quiet` | — |
 
-Under `--json` or `--quiet` the invocation, restore output, and build output go to stderr so stdout stays pure JSON / clean.
+Under `--json`, each invocation and its child output go to stderr so stdout stays pure JSON. Under `--quiet`, invocations are suppressed and dotnet's quiet restore/build output is routed to stderr so stdout stays clean.
 
 **Option applicability:** the identity/loose-layout options (`--manifest`, `--output-appx-directory`, `--no-launch`, `--with-alias`, `--unregister-on-exit`, `--clean`, `--executable`) apply to packaged apps only. They are rejected with a clear error for unpackaged apps (which have no MSIX package). Launch/debug options (`--args`/`--`, `--detach`, `--debug-output`, `--symbols`, `--json`) work in both.
 

--- a/plugins/winapp/skills/winapp-setup/SKILL.md
+++ b/plugins/winapp/skills/winapp-setup/SKILL.md
@@ -183,7 +183,7 @@ Project mode supports both **packaged** and **unpackaged** WinUI apps, detected 
 
 - **Build inputs:** `-c/--configuration`, `--arch`, `-r/--runtime`, `-f/--framework`, `--no-build`, `--no-restore`, `-p/--property` (repeatable).
 - **Packaged-only options:** `--manifest`, `--no-launch`, `--with-alias`, `--clean`, `--unregister-on-exit`, `--output-appx-directory`, `--executable` — rejected for unpackaged apps.
-- **Output:** winapp prints the exact `dotnet build …` invocation, then streams build output live (warnings included on success). Under `--json`/`--quiet` both go to **stderr** so stdout stays clean.
+- **Output:** winapp restores dependencies, builds, and streams both commands' output live (including successful-build warnings). Interactive terminals show dotnet's in-place progress; redirected output uses plain lines. `--json` sends invocations and child output to **stderr** so stdout stays valid JSON. `--quiet` suppresses invocations and sends dotnet's quiet restore/build output to **stderr** so stdout stays clean.
 
 #### Choosing between `run` and `create-debug-identity`
 

--- a/src/winapp-CLI/WinApp.Cli.Tests/ProjectRunServiceTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/ProjectRunServiceTests.cs
@@ -1996,7 +1996,7 @@ public class ProjectRunServiceTests
     {
         // C6: the pre-build restore mirrors the build's effective RID + configuration (as
         // -p:Configuration=, since 'dotnet restore' has no -c switch) + user -p, but never adds
-        // --no-restore (restoring is the whole point) and omits -v.
+        // --no-restore (restoring is the whole point) and leaves dotnet at its default verbosity.
         var csproj = WriteFile("App.csproj", ExecutableCsproj);
         var options = new ProjectRunOptions("Debug", "arm64", "net10.0-windows10.0.26100.0", NoBuild: false, NoRestore: false,
             Properties: ["WindowsPackageType=None"]);
@@ -2009,6 +2009,19 @@ public class ProjectRunServiceTests
         StringAssert.Contains(args, "-p:WindowsPackageType=None");
         Assert.IsFalse(args.Contains("--no-restore", StringComparison.Ordinal), "restore must not carry --no-restore");
         Assert.IsFalse(args.Contains(" -c ", StringComparison.Ordinal), "restore has no -c switch; configuration flows via -p:Configuration=");
+        Assert.IsFalse(args.Contains(" -v ", StringComparison.Ordinal), "default restore must keep dotnet's default minimal verbosity");
+    }
+
+    [TestMethod]
+    public void BuildRestorePassArguments_QuietVerbosity_AddsQuietSwitch()
+    {
+        var csproj = WriteFile("App.csproj", ExecutableCsproj);
+        var options = new ProjectRunOptions(
+            "Debug", "x64", null, NoBuild: false, NoRestore: false, Properties: []);
+
+        var args = ProjectRunService.BuildRestorePassArguments(csproj, options, "quiet");
+
+        StringAssert.Contains(args, "-v quiet");
     }
 
     [TestMethod]
@@ -2920,6 +2933,115 @@ public class ProjectRunServiceTests
             dotnet.StreamingCalls.Any(a => a.StartsWith("restore ", StringComparison.Ordinal)),
             "an interactive restore must not use redirected line streaming");
         StringAssert.Contains(console.Output, "Restoring App.slnx dependencies");
+    }
+
+    [TestMethod]
+    [DoNotParallelize] // redirects the process-wide Console.Error
+    public async Task RunRestoreCommandAsync_Json_KeepsStdoutClean_RoutesInvocationAndOutputToStderr()
+    {
+        var solution = WriteFile("App.slnx", SlnxListing("App.csproj", "Server/Server.csproj"));
+        var options = new ProjectRunOptions(
+            "Debug", "x64", null, NoBuild: false, NoRestore: false,
+            Properties: ["NuGetApiKey=top-secret"], Json: true, Solution: solution);
+        var args = ProjectRunService.BuildRestorePassArguments(solution, options);
+        var dotnet = new FakeDotNetService
+        {
+            RunDotnetStreamingHandler = (_, onOut, onErr) =>
+            {
+                onOut?.Invoke("RESTORE-STDOUT");
+                onErr?.Invoke("RESTORE-STDERR");
+                return 0;
+            },
+        };
+        var service = NewServiceWith(dotnet, LogLevel.None, out var console);
+
+        var stderr = new StringWriter();
+        var originalError = Console.Error;
+        Console.SetError(stderr);
+        int exit;
+        try
+        {
+            exit = await service.RunRestoreCommandAsync(
+                args, "Restoring App.slnx dependencies...", options, _tempDir, CancellationToken.None);
+        }
+        finally
+        {
+            Console.SetError(originalError);
+        }
+
+        Assert.AreEqual(0, exit);
+        Assert.AreEqual(string.Empty, console.Output, "--json must keep stdout clean");
+        StringAssert.Contains(stderr.ToString(), "dotnet restore", "--json must route the invocation to stderr");
+        StringAssert.Contains(stderr.ToString(), "NuGetApiKey=***", "displayed restore commands must redact secrets");
+        Assert.IsFalse(stderr.ToString().Contains("top-secret"), "the secret must not be displayed");
+        StringAssert.Contains(stderr.ToString(), "RESTORE-STDOUT", "--json must route child stdout to stderr");
+        StringAssert.Contains(stderr.ToString(), "RESTORE-STDERR", "--json must route child stderr to stderr");
+        Assert.IsFalse(args.Contains(" -v quiet", StringComparison.Ordinal),
+            "--json must preserve dotnet's default restore verbosity");
+    }
+
+    [TestMethod]
+    [DoNotParallelize] // redirects the process-wide Console.Error
+    public async Task RunRestoreCommandAsync_Quiet_KeepsStdoutClean_RoutesQuietOutputToStderr_SuppressesInvocation()
+    {
+        var csproj = WriteFile("App.csproj", ExecutableCsproj);
+        var options = new ProjectRunOptions(
+            "Debug", "x64", null, NoBuild: false, NoRestore: false, Properties: []);
+        var args = ProjectRunService.BuildRestorePassArguments(csproj, options, "quiet");
+        var dotnet = new FakeDotNetService
+        {
+            RunDotnetStreamingHandler = (_, onOut, onErr) =>
+            {
+                onOut?.Invoke("QUIET-RESTORE-STDOUT");
+                onErr?.Invoke("QUIET-RESTORE-STDERR");
+                return 0;
+            },
+        };
+        var service = NewServiceWith(dotnet, LogLevel.Warning, out var console);
+
+        var stderr = new StringWriter();
+        var originalError = Console.Error;
+        Console.SetError(stderr);
+        int exit;
+        try
+        {
+            exit = await service.RunRestoreCommandAsync(
+                args, "Restoring App.csproj dependencies...", options, _tempDir, CancellationToken.None);
+        }
+        finally
+        {
+            Console.SetError(originalError);
+        }
+
+        Assert.AreEqual(0, exit);
+        Assert.AreEqual(string.Empty, console.Output, "--quiet must keep stdout clean");
+        Assert.IsFalse(stderr.ToString().Contains("dotnet restore"), "--quiet must suppress the invocation");
+        StringAssert.Contains(stderr.ToString(), "QUIET-RESTORE-STDOUT", "--quiet must route child stdout to stderr");
+        StringAssert.Contains(stderr.ToString(), "QUIET-RESTORE-STDERR", "--quiet must route child stderr to stderr");
+        StringAssert.Contains(dotnet.StreamingCalls.Single(), "-v quiet",
+            "--quiet must run dotnet restore at quiet verbosity");
+    }
+
+    [TestMethod]
+    public async Task BuildAndResolveAsync_SolutionRestore_QuietUsesQuietVerbosity()
+    {
+        var csproj = WriteFile("App.csproj", ExecutableCsproj);
+        var solution = WriteFile("App.slnx", SlnxListing("App.csproj", "Server/Server.csproj"));
+        var dotnet = new FakeDotNetService
+        {
+            RunDotnetCommandHandler = _ => (0, PackagedPropertiesJson(), string.Empty),
+        };
+        var service = NewServiceWith(dotnet, LogLevel.Warning, out _);
+        var options = new ProjectRunOptions(
+            "Debug", "x64", null, NoBuild: false, NoRestore: false, Properties: [], Solution: solution);
+
+        var outcome = await service.BuildAndResolveAsync(csproj, options, CancellationToken.None);
+
+        Assert.IsNotNull(outcome.Resolution);
+        var restoreArgs = dotnet.StreamingCalls.Single(
+            args => args.StartsWith($"restore {solution.FullName}", StringComparison.Ordinal));
+        StringAssert.Contains(restoreArgs, "-v quiet",
+            "--quiet must apply quiet verbosity to the restore created by the project-run pipeline");
     }
 
     [TestMethod]

--- a/src/winapp-CLI/WinApp.Cli.Tests/ProjectRunServiceTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/ProjectRunServiceTests.cs
@@ -2955,7 +2955,7 @@ public class ProjectRunServiceTests
         };
         var service = NewServiceWith(dotnet, LogLevel.None, out var console);
 
-        var stderr = new StringWriter();
+        using var stderr = new StringWriter();
         var originalError = Console.Error;
         Console.SetError(stderr);
         int exit;
@@ -2999,7 +2999,7 @@ public class ProjectRunServiceTests
         };
         var service = NewServiceWith(dotnet, LogLevel.Warning, out var console);
 
-        var stderr = new StringWriter();
+        using var stderr = new StringWriter();
         var originalError = Console.Error;
         Console.SetError(stderr);
         int exit;

--- a/src/winapp-CLI/WinApp.Cli/Services/ProjectRunService.Arguments.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/ProjectRunService.Arguments.cs
@@ -18,9 +18,13 @@ internal sealed partial class ProjectRunService
     /// RID / Configuration / user <c>-p</c> / solution properties so the same graph resolves into
     /// <c>project.assets.json</c> that the subsequent <c>--no-restore</c> build consumes. Dedicated-flag
     /// user <c>-p</c> are filtered (see <see cref="ForwardableProperties"/>) so a conflicting
-    /// <c>-p:RuntimeIdentifier</c> can't restore a different RID's assets than the build needs.
+    /// <c>-p:RuntimeIdentifier</c> can't restore a different RID's assets than the build needs. The optional
+    /// <paramref name="verbosity"/> is used by quiet mode; otherwise dotnet keeps its default verbosity.
     /// </summary>
-    internal static string BuildRestorePassArguments(FileInfo csproj, ProjectRunOptions options)
+    internal static string BuildRestorePassArguments(
+        FileInfo csproj,
+        ProjectRunOptions options,
+        string? verbosity = null)
     {
         var rid = RunArchHelper.ToRuntimeIdentifier(options.Architecture);
         var tokens = new List<string>
@@ -54,6 +58,12 @@ internal sealed partial class ProjectRunService
         }
 
         AppendSolutionProperties(tokens, options);
+
+        if (!string.IsNullOrWhiteSpace(verbosity))
+        {
+            tokens.Add("-v");
+            tokens.Add(verbosity);
+        }
 
         return WindowsCommandLine.JoinArguments(tokens) ?? string.Empty;
     }

--- a/src/winapp-CLI/WinApp.Cli/Services/ProjectRunService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/ProjectRunService.cs
@@ -508,8 +508,8 @@ internal sealed partial class ProjectRunService(
     /// </summary>
     private async Task<int> RunRestorePassAsync(FileInfo csproj, ProjectRunOptions options, DirectoryInfo workingDir, CancellationToken cancellationToken)
     {
-        var restoreArgs = BuildRestorePassArguments(csproj, options);
-        logger.LogDebug("{UISymbol} Restoring before SDK-less CsWinRT metadata resolution: dotnet {Arguments}", UiSymbols.Note, RedactSecretsForDisplay(restoreArgs));
+        var restoreArgs = BuildRestorePassArguments(csproj, options, ResolveRestoreVerbosity(logger, options.Json));
+        logger.LogDebug("{UISymbol} Restoring before SDK-less CsWinRT metadata resolution.", UiSymbols.Note);
         var exitCode = await RunRestoreCommandAsync(
             restoreArgs, $"Restoring {csproj.Name} dependencies...", options, workingDir, cancellationToken);
         if (exitCode != 0)
@@ -548,8 +548,8 @@ internal sealed partial class ProjectRunService(
         if (allManaged)
         {
             // Closest to VS: one restore over the whole solution pulls the target and every sibling.
-            var args = BuildRestorePassArguments(options.Solution, options);
-            logger.LogDebug("{UISymbol} Restoring solution before build (build-dependency parity): dotnet {Arguments}", UiSymbols.Note, RedactSecretsForDisplay(args));
+            var args = BuildRestorePassArguments(options.Solution, options, ResolveRestoreVerbosity(logger, options.Json));
+            logger.LogDebug("{UISymbol} Restoring solution before build for build-dependency parity.", UiSymbols.Note);
             var exitCode = await RunRestoreCommandAsync(
                 args, $"Restoring {options.Solution.Name} dependencies...", options, workingDir, cancellationToken);
             if (exitCode == 0)
@@ -582,8 +582,8 @@ internal sealed partial class ProjectRunService(
     {
         foreach (var sibling in siblings)
         {
-            var args = BuildRestorePassArguments(sibling, options);
-            logger.LogDebug("{UISymbol} Restoring solution sibling before build (build-dependency parity): dotnet {Arguments}", UiSymbols.Note, RedactSecretsForDisplay(args));
+            var args = BuildRestorePassArguments(sibling, options, ResolveRestoreVerbosity(logger, options.Json));
+            logger.LogDebug("{UISymbol} Restoring solution sibling {Sibling} before build for build-dependency parity.", UiSymbols.Note, sibling.Name);
             var exitCode = await RunRestoreCommandAsync(
                 args, $"Restoring {sibling.Name} dependencies...", options, workingDir, cancellationToken);
             if (exitCode != 0)
@@ -598,7 +598,7 @@ internal sealed partial class ProjectRunService(
     /// are visible as they happen. A real terminal is handed directly to dotnet so its terminal logger can
     /// render in-place progress; redirected, JSON, and quiet modes use line streaming instead.
     /// </summary>
-    private async Task<int> RunRestoreCommandAsync(
+    internal async Task<int> RunRestoreCommandAsync(
         string arguments,
         string banner,
         ProjectRunOptions options,
@@ -641,6 +641,9 @@ internal sealed partial class ProjectRunService(
         return await dotNetService.RunDotnetStreamingAsync(
             workingDir, arguments, WriteLive, WriteLive, cancellationToken);
     }
+
+    private static string? ResolveRestoreVerbosity(ILogger logger, bool json) =>
+        !json && !logger.IsEnabled(LogLevel.Information) ? "quiet" : null;
 
     /// <summary>
     /// Runs the project-mode build pass, streaming dotnet's output live. Output routing:


### PR DESCRIPTION
## Summary
- pass quiet verbosity to project-mode `dotnet restore` while preserving default, JSON, and interactive terminal behavior
- remove duplicate restore command text from verbose decision traces while keeping displayed commands redacted
- add direct JSON/quiet restore routing regressions and update project-mode docs and setup guidance

## Validation
- `dotnet test src\winapp-CLI\WinApp.Cli.Tests\WinApp.Cli.Tests.csproj -c Release --filter "FullyQualifiedName~ProjectRunServiceTests"` (195 passed)
- Release CLI against a throwaway two-project solution: quiet emitted no restore invocation or normal restore progress; verbose emitted one restore invocation
- `.\scripts\validate-plugin-package.ps1`
- `git diff --check`
- `.\scripts\build-cli.ps1` reached NativeAOT publish, then stopped at the machine's known missing Desktop Development for C++ linker prerequisite