### PR TITLE
Resolve $targetnametoken$ for WinAppSDK self-contained apps

### DIFF
--- a/src/winapp-CLI/WinApp.Cli.Tests/MsixServiceIdentityTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/MsixServiceIdentityTests.cs
@@ -538,18 +538,18 @@ public class MsixServiceIdentityTests : BaseCommandTests
         // payload into the build output root, so a helper exe always sits next to the app exe.
         // $targetnametoken$ must still resolve to the app exe without --executable.
         var srcDir = _tempDirectory.CreateSubdirectory("raw-input");
-        var srcManifest = new FileInfo(Path.Combine(srcDir.FullName, "Package.appxmanifest"));
+        var srcManifest = new FileInfo(Path.Join(srcDir.FullName, "Package.appxmanifest"));
         await File.WriteAllTextAsync(srcManifest.FullName, BuildRawManifest(exe: "$targetnametoken$.exe"), TestContext.CancellationToken);
-        await File.WriteAllTextAsync(Path.Combine(srcDir.FullName, "TestApp.exe"), "not-a-real-pe", TestContext.CancellationToken);
-        await File.WriteAllTextAsync(Path.Combine(srcDir.FullName, helperExeName), "not-a-real-pe", TestContext.CancellationToken);
+        await File.WriteAllTextAsync(Path.Join(srcDir.FullName, "TestApp.exe"), "not-a-real-pe", TestContext.CancellationToken);
+        await File.WriteAllTextAsync(Path.Join(srcDir.FullName, helperExeName), "not-a-real-pe", TestContext.CancellationToken);
 
-        var output = new DirectoryInfo(Path.Combine(_tempDirectory.FullName, "layout"));
+        var output = new DirectoryInfo(Path.Join(_tempDirectory.FullName, "layout"));
 
         var result = await _msixService.AddLooseLayoutIdentityAsync(
             srcManifest, srcDir, output, TestTaskContext, cancellationToken: TestContext.CancellationToken);
 
         Assert.AreEqual("TestApp", result.PackageName);
-        var written = await File.ReadAllTextAsync(Path.Combine(output.FullName, "appxmanifest.xml"), TestContext.CancellationToken);
+        var written = await File.ReadAllTextAsync(Path.Join(output.FullName, "appxmanifest.xml"), TestContext.CancellationToken);
         Assert.Contains(@"Executable=""TestApp.exe""", written,
             $"{helperExeName} should be skipped so the app exe resolves without --executable");
         Assert.DoesNotContain("$targetnametoken$", written, "No $targetnametoken$ placeholder should remain");

--- a/src/winapp-CLI/WinApp.Cli.Tests/MsixServiceIdentityTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/MsixServiceIdentityTests.cs
@@ -529,6 +529,32 @@ public class MsixServiceIdentityTests : BaseCommandTests
         Assert.DoesNotContain("x-generate", written, "x-generate language token should be resolved");
     }
 
+    [TestMethod]
+    [DataRow("RestartAgent.exe", DisplayName = "Windows App SDK restart agent")]
+    [DataRow("DeploymentAgent.exe", DisplayName = "Windows App SDK deployment agent")]
+    public async Task AddLooseLayoutIdentityAsync_RawManifest_PlaceholderWithWinAppSdkHelper_InfersAppExe(string helperExeName)
+    {
+        // Issue #790: WindowsAppSDKSelfContained=true extracts the Windows App SDK framework
+        // payload into the build output root, so a helper exe always sits next to the app exe.
+        // $targetnametoken$ must still resolve to the app exe without --executable.
+        var srcDir = _tempDirectory.CreateSubdirectory("raw-input");
+        var srcManifest = new FileInfo(Path.Combine(srcDir.FullName, "Package.appxmanifest"));
+        await File.WriteAllTextAsync(srcManifest.FullName, BuildRawManifest(exe: "$targetnametoken$.exe"), TestContext.CancellationToken);
+        await File.WriteAllTextAsync(Path.Combine(srcDir.FullName, "TestApp.exe"), "not-a-real-pe", TestContext.CancellationToken);
+        await File.WriteAllTextAsync(Path.Combine(srcDir.FullName, helperExeName), "not-a-real-pe", TestContext.CancellationToken);
+
+        var output = new DirectoryInfo(Path.Combine(_tempDirectory.FullName, "layout"));
+
+        var result = await _msixService.AddLooseLayoutIdentityAsync(
+            srcManifest, srcDir, output, TestTaskContext, cancellationToken: TestContext.CancellationToken);
+
+        Assert.AreEqual("TestApp", result.PackageName);
+        var written = await File.ReadAllTextAsync(Path.Combine(output.FullName, "appxmanifest.xml"), TestContext.CancellationToken);
+        Assert.Contains(@"Executable=""TestApp.exe""", written,
+            $"{helperExeName} should be skipped so the app exe resolves without --executable");
+        Assert.DoesNotContain("$targetnametoken$", written, "No $targetnametoken$ placeholder should remain");
+    }
+
     // ---- AddSparseIdentityAsync workflow ------------------------------------------
 
     private (FileInfo manifest, string exePath) ArrangeSparseInputs()

--- a/src/winapp-CLI/WinApp.Cli.Tests/PackageCommandTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/PackageCommandTests.cs
@@ -1307,7 +1307,7 @@ public class PackageCommandTests : BaseCommandTests
         // apphost.exe from a .NET self-contained publish, RestartAgent.exe and DeploymentAgent.exe
         // from the Windows App SDK framework payload (WindowsAppSDKSelfContained=true, issue #790).
         // Auto-inference must skip the helper and pick the app exe.
-        var packageDir = new DirectoryInfo(Path.Combine(_tempDirectory.FullName, $"PlaceholderHelperTest_{Path.GetFileNameWithoutExtension(helperExeName)}"));
+        var packageDir = new DirectoryInfo(Path.Join(_tempDirectory.FullName, $"PlaceholderHelperTest_{Path.GetFileNameWithoutExtension(helperExeName)}"));
         CreatePlaceholderTestPackageStructure(packageDir, "MyApp.exe", helperExeName);
 
         await File.WriteAllTextAsync(_configService.ConfigPath.FullName, "packages: []", TestContext.CancellationToken);

--- a/src/winapp-CLI/WinApp.Cli.Tests/PackageCommandTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/PackageCommandTests.cs
@@ -1267,6 +1267,8 @@ public class PackageCommandTests : BaseCommandTests
         });
 
         Assert.Contains("--executable", ex.Message, "Error message should mention --executable option");
+        Assert.Contains("App1.exe", ex.Message, "Error message should name the candidate exes so the user can pick one");
+        Assert.Contains("App2.exe", ex.Message, "Error message should name the candidate exes so the user can pick one");
     }
 
     [TestMethod]
@@ -1295,12 +1297,18 @@ public class PackageCommandTests : BaseCommandTests
     }
 
     [TestMethod]
-    public async Task CreateMsixPackageAsync_PlaceholderWithAppExeAndCreatedump_InfersAppExe()
+    [DataRow("createdump.exe", DisplayName = ".NET crash dump tool")]
+    [DataRow("apphost.exe", DisplayName = ".NET app host")]
+    [DataRow("RestartAgent.exe", DisplayName = "Windows App SDK restart agent")]
+    [DataRow("DeploymentAgent.exe", DisplayName = "Windows App SDK deployment agent")]
+    public async Task CreateMsixPackageAsync_PlaceholderWithAppExeAndRuntimeHelper_InfersAppExe(string helperExeName)
     {
-        // Arrange - .NET self-contained build outputs include createdump.exe alongside the app exe.
-        // Auto-inference must skip createdump.exe and pick the app exe.
-        var packageDir = new DirectoryInfo(Path.Combine(_tempDirectory.FullName, "PlaceholderCreatedumpTest"));
-        CreatePlaceholderTestPackageStructure(packageDir, "MyApp.exe", "createdump.exe");
+        // Arrange - build outputs ship runtime helpers next to the app exe: createdump.exe and
+        // apphost.exe from a .NET self-contained publish, RestartAgent.exe and DeploymentAgent.exe
+        // from the Windows App SDK framework payload (WindowsAppSDKSelfContained=true, issue #790).
+        // Auto-inference must skip the helper and pick the app exe.
+        var packageDir = new DirectoryInfo(Path.Combine(_tempDirectory.FullName, $"PlaceholderHelperTest_{Path.GetFileNameWithoutExtension(helperExeName)}"));
+        CreatePlaceholderTestPackageStructure(packageDir, "MyApp.exe", helperExeName);
 
         await File.WriteAllTextAsync(_configService.ConfigPath.FullName, "packages: []", TestContext.CancellationToken);
 
@@ -1316,45 +1324,21 @@ public class PackageCommandTests : BaseCommandTests
         );
 
         // Assert
-        var manifestContent = await ExtractManifestContentFromPackageAsync(result.MsixPath, "PlaceholderCreatedumpExtracted");
-        Assert.Contains(@"Executable=""MyApp.exe""", manifestContent, "createdump.exe should be filtered out, MyApp.exe should be picked");
-        Assert.DoesNotContain("createdump", manifestContent, "createdump should not appear in resolved manifest");
-    }
-
-    [TestMethod]
-    public async Task CreateMsixPackageAsync_PlaceholderWithAppExeAndApphost_InfersAppExe()
-    {
-        // Arrange - apphost.exe is a .NET runtime artifact that should also be filtered
-        // during executable auto-inference.
-        var packageDir = new DirectoryInfo(Path.Combine(_tempDirectory.FullName, "PlaceholderApphostTest"));
-        CreatePlaceholderTestPackageStructure(packageDir, "MyApp.exe", "apphost.exe");
-
-        await File.WriteAllTextAsync(_configService.ConfigPath.FullName, "packages: []", TestContext.CancellationToken);
-
-        // Act
-        var result = await _msixService.CreateMsixPackageAsync(
-            inputFolder: packageDir,
-            outputPath: _tempDirectory,
-            TestTaskContext,
-            packageName: "TestPackage",
-            skipPri: true,
-            autoSign: false,
-            cancellationToken: TestContext.CancellationToken
-        );
-
-        // Assert
-        var manifestContent = await ExtractManifestContentFromPackageAsync(result.MsixPath, "PlaceholderApphostExtracted");
-        Assert.Contains(@"Executable=""MyApp.exe""", manifestContent, "apphost.exe should be filtered out, MyApp.exe should be picked");
-        Assert.DoesNotContain("apphost", manifestContent, "apphost should not appear in resolved manifest");
+        var manifestContent = await ExtractManifestContentFromPackageAsync(
+            result.MsixPath, $"PlaceholderHelperExtracted_{Path.GetFileNameWithoutExtension(helperExeName)}");
+        Assert.Contains(@"Executable=""MyApp.exe""", manifestContent, $"{helperExeName} should be filtered out, MyApp.exe should be picked");
+        Assert.DoesNotContain(Path.GetFileNameWithoutExtension(helperExeName), manifestContent,
+            $"{helperExeName} should not appear in resolved manifest");
     }
 
     [TestMethod]
     public async Task CreateMsixPackageAsync_PlaceholderWithOnlyRuntimeTools_Throws()
     {
-        // Arrange - only runtime-tool exes present; auto-inference should fail with the
-        // same multi-/no-exe guidance rather than silently picking createdump.exe.
+        // Arrange - only runtime-helper exes present; auto-inference should fail rather than
+        // silently picking one, and should name the helpers it skipped instead of claiming the
+        // folder has no .exe files at all.
         var packageDir = new DirectoryInfo(Path.Combine(_tempDirectory.FullName, "PlaceholderOnlyRuntimeToolsTest"));
-        CreatePlaceholderTestPackageStructure(packageDir, "createdump.exe", "apphost.exe");
+        CreatePlaceholderTestPackageStructure(packageDir, "createdump.exe", "RestartAgent.exe");
 
         // Act & Assert
         var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(async () =>
@@ -1371,6 +1355,8 @@ public class PackageCommandTests : BaseCommandTests
         });
 
         Assert.Contains("--executable", ex.Message, "Error message should mention --executable option");
+        Assert.Contains("createdump.exe", ex.Message, "Error message should name the skipped runtime helpers");
+        Assert.Contains("RestartAgent.exe", ex.Message, "Error message should name the skipped runtime helpers");
     }
 
     #endregion

--- a/src/winapp-CLI/WinApp.Cli/Services/MsixService.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/MsixService.cs
@@ -144,12 +144,13 @@ internal partial class MsixService(
             var doc = AppxManifestDocument.Parse(manifestContent);
             if (doc.ApplicationExecutable != null && PlaceholderHelper.ContainsPlaceholders(doc.ApplicationExecutable))
             {
-                // Try to auto-infer by finding .exe files in the input folder root
-                var exeFiles = inputFolder.Exists
+                // Try to auto-infer by finding .exe files in the input folder root. Runtime
+                // helpers (createdump.exe, RestartAgent.exe, ...) are never entry points, so
+                // they are excluded from the candidates but kept for the error message.
+                var allExeFiles = inputFolder.Exists
                     ? inputFolder.GetFiles("*.exe", SearchOption.TopDirectoryOnly)
-                        .Where(f => !IsRuntimeToolExecutable(f.Name))
-                        .ToArray()
                     : [];
+                var exeFiles = allExeFiles.Where(f => !IsRuntimeToolExecutable(f.Name)).ToArray();
 
                 if (exeFiles.Length == 1)
                 {
@@ -164,9 +165,8 @@ internal partial class MsixService(
                 }
                 else
                 {
-                    var count = exeFiles.Length == 0 ? "no" : "multiple";
                     throw new InvalidOperationException(
-                        $"The manifest contains a placeholder for the executable but {count} .exe files were found in the input folder. " +
+                        $"The manifest contains a placeholder for the executable but {DescribeExecutableCandidates(allExeFiles, exeFiles)}. " +
                         "Edit the manifest to specify the executable or use --executable to specify the relative path to the exe.");
                 }
             }
@@ -180,6 +180,32 @@ internal partial class MsixService(
 
         return manifestContent;
     }
+
+    /// <summary>
+    /// Builds the middle clause of the "cannot resolve the executable placeholder" error,
+    /// naming the candidates so the caller knows what to pass to <c>--executable</c>. When
+    /// every executable was filtered out as a runtime helper, it says so instead of claiming
+    /// the folder has no <c>.exe</c> files at all.
+    /// </summary>
+    private static string DescribeExecutableCandidates(FileInfo[] allExeFiles, FileInfo[] candidates)
+    {
+        if (candidates.Length > 1)
+        {
+            return $"multiple .exe files in the input folder could be the app: {FormatExeNames(candidates)}";
+        }
+
+        var skipped = allExeFiles.Where(f => IsRuntimeToolExecutable(f.Name)).ToArray();
+        if (skipped.Length > 0)
+        {
+            var helperLabel = skipped.Length == 1 ? "a known runtime helper" : "known runtime helpers";
+            return $"no .exe file in the input folder could be the app ({FormatExeNames(skipped)} skipped as {helperLabel})";
+        }
+
+        return "no .exe files were found in the input folder";
+    }
+
+    private static string FormatExeNames(IEnumerable<FileInfo> files) =>
+        string.Join(", ", files.Select(f => f.Name).Order(StringComparer.OrdinalIgnoreCase));
 
     /// <summary>
     /// Resolves <c>&lt;Resource Language="x-generate"/&gt;</c> in the manifest by replacing it
@@ -838,13 +864,32 @@ internal partial class MsixService(
     }
 
     /// <summary>
-    /// Returns true if the given file name belongs to a .NET runtime tool that should be
+    /// Helper executables that runtimes drop next to the application executable in a build
+    /// output. None of them is ever an app entry point, so they are excluded when
+    /// auto-detecting the application executable.
+    /// </summary>
+    /// <remarks>
+    /// <c>createdump.exe</c> and <c>apphost.exe</c> come from a .NET self-contained publish.
+    /// <c>RestartAgent.exe</c> and <c>DeploymentAgent.exe</c> are the only two executables in
+    /// the Windows App SDK framework payload, which <c>WindowsAppSDKSelfContained=true</c>
+    /// extracts into the output root — so without them here, auto-detection is ambiguous for
+    /// every Windows App SDK self-contained app (issue #790).
+    /// </remarks>
+    private static readonly HashSet<string> RuntimeToolExecutables = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "createdump.exe",
+        "apphost.exe",
+        "RestartAgent.exe",
+        "DeploymentAgent.exe"
+    };
+
+    /// <summary>
+    /// Returns true if the given file name belongs to a runtime helper that should be
     /// excluded when auto-detecting the application executable.
     /// </summary>
     internal static bool IsRuntimeToolExecutable(string fileName)
     {
-        return string.Equals(fileName, "createdump.exe", StringComparison.OrdinalIgnoreCase)
-            || string.Equals(fileName, "apphost.exe", StringComparison.OrdinalIgnoreCase);
+        return RuntimeToolExecutables.Contains(fileName);
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #790

## Problem

`winapp run <folder>` and `winapp package <folder>` failed for **every** Windows App SDK self-contained app:

```
The manifest contains a placeholder for the executable but multiple .exe files
were found in the input folder. Edit the manifest to specify the executable or
use --executable to specify the relative path to the exe.
```

`--executable` was effectively mandatory for a whole class of apps, and the message never named the files it was torn between.

## Root cause

`MsixService.ResolveManifestPlaceholders` resolves `Executable="$targetnametoken$.exe"` by scanning the input folder's top level for `.exe` files and requiring exactly one candidate, filtering through `IsRuntimeToolExecutable` — which only knew `createdump.exe` and `apphost.exe`.

`WindowsAppSDKSelfContained=true` extracts the Windows App SDK framework payload into the build output root. Every version of `microsoft.windowsappsdk.foundation` ships exactly two executables under `runtimes-framework/win-<arch>/native/`: `RestartAgent.exe` and `DeploymentAgent.exe`. Neither is ever an app entry point, so the candidate set was always ≥ 2 and the ambiguity was never genuine.

## Changes

- Add both Windows App SDK helpers to the exclusion set (`string.Equals` chain → `HashSet`).
- Make the remaining ambiguity actionable: name the candidate exes so the user knows what to pass to `--executable`, and stop reporting *"no .exe files were found"* when the folder does contain exes that were all filtered as helpers.

All three placeholder call sites share `ResolveManifestPlaceholders`, so one change covers `winapp run`, `winapp package`, `winapp package --bundle`, and the `dotnet run` NuGet path — `-p:WinAppRunExecutable=` is no longer required.

The filter affects entry-point **detection** only. The helper executables are still packed into the MSIX, so self-contained apps are not broken at runtime.

## Deliberately out of scope

The issue's suggested fix #2 (prefer the exe matching the manifest package/application name) is not implemented: `Identity/@Name` is routinely unrelated to the exe name (`Contoso.MyApp` vs `MyApp.exe`) and `Application/@Id` is almost always `App`, so the heuristic would rarely fire and could silently pick the wrong binary. `--executable` remains the escape hatch for genuine ambiguity — and it bypasses the filter entirely, so an app legitimately named `RestartAgent.exe` still has a working override.

## Validation

Exercised with the **published** CLI binary against the **real** `RestartAgent.exe` / `DeploymentAgent.exe` from the NuGet cache:

| Input | Result |
|---|---|
| `counter.exe` + all four helpers | resolves `Executable="counter.exe"`, no `--executable` |
| two real app exes | `...could be the app: counter.exe, tools.exe` |
| helpers only | `...(DeploymentAgent.exe, RestartAgent.exe skipped as known runtime helpers)` |

- The new regression test fails without the production fix (reproducing the exact issue error) and passes with it.
- Confirmed all four exes still ship in the MSIX payload.
- An exe named ``Evil[red]&$x --flag .exe`` reaches the message verbatim — no markup interpretation, no argv split; under `--json` it serializes as `\u0026` and parses cleanly, exit code 1.
- `PackageCommandTests` 114/114; identity/bundle/msix/run/manifest suites 305 passed, 1 pre-existing skip.
- `scripts/build-cli.ps1` completes and regenerates `docs/cli-schema.json` identically — no CLI surface change, so no doc or skill updates are owed.