### PR TITLE
Test shared Windows app-model conformance vectors

### DIFF
--- a/src/winapp-CLI/WinApp.Cli.Tests/TestData/WindowsAppModel/appx-manifest-conformance-vectors.json
+++ b/src/winapp-CLI/WinApp.Cli.Tests/TestData/WindowsAppModel/appx-manifest-conformance-vectors.json
@@ -1,0 +1,121 @@
+{
+  "schemaVersion": 1,
+  "description": "Implementation-neutral Windows package identity and application-model vectors intended for reuse by testfx, WinApp CLI, and other Windows app tooling.",
+  "references": [
+    "https://github.com/microsoft/testfx/tree/main/src/Platform/Microsoft.Testing.Extensions.PackagedApp",
+    "https://github.com/microsoft/WinAppCli/blob/main/src/winapp-CLI/WinApp.Cli/Services/AppLauncherService.cs"
+  ],
+  "vectors": [
+    {
+      "name": "store-publisher-full-trust",
+      "manifestLines": [
+        "<?xml version=\"1.0\" encoding=\"utf-8\"?>",
+        "<Package xmlns=\"http://schemas.microsoft.com/appx/manifest/foundation/windows10\" xmlns:uap10=\"http://schemas.microsoft.com/appx/manifest/uap/windows10/10\" xmlns:rescap=\"http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities\">",
+        "  <Identity Name=\"Microsoft.TestApp\" Publisher=\"CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US\" Version=\"1.0.0.0\" />",
+        "  <Applications>",
+        "    <Application Id=\"App\" Executable=\"TestApp.exe\" EntryPoint=\"Windows.FullTrustApplication\" uap10:RuntimeBehavior=\"packagedClassicApp\" uap10:TrustLevel=\"mediumIL\" />",
+        "  </Applications>",
+        "  <Capabilities>",
+        "    <rescap:Capability Name=\"runFullTrust\" />",
+        "  </Capabilities>",
+        "</Package>"
+      ],
+      "expected": {
+        "packageName": "Microsoft.TestApp",
+        "publisher": "CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US",
+        "publisherId": "8wekyb3d8bbwe",
+        "packageFamilyName": "Microsoft.TestApp_8wekyb3d8bbwe",
+        "applications": [
+          {
+            "id": "App",
+            "executable": "TestApp.exe",
+            "appUserModelId": "Microsoft.TestApp_8wekyb3d8bbwe!App",
+            "usesLaunchActivationArguments": false,
+            "runsInAppContainer": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "legacy-uwp-defaults-to-app-container",
+      "manifestLines": [
+        "<?xml version=\"1.0\" encoding=\"utf-8\"?>",
+        "<Package xmlns=\"http://schemas.microsoft.com/appx/manifest/foundation/windows10\">",
+        "  <Identity Name=\"Contoso.LegacyUwp\" Publisher=\"CN=Contoso\" Version=\"1.0.0.0\" />",
+        "  <Applications>",
+        "    <Application Id=\"App\" Executable=\"LegacyUwp.exe\" EntryPoint=\"Contoso.LegacyUwp.App\" />",
+        "  </Applications>",
+        "</Package>"
+      ],
+      "expected": {
+        "packageName": "Contoso.LegacyUwp",
+        "publisher": "CN=Contoso",
+        "publisherId": "h91ms92gdsmmt",
+        "packageFamilyName": "Contoso.LegacyUwp_h91ms92gdsmmt",
+        "applications": [
+          {
+            "id": "App",
+            "executable": "LegacyUwp.exe",
+            "appUserModelId": "Contoso.LegacyUwp_h91ms92gdsmmt!App",
+            "usesLaunchActivationArguments": true,
+            "runsInAppContainer": true
+          }
+        ]
+      }
+    },
+    {
+      "name": "packaged-classic-app-container-with-nested-executable",
+      "manifestLines": [
+        "<?xml version=\"1.0\" encoding=\"utf-8\"?>",
+        "<Package xmlns=\"http://schemas.microsoft.com/appx/manifest/foundation/windows10\" xmlns:uap10=\"http://schemas.microsoft.com/appx/manifest/uap/windows10/10\">",
+        "  <Identity Name=\"Contoso.ClassicSandbox\" Publisher=\"CN=contoso\" Version=\"1.0.0.0\" />",
+        "  <Applications>",
+        "    <Application Id=\"Nested\" Executable=\"bin\\Sandbox.exe\" EntryPoint=\"Windows.FullTrustApplication\" uap10:RuntimeBehavior=\"packagedClassicApp\" uap10:TrustLevel=\"appContainer\" />",
+        "  </Applications>",
+        "</Package>"
+      ],
+      "expected": {
+        "packageName": "Contoso.ClassicSandbox",
+        "publisher": "CN=contoso",
+        "publisherId": "74f99pa6tm8gt",
+        "packageFamilyName": "Contoso.ClassicSandbox_74f99pa6tm8gt",
+        "applications": [
+          {
+            "id": "Nested",
+            "executable": "bin\\Sandbox.exe",
+            "appUserModelId": "Contoso.ClassicSandbox_74f99pa6tm8gt!Nested",
+            "usesLaunchActivationArguments": false,
+            "runsInAppContainer": true
+          }
+        ]
+      }
+    },
+    {
+      "name": "windows-app-explicit-medium-integrity",
+      "manifestLines": [
+        "<?xml version=\"1.0\" encoding=\"utf-8\"?>",
+        "<Package xmlns=\"http://schemas.microsoft.com/appx/manifest/foundation/windows10\" xmlns:uap10=\"http://schemas.microsoft.com/appx/manifest/uap/windows10/10\">",
+        "  <Identity Name=\"Contoso.WindowsApp\" Publisher=\"CN=Contoso, O=Contoso Corporation, C=US\" Version=\"1.0.0.0\" />",
+        "  <Applications>",
+        "    <Application Id=\"Main\" Executable=\"WindowsApp.exe\" EntryPoint=\"Contoso.WindowsApp.App\" uap10:RuntimeBehavior=\"windowsApp\" uap10:TrustLevel=\"mediumIL\" />",
+        "  </Applications>",
+        "</Package>"
+      ],
+      "expected": {
+        "packageName": "Contoso.WindowsApp",
+        "publisher": "CN=Contoso, O=Contoso Corporation, C=US",
+        "publisherId": "qxmmcvdvc0h2g",
+        "packageFamilyName": "Contoso.WindowsApp_qxmmcvdvc0h2g",
+        "applications": [
+          {
+            "id": "Main",
+            "executable": "WindowsApp.exe",
+            "appUserModelId": "Contoso.WindowsApp_qxmmcvdvc0h2g!Main",
+            "usesLaunchActivationArguments": true,
+            "runsInAppContainer": false
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/winapp-CLI/WinApp.Cli.Tests/WinApp.Cli.Tests.csproj
+++ b/src/winapp-CLI/WinApp.Cli.Tests/WinApp.Cli.Tests.csproj
@@ -44,4 +44,9 @@
     <ProjectReference Include="..\WinApp.Cli.Fuzz\WinApp.Cli.Fuzz.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="TestData\WindowsAppModel\appx-manifest-conformance-vectors.json"
+          CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
 </Project>

--- a/src/winapp-CLI/WinApp.Cli.Tests/WindowsAppModelConformanceTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/WindowsAppModelConformanceTests.cs
@@ -1,0 +1,120 @@
+// Copyright (c) Microsoft Corporation and Contributors. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using WinApp.Cli.Services;
+
+namespace WinApp.Cli.Tests;
+
+[TestClass]
+public class WindowsAppModelConformanceTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly AppLauncherService _launcher = new(
+        new Microsoft.Extensions.Logging.Abstractions.NullLogger<AppLauncherService>());
+
+    [TestMethod]
+    public void PackageIdentityVectors_MatchWindowsPublisherIds()
+    {
+        foreach (var vector in LoadVectors())
+        {
+            var expected = vector.Expected;
+            var packageFamilyName = _launcher.ComputePackageFamilyName(expected.PackageName, expected.Publisher);
+
+            Assert.AreEqual(expected.PackageFamilyName, packageFamilyName, vector.Name);
+            Assert.AreEqual(
+                expected.PublisherId,
+                packageFamilyName[(expected.PackageName.Length + 1)..],
+                vector.Name);
+        }
+    }
+
+    [TestMethod]
+    public void ManifestVectors_MatchIdentityAndApplicationFields()
+    {
+        foreach (var vector in LoadVectors())
+        {
+            var manifest = AppxManifestDocument.Parse(string.Join(Environment.NewLine, vector.ManifestLines));
+            var expected = vector.Expected;
+
+            Assert.HasCount(1, expected.Applications, vector.Name);
+            var expectedApplication = expected.Applications[0];
+
+            Assert.AreEqual(expected.PackageName, manifest.IdentityName, vector.Name);
+            Assert.AreEqual(expected.Publisher, manifest.IdentityPublisher, vector.Name);
+            Assert.AreEqual(expectedApplication.Id, manifest.ApplicationId, vector.Name);
+            Assert.AreEqual(expectedApplication.Executable, manifest.ApplicationExecutable, vector.Name);
+            Assert.AreEqual(
+                expectedApplication.AppUserModelId,
+                $"{expected.PackageFamilyName}!{manifest.ApplicationId}",
+                vector.Name);
+
+            // WinAppCli does not consume these semantics yet, but the typed model keeps the
+            // shared fields visible so future activation work can use the same vectors.
+            Assert.IsNotNull(expectedApplication.UsesLaunchActivationArguments, vector.Name);
+            Assert.IsNotNull(expectedApplication.RunsInAppContainer, vector.Name);
+        }
+    }
+
+    private static IReadOnlyList<ConformanceVector> LoadVectors()
+    {
+        var path = Path.Combine(
+            AppContext.BaseDirectory,
+            "TestData",
+            "WindowsAppModel",
+            "appx-manifest-conformance-vectors.json");
+        var document = JsonSerializer.Deserialize<ConformanceVectorSet>(File.ReadAllText(path), JsonOptions);
+
+        Assert.IsNotNull(document);
+        Assert.AreEqual(1, document.SchemaVersion);
+        Assert.HasCount(4, document.Vectors);
+        return document.Vectors;
+    }
+
+    private sealed class ConformanceVectorSet
+    {
+        public int SchemaVersion { get; init; }
+
+        public required string Description { get; init; }
+
+        public required IReadOnlyList<string> References { get; init; }
+
+        public required IReadOnlyList<ConformanceVector> Vectors { get; init; }
+    }
+
+    private sealed class ConformanceVector
+    {
+        public required string Name { get; init; }
+
+        public required IReadOnlyList<string> ManifestLines { get; init; }
+
+        public required ExpectedPackage Expected { get; init; }
+    }
+
+    private sealed class ExpectedPackage
+    {
+        public required string PackageName { get; init; }
+
+        public required string Publisher { get; init; }
+
+        public required string PublisherId { get; init; }
+
+        public required string PackageFamilyName { get; init; }
+
+        public required IReadOnlyList<ExpectedApplication> Applications { get; init; }
+    }
+
+    private sealed class ExpectedApplication
+    {
+        public required string Id { get; init; }
+
+        public required string Executable { get; init; }
+
+        public required string AppUserModelId { get; init; }
+
+        public bool? UsesLaunchActivationArguments { get; init; }
+
+        public bool? RunsInAppContainer { get; init; }
+    }
+}


### PR DESCRIPTION
## Description

Adds an offline WinAppCli consumer for shared Windows app-model conformance vectors so package identity hashing and manifest parsing stay aligned with other Windows app tooling. The tests validate four canonical publisher identities, package family names, AUMIDs, and application fields without a TestFX dependency or network access.

## Usage Example

N/A

## Related Issue

N/A

## Type of Change

- 🧪 Test update

## Checklist

- [x] New tests added for new functionality (if applicable)
- [x] Tested locally on Windows

## Screenshots / Demo

N/A

## Additional Notes

The JSON fixture is copied byte-for-byte from the canonical TestFX vectors. Activation-argument and AppContainer expectations remain in the typed vector model as forward-compatible data, but are not asserted as WinAppCli behavior yet.

## AI Description

<!-- ai-description-start -->
_This section is auto-generated by AI when the PR is opened or updated. To opt out, delete this entire section including the marker comments._
<!-- ai-description-end -->