### PR TITLE
Count JS bindings recursively in the electron sample test

### DIFF
--- a/samples/electron/test.Tests.ps1
+++ b/samples/electron/test.Tests.ps1
@@ -132,7 +132,10 @@ Describe "Electron Sample" {
             (Join-Path $bindingsDir ".dynwinrt-managed") | Should -Exist
             # 50 is a generous lower bound for the full WinAppSDK scope; catches
             # "0 files generated" regressions without being brittle to SDK updates.
-            $jsCount = (Get-ChildItem -Path $bindingsDir -Filter '*.js' -ErrorAction SilentlyContinue).Count
+            # -Recurse because codegen emits namespace subdirectories (dynwinrt-codegen
+            # 0.1.0-preview.20 moved output from flat to windows/foundation/-style
+            # nesting); without it only the 3 root scaffolding files are counted.
+            $jsCount = (Get-ChildItem -Path $bindingsDir -Filter '*.js' -Recurse -ErrorAction SilentlyContinue).Count
             $jsCount | Should -BeGreaterThan 50 -Because "Default jsBindings (full WinAppSDK) should generate many JS files"
         }
 


### PR DESCRIPTION
## What is wrong

Every open PR started failing the `electron` sample test today, regardless of its contents.

`@microsoft/dynwinrt-codegen@0.1.0-preview.20` was published **2026-09-01T14:42:36Z** and changed the generated-bindings layout from **flat** to **namespace-nested** (`windows/foundation/...`).

The assertion in `samples/electron/test.Tests.ps1` counted `.js` files **non-recursively**, so it stopped seeing the generated bindings and only counted the 3 root scaffolding files.

## Show me

```
Expected the actual value to be greater than 50, because Default jsBindings
(full WinAppSDK) should generate many JS files, but got 3.
at $jsCount | Should -BeGreaterThan 50, samples\electron\test.Tests.ps1:136
```

Reproduced locally by running both codegen builds against the same metadata (`C:\Windows\System32\WinMetadata`, `--namespace Windows.Foundation`):

| codegen | top-level `.js` | recursive `.js` | subdirs |
|---|---|---|---|
| `0.1.0-preview.19` | 26 | 26 | 0 |
| `0.1.0-preview.20` | **3** | **26** | 1 (`windows/foundation/`) |

The 3 survivors are `index.js`, `index.proxy.js`, and `lifetime.js` (`index.mjs` does not match the `*.js` filter). Those root files are emitted regardless of how much is generated, so the top-level count is now a **constant** — it no longer scales with output at all.

## Why it matters

**Nothing is actually broken.** The generated file set is unchanged (26 recursive in both versions), and every downstream test passed: `winmds.lock.json`, `#winapp/bindings` resolution via Node package imports, `generate-bindings` regeneration, and cross-language drift detection. This is a stale test assertion, not a functional regression.

But it blocked everyone: **7 runs across 5 branches and 4 authors**. The cleanest evidence that no PR caused it — `azchohfi-uiautomation-nuget-package` was green at `06:38Z` and red at `17:46Z` on the **same branch**, straddling the publish. Every run before 14:42Z passed, back to Aug 27; every run after it failed.

## The fix

Add `-Recurse`. The generated file set did not change, only its location, so the recursive count today equals the old flat count and the `> 50` threshold keeps exactly the meaning it had. It is layout-agnostic, so it holds whether codegen nests further or reverts to flat, and it still catches the "0 files generated" regression the assertion was written for (scaffolding-only output is 3, far below 50).

## Follow-up, not addressed here

`ensureCodegenInstalledForInit` (`src/winapp-npm/src/jsbindings/cli-hooks.ts:507`) installs this package at `latest`, **unpinned by design**:

> `latest` (not pinned) on purpose: codegen ships independently of winappcli and the ABI-lockstep step then queries its `runtime-dependency` capability for the matching runtime pin.

Two consequences worth discussing separately:

1. **Any codegen publish can red-wall every branch at once**, as it did here. There is no scheduled canary — `test-samples.yml` runs only on `pull_request` and `workflow_dispatch`, so the first signal is always a contributor's PR going red.
2. **It bypasses our 7-day cooldown.** `.github/dependabot.yml` sets `cooldown: default-days: 7`, but that only governs manifests dependabot tracks (`/src/winapp-npm`). This package is in no such manifest — our own init code installs it into the user's project — so the cooldown structurally cannot apply. CI consumed preview.20 roughly 4 hours after publish, and the same code path runs on a user's machine.

I have not changed that behavior here, to keep this PR limited to unblocking CI.
