### PR TITLE
Keep short recordings from ending before the first frame

### DIFF
--- a/src/winapp-CLI/WinApp.Cli.Tests/RealRecordingTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/RealRecordingTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Microsoft.Extensions.Logging;
+using System.Diagnostics;
 using System.Text.Json;
 using Windows.Win32.Foundation;
 using WinApp.Cli.Services;
@@ -602,6 +603,96 @@ public partial class RealRecordingTests
             warning => warning.Contains("only the indexed frame prefix was retained", StringComparison.Ordinal)));
     }
 
+    [TestMethod]
+    public async Task RecordAsync_FirstFrameArrivesAfterTheRequestedDuration_StillCapturesAFrame()
+    {
+        // The elapsed-duration check used to run before any frame had been committed, so a capture
+        // source that took longer than --duration to deliver its first frame into the capture loop
+        // ended the recording with zero frames: an empty MP4 and, with --frames-dir, a zero-frame
+        // manifest. Elapsed time may only end a recording that has already captured something.
+        using var fx = new UiaTestFixture();
+        var capture = new FakeWindowCapture();
+        var svc = NewAutomation();
+        var recording = NewRecordingService(svc, capture);
+        var uiTarget = SessionFor(fx);
+        await ResolveAsync(svc, uiTarget, "btnInvoke");
+
+        var root = Path.Join(AppContext.BaseDirectory, "coverage-scratch", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        var output = Path.Join(root, "slow-first-frame.mp4");
+        var frame = Enumerable.Repeat((byte)0x33, 64 * 64 * 4).ToArray();
+
+        capture.Supported = true;
+        capture.StartGrabberCallback = (_, _) =>
+            new SlowStartingFrameGrabber(frame, 64, 64, TimeSpan.FromMilliseconds(1_500));
+        Mp4SinkWriterEncoder.s_createNoClobber =
+            (path, width, height, _, _) => new FakeVideoEncoder(path, width, height);
+
+        var result = await recording.RecordAsync(uiTarget, null, new RecordOptions
+        {
+            OutputPath = output,
+            DurationSec = 1,
+            Fps = 2,
+            MaxEdge = 64,
+        }, CancellationToken.None);
+
+        Assert.IsTrue(
+            result.Frames >= 1,
+            $"a recording whose capture source starts late must still capture a frame, got {result.Frames}");
+    }
+
+    [TestMethod]
+    public async Task RecordAsync_SlowFrameArtifactSetup_IsNotChargedToTheRequestedDuration()
+    {
+        // Frame artifact setup creates a staging directory and opens the manifest and index writers.
+        // The capture clock used to start before that work, so on a loaded machine a short recording
+        // could spend its whole --duration budget on filesystem setup and capture almost nothing.
+        using var fx = new UiaTestFixture();
+        var capture = new FakeWindowCapture();
+        var svc = NewAutomation();
+        var recording = NewRecordingService(svc, capture);
+        var uiTarget = SessionFor(fx);
+        await ResolveAsync(svc, uiTarget, "btnInvoke");
+
+        var root = Path.Join(AppContext.BaseDirectory, "coverage-scratch", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        var output = Path.Join(root, "slow-setup.mp4");
+        var setupDelay = TimeSpan.FromMilliseconds(1_500);
+
+        capture.Supported = true;
+        capture.StartGrabberCallback = (_, _) =>
+            new FakeFrameGrabber(new byte[64 * 64 * 4], 64, 64);
+        Mp4SinkWriterEncoder.s_createNoClobber =
+            (path, width, height, _, _) => new FakeVideoEncoder(path, width, height);
+        RecordFrameBundleWriter.s_create = _ =>
+        {
+            Thread.Sleep(setupDelay);
+            return new FakeFrameSink();
+        };
+
+        var wallClock = Stopwatch.StartNew();
+        var result = await recording.RecordAsync(uiTarget, null, new RecordOptions
+        {
+            OutputPath = output,
+            FramesDirectory = Path.Join(root, "slow-setup.frames"),
+            DurationSec = 1,
+            Fps = 4,
+            MaxEdge = 64,
+        }, CancellationToken.None);
+        wallClock.Stop();
+
+        Assert.IsTrue(result.Frames >= 1, "the recording must capture something");
+
+        // Wall time covers setup and capture; the reported elapsed time must cover capture only, so
+        // the setup delay has to show up as the difference. Comparing the two rather than asserting
+        // an absolute elapsed time keeps this immune to a slow machine stretching the capture loop.
+        var excluded = wallClock.ElapsedMilliseconds - result.ElapsedMs;
+        Assert.IsTrue(
+            excluded >= setupDelay.TotalMilliseconds * 0.8,
+            $"reported elapsed time must measure capture, not setup: only {excluded}ms of the " +
+            $"{setupDelay.TotalMilliseconds}ms setup was excluded from {result.ElapsedMs}ms elapsed");
+    }
+
     private sealed class FakeFrameGrabber(byte[] pixels, int width, int height) : IFrameGrabber
     {
         private long _version;
@@ -616,6 +707,48 @@ public partial class RealRecordingTests
         public Task<bool> WaitForFirstFrameAsync(TimeSpan timeout, CancellationToken ct) => Task.FromResult(true);
 
         public void Dispose() => Disposed = true;
+    }
+
+    /// <summary>
+    /// Reports one frame to the recorder's setup read, then yields nothing for the given silence
+    /// window before delivering frames again — the shape of a capture source that is slow to start
+    /// feeding the capture loop.
+    /// </summary>
+    private sealed class SlowStartingFrameGrabber(
+        byte[] pixels, int width, int height, TimeSpan silence) : IFrameGrabber
+    {
+        private readonly Stopwatch _silenceSince = new();
+        private int _reads;
+        private long _version;
+
+        public bool IsClosed => false;
+
+        public (byte[] Pixels, int Width, int Height, long Version)? TryGetLatest()
+        {
+            // Recorder setup dereferences its read without a null check, so it always gets a frame.
+            if (Interlocked.Increment(ref _reads) == 1)
+            {
+                return Latest();
+            }
+
+            // Time the silence from the capture loop's first read, so the window the recorder sees
+            // does not shrink by however long the recorder spent between the two.
+            if (!_silenceSince.IsRunning)
+            {
+                _silenceSince.Start();
+            }
+
+            return _silenceSince.Elapsed < silence ? null : Latest();
+        }
+
+        public Task<bool> WaitForFirstFrameAsync(TimeSpan timeout, CancellationToken ct) => Task.FromResult(true);
+
+        public void Dispose()
+        {
+        }
+
+        private (byte[] Pixels, int Width, int Height, long Version) Latest()
+            => (pixels, width, height, Interlocked.Increment(ref _version));
     }
 
     private sealed class FakeVideoEncoder(string path, int width, int height) : IVideoEncoder

--- a/src/winapp-CLI/WinApp.Cli.Tests/UiCommandTests.Record.Frames.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/UiCommandTests.Record.Frames.cs
@@ -450,7 +450,6 @@ public partial class UiCommandTests
         {
             FinalDirectory = finalDirectory,
             VideoPath = Path.Join(_tempDirectory.FullName, "video.mp4"),
-            StartedUtc = DateTimeOffset.Parse("2026-01-01T00:00:00Z"),
             Width = 64,
             Height = 64,
             MaximumBundleBytes = maximumBundleBytes,
@@ -476,6 +475,7 @@ public partial class UiCommandTests
         {
             Status = "complete",
             StopReason = "cancelled",
+            StartedUtc = DateTimeOffset.Parse("2026-01-01T00:00:00Z"),
             ElapsedMs = 300,
             AchievedFps = 10,
             CadenceRatio = 1,

--- a/src/winapp-CLI/WinApp.UIAutomation.Recording/RecordFrameBundleWriter.cs
+++ b/src/winapp-CLI/WinApp.UIAutomation.Recording/RecordFrameBundleWriter.cs
@@ -26,7 +26,6 @@ internal sealed class RecordFrameBundleConfiguration
 
     public required string FinalDirectory { get; init; }
     public required string VideoPath { get; init; }
-    public required DateTimeOffset StartedUtc { get; init; }
     public required int Width { get; init; }
     public required int Height { get; init; }
     public required RecordFrameRequestManifest Requested { get; init; }
@@ -38,6 +37,12 @@ internal sealed class RecordFrameCompletion
 {
     public required string Status { get; init; }
     public required string StopReason { get; init; }
+
+    /// <summary>
+    /// Wall-clock instant capture began. Supplied at completion because it is the same instant the
+    /// capture clock starts, which is only known once artifact setup is done.
+    /// </summary>
+    public required DateTimeOffset StartedUtc { get; init; }
     public required long ElapsedMs { get; init; }
     public required double AchievedFps { get; init; }
     public required double CadenceRatio { get; init; }
@@ -213,7 +218,7 @@ internal sealed class RecordFrameBundleWriter : IRecordFrameSink
             Status = completion.Status == "complete" && IsTruncated
                 ? "truncated"
                 : completion.Status,
-            StartedUtc = _configuration.StartedUtc,
+            StartedUtc = completion.StartedUtc,
             CompletedUtc = DateTimeOffset.UtcNow,
             StopReason = completion.StopReason,
             Requested = _configuration.Requested,

--- a/src/winapp-CLI/WinApp.UIAutomation.Recording/UiRecordingService.Frames.cs
+++ b/src/winapp-CLI/WinApp.UIAutomation.Recording/UiRecordingService.Frames.cs
@@ -17,7 +17,6 @@ internal sealed partial class UiRecordingService
     private sealed class RecordFrameArtifactSetup
     {
         public required RecordOptions Options { get; init; }
-        public required DateTimeOffset StartedUtc { get; init; }
         public required int EncoderWidth { get; init; }
         public required int EncoderHeight { get; init; }
     }
@@ -29,7 +28,6 @@ internal sealed partial class UiRecordingService
         {
             FinalDirectory = setup.Options.FramesDirectory!,
             VideoPath = setup.Options.OutputPath,
-            StartedUtc = setup.StartedUtc,
             Width = setup.EncoderWidth,
             Height = setup.EncoderHeight,
             Requested = new RecordFrameRequestManifest

--- a/src/winapp-CLI/WinApp.UIAutomation.Recording/UiRecordingService.cs
+++ b/src/winapp-CLI/WinApp.UIAutomation.Recording/UiRecordingService.cs
@@ -317,8 +317,6 @@ internal sealed partial class UiRecordingService(
 
             var frameDurationHns = 10_000_000L / options.Fps;
             var totalFrames = options.DurationSec > 0 ? (long)options.DurationSec * options.Fps : (long?)null;
-            var stopwatch = Stopwatch.StartNew();
-            var startedUtc = DateTimeOffset.UtcNow;
             var frameIndex = 0;
             long lastEncodedVersion = -1;
             var startedSignaled = false;
@@ -330,11 +328,18 @@ internal sealed partial class UiRecordingService(
                 frameOutput = CreateRecordFrameArtifactCoordinator(new RecordFrameArtifactSetup
                 {
                     Options = options,
-                    StartedUtc = startedUtc,
                     EncoderWidth = encoderW,
                     EncoderHeight = encoderH,
                 });
             }
+
+            // The capture clock starts here, after frame artifact setup has created its staging
+            // directory and opened the manifest and index writers. Starting it before that setup
+            // charged the filesystem work to --duration, so on a loaded machine a short recording
+            // could spend its whole budget before capturing anything. startedUtc marks the same
+            // instant, so a frame's elapsedMs is an offset from the manifest's startedUtc.
+            var stopwatch = Stopwatch.StartNew();
+            var startedUtc = DateTimeOffset.UtcNow;
 
             async ValueTask CommitFrameAsync(byte[] processedFrame)
             {
@@ -375,7 +380,12 @@ internal sealed partial class UiRecordingService(
                         break;
                     }
 
-                    if (totalFrames.HasValue && stopwatch.Elapsed.TotalSeconds >= options.DurationSec)
+                    // Elapsed time only ends a recording that has already captured something.
+                    // Reaching the requested duration before the first frame is committed means
+                    // capture was slow to start, not that the recording is done; ending here handed
+                    // the caller an empty MP4 and a zero-frame manifest instead of a recording.
+                    // Cancellation is unaffected and still ends the loop at zero frames.
+                    if (totalFrames.HasValue && frameIndex > 0 && stopwatch.Elapsed.TotalSeconds >= options.DurationSec)
                     {
                         break;
                     }
@@ -518,6 +528,7 @@ internal sealed partial class UiRecordingService(
                         {
                             Status = "partial",
                             StopReason = stopReason,
+                            StartedUtc = startedUtc,
                             ElapsedMs = elapsedMs,
                             AchievedFps = frameAchievedFps,
                             CadenceRatio = frameCadenceRatio,
@@ -557,6 +568,7 @@ internal sealed partial class UiRecordingService(
                     {
                         Status = "complete",
                         StopReason = stopReason,
+                        StartedUtc = startedUtc,
                         ElapsedMs = elapsedMs,
                         AchievedFps = achievedFps,
                         CadenceRatio = cadenceRatio,


### PR DESCRIPTION
## The bug

`winapp ui record` can finish with zero frames — an empty MP4 and, with `--frames`, a `manifest.json` reporting no samples — when the machine is loaded. It showed up as an intermittent CI failure on `main`:

```
failed RecordAsync_FrameArtifacts_UseTheProcessedMp4FrameStream
  Assert.AreEqual failed. Expected:<2>. Actual:<0>. 'actual' expression: 'result.Frames'.
```

A re-run of the same commit went green, and the commit under test doesn't touch the recording path, so this is a race in the product, not a bad test.

Two things in `RecordAsync` combine to cause it:

- The capture loop's elapsed-duration check ran before any frame had been committed. Reaching `--duration-sec` with nothing captured means capture was slow to start, but the loop treated it as "done" and exited.
- The capture stopwatch started *before* `CreateRecordFrameArtifactCoordinator` created its staging directory, opened `frames.ndjson`, and spun up the JPEG worker. That filesystem work was charged to `--duration-sec`, so a short recording could spend its whole budget on setup before capturing anything. `--duration-sec 1 --fps 2 --frames` is the worst case, which is exactly the failing test.

## The fix

1. Elapsed time now only ends a recording that has already captured a frame (`frameIndex > 0`). The frame-count guard is untouched, and cancellation is deliberately unchanged — Ctrl+C still ends a recording at zero frames and still aborts the staging directory instead of publishing it.
2. The capture clock starts after artifact setup, so `--duration-sec` and the reported `elapsedMs` / `achievedFps` / `cadenceRatio` measure capture.
3. The manifest's `startedUtc` moves from `RecordFrameBundleConfiguration` to `RecordFrameCompletion`. It has to: the instant the clock starts isn't knowable at coordinator construction, because construction *is* the setup. Leaving it behind would desync `manifest.startedUtc` from the origin that each sample's `elapsedMs` is measured from. Both types are `internal` and the property is `required`, so the compiler covers both completion sites. No flag, command, or JSON field name changed.

## Tests

Two regression tests, both mutation-checked:

| Revert | Test that goes red |
| --- | --- |
| the `frameIndex > 0` gate | `RecordAsync_FirstFrameArrivesAfterTheRequestedDuration_StillCapturesAFrame` → `'result.Frames >= 1' ... got 0` |
| the stopwatch move | `RecordAsync_SlowFrameArtifactSetup_IsNotChargedToTheRequestedDuration` → `only 5ms of the 1500ms setup was excluded from 1506ms elapsed` |

Since this is a fix for a load-induced flake, I made a point of not introducing another one. The fake grabber times its silence window from the capture loop's first read rather than from setup, so the window the recorder sees can't shrink; and the setup test compares wall time against reported elapsed instead of asserting an absolute `elapsedMs`, so a slow machine stretching the capture loop can't flip it. The mutation check was re-run after that hardening.

## Verification

- Recording suites: 98 tests, 0 failed (2 skipped — no interactive desktop lane).
- `WinApp.UIAutomation.Tests`: 397 tests, 0 failed.
- `scripts/build-cli.ps1 -SkipMsix -SkipNpm`: clean build and x64/arm64 publish. The 11 failures in the full run are all `NugetServiceTests` against unreachable `api.nuget.org` (the corp-machine limitation documented in `AGENTS.md`) plus one foreground-steal screenshot test that passes standalone. None are in the recording path.
- Published binary against a live Notepad window: `ui record --duration-sec 1 --fps 2 --frames` → 2 frames, cadence 0.995, `stopReason: duration_elapsed`, and the manifest's `startedUtc`→`completedUtc` span of 1007ms lines up with the reported `elapsedMs` of 1005 — the two clocks now mark the same instant.
- Cancellation via redirected-stdin newline after 2s → `stopReason: cancelled`, artifacts published, exits promptly.

No documentation changes: `docs/ui-automation.md` already describes the behavior this restores.