### PR TITLE
Fix AOT publish restore and authored-manifest identity runs

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -791,6 +791,8 @@ winapp run . --aot -c Release
 
 `--aot` supports x64 and ARM64 projects. It runs `dotnet publish` with the project's AOT configuration, then launches that output; use `-p PublishAot=true` for a one-time override. It does not perform separate runtime certification and cannot be combined with `--no-build` or `--manifest`.
 
+For apps that use package identity without a generated MSIX layout, include `Package.appxmanifest` or `appxmanifest.xml` in the project's publish output. Winapp stages the published files with that manifest.
+
 **Project-mode options** (ignored in folder mode unless noted):
 
 - `-c, --configuration <name>` - Build configuration. Default: `Debug`. *(Also honored in single-file mode.)*
@@ -799,7 +801,7 @@ winapp run . --aot -c Release
 - `-f, --framework <tfm>` - Target framework moniker for multi-targeted projects (e.g. `net10.0-windows10.0.26100.0`). *(Rejected in single-file mode — use `#:property TargetFramework=...`.)*
 - `--project <name-or-path>` - When the input is a solution (`.sln`/`.slnx`) or a directory with multiple runnable app projects, selects which project to launch (by project name or path). *(Rejected in single-file mode — a `.cs` file-based app is itself the project.)*
 - `--no-build` - Skip building and run the existing build output (still evaluates output properties). *(Also honored in single-file mode.)*
-- `--no-restore` - Skip restoring before building. *(Also honored in single-file mode.)*
+- `--no-restore` - Skip restoring before building or Native AOT publishing. *(Also honored in single-file mode.)*
 - `--aot` - Run the project's configured .NET Native AOT publish. Requires effective `PublishAot=true`. Rejected in folder and single-file modes.
 - `-p, --property <Name=Value>` - MSBuild property, forwarded to both the build and the property evaluation. Repeat `-p` for multiple properties; use `%3B` or `%2C` for a literal semicolon or comma in a value. *(Also honored in single-file mode, where it is the only way to set `TargetFramework`.)*
 
@@ -1881,7 +1883,6 @@ stop reason, optional `frameArtifacts`, and warnings.
 > stills. Tracked in [#646](https://github.com/microsoft/winappCli/issues/646).
 
 For full documentation, see [docs/ui-automation.md](ui-automation.md).
-
 
 
 

--- a/src/winapp-CLI/WinApp.Cli.Tests/ProjectRunServiceAotTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/ProjectRunServiceAotTests.cs
@@ -283,6 +283,111 @@ public sealed class ProjectRunServiceAotTests
     }
 
     [TestMethod]
+    [DataRow(false, false)]
+    [DataRow(false, true)]
+    [DataRow(true, false)]
+    [DataRow(true, true)]
+    public async Task PublishAot_PreRestorePreservesPublishRestorePreference(
+        bool sdkAbsent,
+        bool noRestore)
+    {
+        var project = WriteProject(
+            extraProperties:
+                """<PublishAot Condition="'$(_IsPublishing)' == 'true'">true</PublishAot>""");
+        var solution = WriteFile(
+            "Sample.slnx",
+            """<Solution><Project Path="Sample.csproj" /><Project Path="Library.csproj" /></Solution>""");
+        WriteFile("Library.csproj", """<Project Sdk="Microsoft.NET.Sdk" />""");
+        var assets = WriteFile("obj\\project.assets.json", "{}");
+        WriteFile("publish\\Sample.exe", "native");
+        var properties = PropertyJson(project, assets, publishAot: true, packaging: "None");
+        var dotnet = SuccessfulDotnet(properties);
+        var service = NewService(
+            dotnet,
+            new FakeCsWinRTMetadataShimService { WindowsSdkAbsent = sdkAbsent });
+
+        var outcome = await service.PublishAotAndResolveAsync(
+            project,
+            Options(noRestore) with { Solution = sdkAbsent ? null : solution },
+            CancellationToken.None);
+
+        Assert.IsNotNull(outcome.Resolution);
+        Assert.AreEqual(noRestore, outcome.Resolution.NoRestore);
+        Assert.AreEqual(
+            noRestore ? 0 : 1,
+            dotnet.StringInvocations.Count(arguments => arguments.StartsWith("restore ", StringComparison.Ordinal)));
+        Assert.AreEqual(
+            noRestore,
+            dotnet.ArgumentListInvocations.Single().Contains("--no-restore"),
+            "A build-context pre-restore must not suppress publishing's own restore.");
+    }
+
+    [TestMethod]
+    [DataRow("Package.appxmanifest", "")]
+    [DataRow("appxmanifest.xml", "")]
+    [DataRow("appxmanifest.xml", "MSIX")]
+    public async Task PublishAot_AuthoredManifestUsesPublishedLayoutWithoutRecipe(
+        string manifestName,
+        string packaging)
+    {
+        var project = WriteProject();
+        var assets = WriteFile("obj\\project.assets.json", "{}");
+        var executable = WriteFile("publish\\Sample.exe", "native");
+        var manifest = WriteFile($"publish\\{manifestName}", "<Package />");
+        WriteFile(manifestName, "<Package />");
+        var properties = PropertyJson(
+            project, assets, publishAot: true, packaging,
+            winAppRunSupportActive: true);
+        var service = NewService(SuccessfulDotnet(properties));
+
+        var outcome = await service.PublishAotAndResolveAsync(
+            project, Options(), CancellationToken.None);
+
+        Assert.IsNotNull(outcome.Resolution);
+        Assert.AreEqual(ProjectPackaging.Packaged, outcome.Resolution.Packaging);
+        Assert.AreEqual(executable.FullName, outcome.Resolution.RunCommand);
+        Assert.AreEqual(manifest.FullName, outcome.Resolution.AppxManifestPath);
+        Assert.IsNull(outcome.Resolution.AppxRecipePath);
+    }
+
+    [TestMethod]
+    public async Task PublishAot_AuthoredManifestMissingFromPublishFailsWithoutSourceFallback()
+    {
+        var project = WriteProject();
+        var assets = WriteFile("obj\\project.assets.json", "{}");
+        WriteFile("publish\\Sample.exe", "native");
+        WriteFile("Package.appxmanifest", "<Package />");
+        var properties = PropertyJson(
+            project, assets, publishAot: true, packaging: "",
+            winAppRunSupportActive: true);
+        var service = NewService(SuccessfulDotnet(properties));
+
+        var error = await Assert.ThrowsExactlyAsync<ProjectRunException>(() =>
+            service.PublishAotAndResolveAsync(project, Options(), CancellationToken.None));
+
+        StringAssert.Contains(error.Message, "package manifest");
+        StringAssert.Contains(error.Message, Path.Join(_tempDirectory.FullName, "publish"));
+    }
+
+    [TestMethod]
+    public async Task PublishAot_MsixToolingMissingGeneratedManifestFailsWithoutAuthoredFallback()
+    {
+        var project = WriteProject();
+        var assets = WriteFile("obj\\project.assets.json", "{}");
+        WriteFile("publish\\Sample.exe", "native");
+        WriteFile("publish\\Package.appxmanifest", "<Package />");
+        var properties = PropertyJson(
+            project, assets, publishAot: true, packaging: "MSIX",
+            enableMsixTooling: true);
+        var service = NewService(SuccessfulDotnet(properties));
+
+        var error = await Assert.ThrowsExactlyAsync<ProjectRunException>(() =>
+            service.PublishAotAndResolveAsync(project, Options(), CancellationToken.None));
+
+        StringAssert.Contains(error.Message, "FinalAppxManifestName");
+    }
+
+    [TestMethod]
     public async Task PublishAot_MissingPackagedRecipeFailsWithoutFallback()
     {
         var project = WriteProject();
@@ -428,7 +533,9 @@ public sealed class ProjectRunServiceAotTests
             RunDotnetArgumentListHandler = _ => (0, properties, string.Empty),
         };
 
-    private ProjectRunService NewService(FakeDotNetService dotnet)
+    private ProjectRunService NewService(
+        FakeDotNetService dotnet,
+        FakeCsWinRTMetadataShimService? shim = null)
     {
         var console = new TestConsole();
         _consoles.Add(console);
@@ -437,7 +544,7 @@ public sealed class ProjectRunServiceAotTests
             new ProjectDetectionService(
                 NullLogger<ProjectDetectionService>.Instance,
                 dotnet),
-            new FakeCsWinRTMetadataShimService(),
+            shim ?? new FakeCsWinRTMetadataShimService(),
             console,
             NullLogger<ProjectRunService>.Instance);
     }
@@ -525,7 +632,9 @@ public sealed class ProjectRunServiceAotTests
         string? targetName = null,
         string? nativeBinary = null,
         string? manifest = null,
-        string? recipe = null)
+        string? recipe = null,
+        bool winAppRunSupportActive = false,
+        bool enableMsixTooling = false)
     {
         var projectDirectory = project.DirectoryName!;
         var properties = new Dictionary<string, string>
@@ -543,6 +652,8 @@ public sealed class ProjectRunServiceAotTests
                 $"{targetName ?? assemblyName}.exe"),
             ["OutputType"] = "WinExe",
             ["WindowsPackageType"] = packaging,
+            ["_WinAppRunSupportActive"] = winAppRunSupportActive ? "true" : "false",
+            ["EnableMsixTooling"] = enableMsixTooling ? "true" : "false",
             ["WindowsAppSDKSelfContained"] = "true",
             ["ProjectAssetsFile"] = assets.FullName,
             ["RuntimeIdentifier"] = "win-x64",

--- a/src/winapp-CLI/WinApp.Cli.Tests/RunCommandProjectModeTests.cs
+++ b/src/winapp-CLI/WinApp.Cli.Tests/RunCommandProjectModeTests.cs
@@ -123,7 +123,7 @@ public class RunCommandProjectModeTests : BaseCommandTests
         FileInfo csproj,
         DirectoryInfo publishDirectory,
         FileInfo manifest,
-        FileInfo recipe,
+        FileInfo? recipe,
         string arch = "x64")
     {
         _fakeProjectRunService.AotOutcome = new ProjectBuildOutcome(
@@ -136,7 +136,7 @@ public class RunCommandProjectModeTests : BaseCommandTests
                 Architecture: arch,
                 IsAot: true,
                 AppxManifestPath: manifest.FullName,
-                AppxRecipePath: recipe.FullName),
+                AppxRecipePath: recipe?.FullName),
             0);
     }
 
@@ -860,6 +860,26 @@ public class RunCommandProjectModeTests : BaseCommandTests
         Assert.AreEqual(
             Path.Join(publishDirectory.FullName, "AppX"),
             _fakeMsixService.AddLooseLayoutDirectoryCalls.Single().OutputDirectory);
+    }
+
+    [TestMethod]
+    public async Task ProjectMode_AotAuthoredManifestUsesPublishedFilesWithoutRecipe()
+    {
+        var csproj = CreateCsproj();
+        var publishDirectory = CreateTargetDir(withManifest: true);
+        var manifest = new FileInfo(Path.Join(publishDirectory.FullName, "appxmanifest.xml"));
+        SetPackagedAotOutcome(csproj, publishDirectory, manifest, recipe: null);
+        var command = GetRequiredService<RunCommand>();
+
+        var exitCode = await ParseAndInvokeWithCaptureAsync(
+            command,
+            [csproj.FullName, "--aot", "--no-launch"]);
+
+        Assert.AreEqual(0, exitCode);
+        Assert.AreEqual(manifest.FullName, _fakeMsixService.AddLooseLayoutCalls.Single().ManifestPath);
+        Assert.IsNull(_fakeMsixService.AddLooseLayoutRecipeCalls.Single());
+        Assert.AreEqual(publishDirectory.FullName, _fakeMsixService.AddLooseLayoutDirectoryCalls.Single().InputDirectory);
+        Assert.AreEqual(0, _fakeAppLauncherService.LaunchExecutableCalls.Count);
     }
 
     [TestMethod]

--- a/src/winapp-CLI/WinApp.Cli/Commands/RunCommand.ProjectMode.cs
+++ b/src/winapp-CLI/WinApp.Cli/Commands/RunCommand.ProjectMode.cs
@@ -290,7 +290,7 @@ internal partial class RunCommand
                 string.IsNullOrWhiteSpace(resolution.AppxManifestPath))
             {
                 return Fail(
-                    "The Native AOT publish did not produce a generated AppxManifest.xml.",
+                    "The Native AOT publish did not produce a package manifest.",
                     isJson);
             }
             var effectiveManifest = resolution.IsAot

--- a/src/winapp-CLI/WinApp.Cli/Services/ProjectRunService.Aot.cs
+++ b/src/winapp-CLI/WinApp.Cli/Services/ProjectRunService.Aot.cs
@@ -31,7 +31,7 @@ internal sealed partial class ProjectRunService
         WarnOnOverriddenFlags(options);
         var workingDirectory = csproj.Directory
             ?? new DirectoryInfo(Directory.GetCurrentDirectory());
-        (options, var publishOptions, var csWinRTMetadata) =
+        (options, _, var csWinRTMetadata) =
             await PrepareBuildInputsAsync(
                 csproj,
                 options,
@@ -52,9 +52,10 @@ internal sealed partial class ProjectRunService
             throw new ProjectRunException(BuildPublishAotRequiredMessage(csproj));
         }
 
+        // A build-context pre-restore does not cover publish-conditional dependencies.
         var publish = await RunAotPublishPassAsync(
             csproj,
-            publishOptions,
+            options,
             workingDirectory,
             csWinRTMetadata,
             cancellationToken);
@@ -350,19 +351,35 @@ internal sealed partial class ProjectRunService
         string? recipe = null;
         if (packaging == ProjectPackaging.Packaged)
         {
-            manifest = ResolveEvaluatedFile(
-                properties,
-                "FinalAppxManifestName",
-                projectDirectory);
-            recipe = ResolveEvaluatedFile(
-                properties,
-                "AppxPackageRecipe",
-                projectDirectory);
-            var nativeBinary = ResolveEvaluatedFile(
-                properties,
-                "NativeBinary",
-                projectDirectory);
-            ValidatePackagedNativeEntryPoint(manifest, recipe, nativeBinary);
+            if (IsTrue(GetProp(properties, "EnableMsixTooling")) ||
+                !string.IsNullOrWhiteSpace(GetProp(properties, "FinalAppxManifestName")) ||
+                !string.IsNullOrWhiteSpace(GetProp(properties, "AppxPackageRecipe")))
+            {
+                manifest = ResolveEvaluatedFile(
+                    properties,
+                    "FinalAppxManifestName",
+                    projectDirectory);
+                recipe = ResolveEvaluatedFile(
+                    properties,
+                    "AppxPackageRecipe",
+                    projectDirectory);
+                var nativeBinary = ResolveEvaluatedFile(
+                    properties,
+                    "NativeBinary",
+                    projectDirectory);
+                ValidatePackagedNativeEntryPoint(manifest, recipe, nativeBinary);
+            }
+            else
+            {
+                var publishedManifest = ManifestHelper.FindManifest(publishDirectory);
+                if (!publishedManifest.Exists)
+                {
+                    throw new ProjectRunException(
+                        $"The Native AOT publish did not produce a package manifest in '{publishDirectory}'. " +
+                        "Include Package.appxmanifest or appxmanifest.xml in the project's publish output.");
+                }
+                manifest = publishedManifest.FullName;
+            }
         }
 
         return new ProjectRunResolution(


### PR DESCRIPTION
## Summary

Follow-up fixes for #817, intended to merge into `nmetulev-native-aot-publish-run`.

- Preserve the user's restore preference for AOT publishing instead of inheriting `--no-restore` from a normal solution or SDK-less pre-restore.
- Use the published authored manifest for package-identity projects without generated MSIX metadata. Keep generated manifest, recipe, and NativeBinary entry-point checks strict.
- Add regression coverage for both restore paths, explicit `--no-restore`, authored manifest names, missing published manifests, generated metadata failures, and command routing. Update the canonical usage guidance.

## Validation

- New regressions failed before the fixes; all 430 targeted tests pass in Debug and Release.
- Native x64/ARM64 CLI builds, generated metadata, npm build, and Release warnings-as-errors build pass.
- Cold solution runs with publish-conditional `PublishAot` publish and launch native executables on x64 and ARM64.
- Authored-manifest AOT applications register and launch on x64 and ARM64; the running applications report their expected package identity, native compilation, and architecture.
- A regular WPF application launches and responds to button interaction both with and without package identity. Requesting WPF Native AOT correctly reports the .NET SDK's `NETSDK1168` limitation.

No runtime certification feature or new command-line options are added.